### PR TITLE
feat: record-video can now record any Editor window, not just the Game View

### DIFF
--- a/.agents/skills/uloop-record-video/SKILL.md
+++ b/.agents/skills/uloop-record-video/SKILL.md
@@ -1,16 +1,16 @@
 ---
 name: uloop-record-video
 toolName: record-video
-description: "Record the Unity Game View to a video file (H.264 .mp4, or VP8 .webm) while Play Mode runs. Use when a still screenshot is not enough: motion, animation, transitions, physics, or a gameplay sequence to review later. `start` returns at once and other uloop commands keep working while it records."
+description: "Record the Unity Game View or any Editor window (Scene, Inspector, Console, ...) to a video file (H.264 .mp4, or VP8 .webm). Use when a still screenshot is not enough: motion, animation, transitions, physics, a gameplay sequence, or an Editor window changing over time. `start` returns at once and other uloop commands keep working while it records."
 ---
 
 # Task
 
-Record the Unity Game View to a video file while Play Mode is running, then hand the file path to the user or inspect frames from it.
+Record the Unity Game View while Play Mode is running, or any Editor window with `--window-name`, then hand the file path to the user or inspect frames from it.
 
 ## Workflow
 
-1. Ensure Play Mode is running (`uloop control-play-mode --action Play`) and the Game View is open. `start` fails in Edit Mode.
+1. For a Game View recording, ensure Play Mode is running (`uloop control-play-mode --action Play`) and the Game View is open; `start` fails in Edit Mode. With `--window-name` the recording targets that Editor window instead and needs no Play Mode.
 2. `uloop record-video --action start [options]`. It returns immediately; encoding continues inside the Editor.
 3. Drive the scene with other uloop commands (`simulate-keyboard`, `simulate-mouse-input`, `replay-input`, ...). Do **not** run `uloop compile` or exit Play Mode mid-recording: both auto-stop and finalize the file.
 4. `uloop record-video --action stop`. The file is playable only after this call (or after an auto-stop).
@@ -20,7 +20,7 @@ Record the Unity Game View to a video file while Play Mode is running, then hand
 ## Tool Reference
 
 ```bash
-uloop record-video --action start [--frame-rate <fps>] [--max-duration-seconds <sec>] [--resolution-scale <0.1-1.0>] [--quality <low|medium|high>] [--output-path <file>]
+uloop record-video --action start [--frame-rate <fps>] [--max-duration-seconds <sec>] [--resolution-scale <0.1-1.0>] [--quality <low|medium|high>] [--window-name <name>] [--match-mode <exact|prefix|contains>] [--output-path <file>]
 uloop record-video --action status
 uloop record-video --action stop
 ```
@@ -34,6 +34,8 @@ uloop record-video --action stop
 | `--max-duration-seconds` | integer | `60` | Auto-stop safety limit in seconds. Valid range 1–600. Used by `start` only. |
 | `--resolution-scale` | number | `1.0` | Resolution scale (0.1 to 1.0) applied to the Game View size before encoding. `0.5` cuts file size and encoding cost to about a quarter. Used by `start` only. |
 | `--quality` | enum | `medium` | Encoder bitrate preset: `low`, `medium`, or `high`. Used by `start` only. |
+| `--window-name` | string | empty | Editor window title to record instead of the Game View (for example Scene, Inspector, Console). Empty records the Game View and requires Play Mode. A window recording does not require Play Mode, brings the tab to the front, repaints it every frame, and keeps running across Play Mode changes. Used by `start` only. |
+| `--match-mode` | enum | `exact` | Window title matching for `--window-name`: `exact`, `prefix`, or `contains` (case-insensitive). Used by `start` only. |
 | `--output-path` | string | empty | Output file path. Empty uses `.uloop/outputs/Videos/gameview_<yyyyMMdd_HHmmss_fff>.mp4` (`.webm` on Linux). Extension must be `.mp4` (H.264) or `.webm` (VP8). Linux rejects `.mp4`. Used by `start` only. |
 
 ### Actions
@@ -52,14 +54,14 @@ Returns JSON containing:
 - `Message`: Human-readable status.
 - `Action`: Echoes the executed action.
 - `IsRecording`: Whether a recording is active after this call.
-- `OutputPath`: Absolute path of the video file. Open this path; do not search the directory.
+- `OutputPath`: Absolute path of the video file. Open this path; do not search the directory. A window recording uses the `window_` name prefix instead of `gameview_`.
 - `Width` / `Height`: Encoded resolution after `--resolution-scale` and even rounding (0 when none).
 - `FrameRate`: Output fps (0 when none).
 - `Quality`: Bitrate preset in use.
 - `EncodedFrameCount`: Frames written to the encoder.
 - `SkippedFrameCount`: Frame slots that could not be captured (Game View closed or resized, or encoder refused a frame). The video keeps its timeline; skipped slots are simply missing.
 - `ElapsedSeconds`: Seconds since start (frozen after stop).
-- `StoppedBy`: Why the recording ended — `"cli"`, `"max-duration"`, `"play-mode-exit"`, `"assembly-reload"`, or `"editor-quit"`. Omitted while recording.
+- `StoppedBy`: Why the recording ended — `"cli"`, `"max-duration"`, `"play-mode-exit"`, `"window-closed"`, `"assembly-reload"`, or `"editor-quit"`. Omitted while recording.
 
 ## Interpreting results
 
@@ -67,6 +69,7 @@ Returns JSON containing:
 - `Success: false` with "Play Mode view RenderTexture is not available" → open the Game View tab (`uloop focus-window`) and make sure a camera renders.
 - `SkippedFrameCount` growing while `EncodedFrameCount` stays flat → the Game View is closed, hidden, or resized. Restore it; recording resumes without restarting.
 - `EncodedFrameCount` far below `ElapsedSeconds × FrameRate` with few skips → the Editor is unfocused and throttling draws; run `uloop focus-window` before the next recording.
+- `Success: false` with "Window '...' not found" → pick the right title from the `Open windows:` list in the message, or use `--match-mode prefix`.
 - `StoppedBy` is not `"cli"` → the recording ended on its own; the file is still valid up to that point.
 
 ## Notes

--- a/.agents/skills/uloop-record-video/SKILL.md
+++ b/.agents/skills/uloop-record-video/SKILL.md
@@ -34,7 +34,7 @@ uloop record-video --action stop
 | `--max-duration-seconds` | integer | `60` | Auto-stop safety limit in seconds. Valid range 1–600. Used by `start` only. |
 | `--resolution-scale` | number | `1.0` | Resolution scale (0.1 to 1.0) applied to the Game View size before encoding. `0.5` cuts file size and encoding cost to about a quarter. Used by `start` only. |
 | `--quality` | enum | `medium` | Encoder bitrate preset: `low`, `medium`, or `high`. Used by `start` only. |
-| `--window-name` | string | empty | Editor window title to record instead of the Game View (for example Scene, Inspector, Console). Empty records the Game View and requires Play Mode. A window recording does not require Play Mode, brings the tab to the front, repaints it every frame, and keeps running across Play Mode changes. Used by `start` only. |
+| `--window-name` | string | empty | Editor window title to record instead of the Game View (for example Scene, Inspector, Console). Empty records the Game View and requires Play Mode. A window recording does not require Play Mode, brings the tab to the front, repaints it every frame, and keeps running when Play Mode stops. Used by `start` only. |
 | `--match-mode` | enum | `exact` | Window title matching for `--window-name`: `exact`, `prefix`, or `contains` (case-insensitive). Used by `start` only. |
 | `--output-path` | string | empty | Output file path. Empty uses `.uloop/outputs/Videos/gameview_<yyyyMMdd_HHmmss_fff>.mp4` (`.webm` on Linux). Extension must be `.mp4` (H.264) or `.webm` (VP8). Linux rejects `.mp4`. Used by `start` only. |
 
@@ -76,5 +76,6 @@ Returns JSON containing:
 
 - Odd Game View sizes are rounded down to even for H.264 (for example 1286×723 → 1286×722; the last pixel row/column is dropped).
 - The recording is wall-clock paced, so Play Mode pause records a still image, not a gap.
+- A window recording survives Play Mode stopping, but entering Play Mode with domain reload enabled (Unity's default) ends it with `StoppedBy: "assembly-reload"`.
 - Default output is H.264 `.mp4` on macOS/Windows and VP8 `.webm` on Linux. An explicit `.webm` path uses VP8 on every host.
 - Default recordings under `.uloop/outputs/Videos/` keep only the newest 20 files per extension; a custom `--output-path` is never pruned.

--- a/.claude/skills/uloop-record-video/SKILL.md
+++ b/.claude/skills/uloop-record-video/SKILL.md
@@ -1,16 +1,16 @@
 ---
 name: uloop-record-video
 toolName: record-video
-description: "Record the Unity Game View to a video file (H.264 .mp4, or VP8 .webm) while Play Mode runs. Use when a still screenshot is not enough: motion, animation, transitions, physics, or a gameplay sequence to review later. `start` returns at once and other uloop commands keep working while it records."
+description: "Record the Unity Game View or any Editor window (Scene, Inspector, Console, ...) to a video file (H.264 .mp4, or VP8 .webm). Use when a still screenshot is not enough: motion, animation, transitions, physics, a gameplay sequence, or an Editor window changing over time. `start` returns at once and other uloop commands keep working while it records."
 ---
 
 # Task
 
-Record the Unity Game View to a video file while Play Mode is running, then hand the file path to the user or inspect frames from it.
+Record the Unity Game View while Play Mode is running, or any Editor window with `--window-name`, then hand the file path to the user or inspect frames from it.
 
 ## Workflow
 
-1. Ensure Play Mode is running (`uloop control-play-mode --action Play`) and the Game View is open. `start` fails in Edit Mode.
+1. For a Game View recording, ensure Play Mode is running (`uloop control-play-mode --action Play`) and the Game View is open; `start` fails in Edit Mode. With `--window-name` the recording targets that Editor window instead and needs no Play Mode.
 2. `uloop record-video --action start [options]`. It returns immediately; encoding continues inside the Editor.
 3. Drive the scene with other uloop commands (`simulate-keyboard`, `simulate-mouse-input`, `replay-input`, ...). Do **not** run `uloop compile` or exit Play Mode mid-recording: both auto-stop and finalize the file.
 4. `uloop record-video --action stop`. The file is playable only after this call (or after an auto-stop).
@@ -20,7 +20,7 @@ Record the Unity Game View to a video file while Play Mode is running, then hand
 ## Tool Reference
 
 ```bash
-uloop record-video --action start [--frame-rate <fps>] [--max-duration-seconds <sec>] [--resolution-scale <0.1-1.0>] [--quality <low|medium|high>] [--output-path <file>]
+uloop record-video --action start [--frame-rate <fps>] [--max-duration-seconds <sec>] [--resolution-scale <0.1-1.0>] [--quality <low|medium|high>] [--window-name <name>] [--match-mode <exact|prefix|contains>] [--output-path <file>]
 uloop record-video --action status
 uloop record-video --action stop
 ```
@@ -34,6 +34,8 @@ uloop record-video --action stop
 | `--max-duration-seconds` | integer | `60` | Auto-stop safety limit in seconds. Valid range 1–600. Used by `start` only. |
 | `--resolution-scale` | number | `1.0` | Resolution scale (0.1 to 1.0) applied to the Game View size before encoding. `0.5` cuts file size and encoding cost to about a quarter. Used by `start` only. |
 | `--quality` | enum | `medium` | Encoder bitrate preset: `low`, `medium`, or `high`. Used by `start` only. |
+| `--window-name` | string | empty | Editor window title to record instead of the Game View (for example Scene, Inspector, Console). Empty records the Game View and requires Play Mode. A window recording does not require Play Mode, brings the tab to the front, repaints it every frame, and keeps running across Play Mode changes. Used by `start` only. |
+| `--match-mode` | enum | `exact` | Window title matching for `--window-name`: `exact`, `prefix`, or `contains` (case-insensitive). Used by `start` only. |
 | `--output-path` | string | empty | Output file path. Empty uses `.uloop/outputs/Videos/gameview_<yyyyMMdd_HHmmss_fff>.mp4` (`.webm` on Linux). Extension must be `.mp4` (H.264) or `.webm` (VP8). Linux rejects `.mp4`. Used by `start` only. |
 
 ### Actions
@@ -52,14 +54,14 @@ Returns JSON containing:
 - `Message`: Human-readable status.
 - `Action`: Echoes the executed action.
 - `IsRecording`: Whether a recording is active after this call.
-- `OutputPath`: Absolute path of the video file. Open this path; do not search the directory.
+- `OutputPath`: Absolute path of the video file. Open this path; do not search the directory. A window recording uses the `window_` name prefix instead of `gameview_`.
 - `Width` / `Height`: Encoded resolution after `--resolution-scale` and even rounding (0 when none).
 - `FrameRate`: Output fps (0 when none).
 - `Quality`: Bitrate preset in use.
 - `EncodedFrameCount`: Frames written to the encoder.
 - `SkippedFrameCount`: Frame slots that could not be captured (Game View closed or resized, or encoder refused a frame). The video keeps its timeline; skipped slots are simply missing.
 - `ElapsedSeconds`: Seconds since start (frozen after stop).
-- `StoppedBy`: Why the recording ended — `"cli"`, `"max-duration"`, `"play-mode-exit"`, `"assembly-reload"`, or `"editor-quit"`. Omitted while recording.
+- `StoppedBy`: Why the recording ended — `"cli"`, `"max-duration"`, `"play-mode-exit"`, `"window-closed"`, `"assembly-reload"`, or `"editor-quit"`. Omitted while recording.
 
 ## Interpreting results
 
@@ -67,6 +69,7 @@ Returns JSON containing:
 - `Success: false` with "Play Mode view RenderTexture is not available" → open the Game View tab (`uloop focus-window`) and make sure a camera renders.
 - `SkippedFrameCount` growing while `EncodedFrameCount` stays flat → the Game View is closed, hidden, or resized. Restore it; recording resumes without restarting.
 - `EncodedFrameCount` far below `ElapsedSeconds × FrameRate` with few skips → the Editor is unfocused and throttling draws; run `uloop focus-window` before the next recording.
+- `Success: false` with "Window '...' not found" → pick the right title from the `Open windows:` list in the message, or use `--match-mode prefix`.
 - `StoppedBy` is not `"cli"` → the recording ended on its own; the file is still valid up to that point.
 
 ## Notes

--- a/.claude/skills/uloop-record-video/SKILL.md
+++ b/.claude/skills/uloop-record-video/SKILL.md
@@ -34,7 +34,7 @@ uloop record-video --action stop
 | `--max-duration-seconds` | integer | `60` | Auto-stop safety limit in seconds. Valid range 1–600. Used by `start` only. |
 | `--resolution-scale` | number | `1.0` | Resolution scale (0.1 to 1.0) applied to the Game View size before encoding. `0.5` cuts file size and encoding cost to about a quarter. Used by `start` only. |
 | `--quality` | enum | `medium` | Encoder bitrate preset: `low`, `medium`, or `high`. Used by `start` only. |
-| `--window-name` | string | empty | Editor window title to record instead of the Game View (for example Scene, Inspector, Console). Empty records the Game View and requires Play Mode. A window recording does not require Play Mode, brings the tab to the front, repaints it every frame, and keeps running across Play Mode changes. Used by `start` only. |
+| `--window-name` | string | empty | Editor window title to record instead of the Game View (for example Scene, Inspector, Console). Empty records the Game View and requires Play Mode. A window recording does not require Play Mode, brings the tab to the front, repaints it every frame, and keeps running when Play Mode stops. Used by `start` only. |
 | `--match-mode` | enum | `exact` | Window title matching for `--window-name`: `exact`, `prefix`, or `contains` (case-insensitive). Used by `start` only. |
 | `--output-path` | string | empty | Output file path. Empty uses `.uloop/outputs/Videos/gameview_<yyyyMMdd_HHmmss_fff>.mp4` (`.webm` on Linux). Extension must be `.mp4` (H.264) or `.webm` (VP8). Linux rejects `.mp4`. Used by `start` only. |
 
@@ -76,5 +76,6 @@ Returns JSON containing:
 
 - Odd Game View sizes are rounded down to even for H.264 (for example 1286×723 → 1286×722; the last pixel row/column is dropped).
 - The recording is wall-clock paced, so Play Mode pause records a still image, not a gap.
+- A window recording survives Play Mode stopping, but entering Play Mode with domain reload enabled (Unity's default) ends it with `StoppedBy: "assembly-reload"`.
 - Default output is H.264 `.mp4` on macOS/Windows and VP8 `.webm` on Linux. An explicit `.webm` path uses VP8 on every host.
 - Default recordings under `.uloop/outputs/Videos/` keep only the newest 20 files per extension; a custom `--output-path` is never pruned.

--- a/Assets/Tests/Editor/EditorWindowFinderTests.cs
+++ b/Assets/Tests/Editor/EditorWindowFinderTests.cs
@@ -1,0 +1,148 @@
+using System;
+using NUnit.Framework;
+using UnityEditor;
+using UnityEngine;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor
+{
+    /// <summary>
+    /// Verifies title matching modes against a probe window that is never shown.
+    /// </summary>
+    public sealed class EditorWindowFinderTests
+    {
+        private const string ProbeTitle = "UloopFinderProbe Alpha";
+
+        private EditorWindowFinderProbeWindow _probe;
+
+        [SetUp]
+        public void SetUp()
+        {
+            // Not shown on purpose: Resources.FindObjectsOfTypeAll also enumerates hidden instances,
+            // so the matching modes can be exercised without disturbing the Editor layout.
+            _probe = ScriptableObject.CreateInstance<EditorWindowFinderProbeWindow>();
+            _probe.titleContent = new GUIContent(ProbeTitle);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            if (_probe == null)
+            {
+                return;
+            }
+
+            UnityEngine.Object.DestroyImmediate(_probe);
+            _probe = null;
+        }
+
+        /// <summary>
+        /// What: exact matching accepts the full title regardless of letter case.
+        /// </summary>
+        [Test]
+        public void FindWindowsByName_Exact_MatchesFullTitleCaseInsensitively()
+        {
+            EditorWindow[] result = EditorWindowFinder.FindWindowsByName(
+                "uloopfinderprobe alpha",
+                WindowMatchMode.exact);
+
+            Assert.That(Array.IndexOf(result, _probe), Is.GreaterThanOrEqualTo(0));
+        }
+
+        /// <summary>
+        /// What: exact matching rejects a title prefix, so it is not silently a prefix match.
+        /// </summary>
+        [Test]
+        public void FindWindowsByName_Exact_DoesNotMatchPrefix()
+        {
+            EditorWindow[] result = EditorWindowFinder.FindWindowsByName(
+                "UloopFinderProbe",
+                WindowMatchMode.exact);
+
+            Assert.That(Array.IndexOf(result, _probe), Is.LessThan(0));
+        }
+
+        /// <summary>
+        /// What: prefix matching accepts the start of the title.
+        /// </summary>
+        [Test]
+        public void FindWindowsByName_Prefix_MatchesTitleStart()
+        {
+            EditorWindow[] result = EditorWindowFinder.FindWindowsByName(
+                "uloopfinderprobe",
+                WindowMatchMode.prefix);
+
+            Assert.That(Array.IndexOf(result, _probe), Is.GreaterThanOrEqualTo(0));
+        }
+
+        /// <summary>
+        /// What: contains matching accepts a fragment from the middle of the title.
+        /// </summary>
+        [Test]
+        public void FindWindowsByName_Contains_MatchesTitleMiddle()
+        {
+            EditorWindow[] result = EditorWindowFinder.FindWindowsByName(
+                "probe alp",
+                WindowMatchMode.contains);
+
+            Assert.That(Array.IndexOf(result, _probe), Is.GreaterThanOrEqualTo(0));
+        }
+
+        /// <summary>
+        /// What: prefix matching rejects a fragment from the middle, so it is not a contains match.
+        /// </summary>
+        [Test]
+        public void FindWindowsByName_Prefix_DoesNotMatchTitleMiddle()
+        {
+            EditorWindow[] result = EditorWindowFinder.FindWindowsByName(
+                "probe alp",
+                WindowMatchMode.prefix);
+
+            Assert.That(Array.IndexOf(result, _probe), Is.LessThan(0));
+        }
+
+        /// <summary>
+        /// What: an empty name matches nothing instead of every open window.
+        /// </summary>
+        [Test]
+        public void FindWindowsByName_EmptyName_ReturnsEmpty()
+        {
+            EditorWindow[] result = EditorWindowFinder.FindWindowsByName("", WindowMatchMode.contains);
+
+            Assert.That(result, Is.Empty);
+        }
+
+        /// <summary>
+        /// What: a title that no window carries matches nothing.
+        /// </summary>
+        [Test]
+        public void FindWindowsByName_UnknownName_ReturnsEmpty()
+        {
+            EditorWindow[] result = EditorWindowFinder.FindWindowsByName(
+                "NoSuchWindow-uloop-test",
+                WindowMatchMode.exact);
+
+            Assert.That(result, Is.Empty);
+        }
+
+        /// <summary>
+        /// What: the open-window name list includes the probe title used by the matching tests.
+        /// </summary>
+        [Test]
+        public void GetOpenWindowNames_ContainsProbeTitle()
+        {
+            string[] names = EditorWindowFinder.GetOpenWindowNames();
+
+            Assert.That(names, Does.Contain(ProbeTitle));
+        }
+
+        /// <summary>
+        /// Titled placeholder window used only to exercise the matching modes.
+        /// </summary>
+        private sealed class EditorWindowFinderProbeWindow : EditorWindow
+        {
+        }
+    }
+}

--- a/Assets/Tests/Editor/EditorWindowFinderTests.cs
+++ b/Assets/Tests/Editor/EditorWindowFinderTests.cs
@@ -139,6 +139,30 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
 
         /// <summary>
+        /// What: a window whose title text is null is skipped instead of throwing.
+        /// </summary>
+        [Test]
+        public void FindWindowsByName_WhenAWindowHasNullTitleText_DoesNotThrow()
+        {
+            EditorWindowFinderProbeWindow nullTitled =
+                ScriptableObject.CreateInstance<EditorWindowFinderProbeWindow>();
+            nullTitled.titleContent = new GUIContent { text = null };
+            try
+            {
+                EditorWindow[] result = EditorWindowFinder.FindWindowsByName(
+                    "uloopfinderprobe",
+                    WindowMatchMode.prefix);
+
+                Assert.That(Array.IndexOf(result, nullTitled), Is.LessThan(0));
+                Assert.That(Array.IndexOf(result, _probe), Is.GreaterThanOrEqualTo(0));
+            }
+            finally
+            {
+                UnityEngine.Object.DestroyImmediate(nullTitled);
+            }
+        }
+
+        /// <summary>
         /// Titled placeholder window used only to exercise the matching modes.
         /// </summary>
         private sealed class EditorWindowFinderProbeWindow : EditorWindow

--- a/Assets/Tests/Editor/EditorWindowFinderTests.cs.meta
+++ b/Assets/Tests/Editor/EditorWindowFinderTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 708c97787201f4f05b0766442aa7a17a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/RecordVideoOutputPathResolverTests.cs
+++ b/Assets/Tests/Editor/RecordVideoOutputPathResolverTests.cs
@@ -20,7 +20,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         {
             DateTime now = new DateTime(2026, 9, 1, 15, 4, 5, 123, DateTimeKind.Utc);
 
-            string resolved = RecordVideoOutputPathResolver.Resolve("", "/project", now, false);
+            string resolved = RecordVideoOutputPathResolver.Resolve("", "/project", now, false, RecordVideoOutputPathResolver.DefaultFileNamePrefix);
 
             string expected = Path.Combine(
                 "/project",
@@ -38,7 +38,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         {
             string requested = Path.Combine("custom", "clip.mp4");
 
-            string resolved = RecordVideoOutputPathResolver.Resolve(requested, "/project", DateTime.UtcNow, false);
+            string resolved = RecordVideoOutputPathResolver.Resolve(requested, "/project", DateTime.UtcNow, false, RecordVideoOutputPathResolver.DefaultFileNamePrefix);
 
             Assert.That(resolved, Is.EqualTo(Path.GetFullPath(requested)));
         }
@@ -51,10 +51,24 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         {
             DateTime now = new DateTime(2026, 9, 1, 15, 4, 5, 123, DateTimeKind.Utc);
 
-            string resolved = RecordVideoOutputPathResolver.Resolve("", "/project", now, true);
+            string resolved = RecordVideoOutputPathResolver.Resolve("", "/project", now, true, RecordVideoOutputPathResolver.DefaultFileNamePrefix);
 
             Assert.That(resolved, Does.EndWith(".webm"));
             Assert.That(resolved, Does.Contain("gameview_20260901_150405_123.webm"));
+        }
+
+        /// <summary>
+        /// What: the window prefix produces a window_ default file name instead of the Game View one.
+        /// </summary>
+        [Test]
+        public void Resolve_WithWindowPrefix_UsesWindowFileName()
+        {
+            DateTime now = new DateTime(2026, 9, 1, 15, 4, 5, 123, DateTimeKind.Utc);
+
+            string resolved = RecordVideoOutputPathResolver.Resolve(
+                "", "/project", now, false, RecordVideoConstants.DefaultWindowFileNamePrefix);
+
+            Assert.That(Path.GetFileName(resolved), Does.StartWith("window_"));
         }
     }
 }

--- a/Assets/Tests/Editor/RecordVideoParameterValidatorTests.cs
+++ b/Assets/Tests/Editor/RecordVideoParameterValidatorTests.cs
@@ -22,7 +22,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 outputPath,
                 isLinux,
                 1.0f,
-                RecordVideoQuality.medium);
+                RecordVideoQuality.medium,
+                WindowMatchMode.exact);
         }
 
         /// <summary>
@@ -182,7 +183,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         [Test]
         public void Validate_WhenResolutionScaleIs0_1_IsValid()
         {
-            ValidationResult result = RecordVideoParameterValidator.Validate(30, 60, "", false, 0.1f, RecordVideoQuality.medium);
+            ValidationResult result = RecordVideoParameterValidator.Validate(
+                30, 60, "", false, 0.1f, RecordVideoQuality.medium, WindowMatchMode.exact);
 
             Assert.That(result.IsValid, Is.True);
         }
@@ -193,7 +195,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         [Test]
         public void Validate_WhenResolutionScaleIs1_IsValid()
         {
-            ValidationResult result = RecordVideoParameterValidator.Validate(30, 60, "", false, 1.0f, RecordVideoQuality.medium);
+            ValidationResult result = RecordVideoParameterValidator.Validate(
+                30, 60, "", false, 1.0f, RecordVideoQuality.medium, WindowMatchMode.exact);
 
             Assert.That(result.IsValid, Is.True);
         }
@@ -205,7 +208,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         public void Validate_WhenResolutionScaleIsNaN_IsInvalid()
         {
             ValidationResult result = RecordVideoParameterValidator.Validate(
-                30, 60, "", false, float.NaN, RecordVideoQuality.medium);
+                30, 60, "", false, float.NaN, RecordVideoQuality.medium, WindowMatchMode.exact);
 
             Assert.That(result.IsValid, Is.False);
             Assert.That(result.ErrorMessage, Does.Contain("ResolutionScale"));
@@ -218,10 +221,23 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         public void Validate_WhenQualityIsUndefined_IsInvalid()
         {
             ValidationResult result = RecordVideoParameterValidator.Validate(
-                30, 60, "", false, 1.0f, (RecordVideoQuality)3);
+                30, 60, "", false, 1.0f, (RecordVideoQuality)3, WindowMatchMode.exact);
 
             Assert.That(result.IsValid, Is.False);
             Assert.That(result.ErrorMessage, Is.EqualTo("Quality must be Low, Medium, or High."));
+        }
+
+        /// <summary>
+        /// What: an undefined match mode (for example numeric JSON input 99) is rejected.
+        /// </summary>
+        [Test]
+        public void Validate_UndefinedMatchMode_Fails()
+        {
+            ValidationResult result = RecordVideoParameterValidator.Validate(
+                30, 60, "", false, 1.0f, RecordVideoQuality.medium, (WindowMatchMode)99);
+
+            Assert.That(result.IsValid, Is.False);
+            Assert.That(result.ErrorMessage, Does.Contain("MatchMode"));
         }
 
         /// <summary>
@@ -230,7 +246,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         [Test]
         public void Validate_WhenResolutionScaleIs0_09_IsInvalid()
         {
-            ValidationResult result = RecordVideoParameterValidator.Validate(30, 60, "", false, 0.09f, RecordVideoQuality.medium);
+            ValidationResult result = RecordVideoParameterValidator.Validate(
+                30, 60, "", false, 0.09f, RecordVideoQuality.medium, WindowMatchMode.exact);
 
             Assert.That(result.IsValid, Is.False);
             Assert.That(
@@ -244,7 +261,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         [Test]
         public void Validate_WhenResolutionScaleIs1_01_IsInvalid()
         {
-            ValidationResult result = RecordVideoParameterValidator.Validate(30, 60, "", false, 1.01f, RecordVideoQuality.medium);
+            ValidationResult result = RecordVideoParameterValidator.Validate(
+                30, 60, "", false, 1.01f, RecordVideoQuality.medium, WindowMatchMode.exact);
 
             Assert.That(result.IsValid, Is.False);
             Assert.That(

--- a/Assets/Tests/Editor/RecordVideoUseCaseTests.cs
+++ b/Assets/Tests/Editor/RecordVideoUseCaseTests.cs
@@ -44,6 +44,44 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
 
         /// <summary>
+        /// What: Start with an unmatched window name fails with the window-not-found message.
+        /// </summary>
+        [Test]
+        public async Task ExecuteAsync_StartWithUnknownWindowName_ReturnsWindowNotFoundFailure()
+        {
+            RecordVideoUseCase useCase = new RecordVideoUseCase();
+            RecordVideoSchema parameters = new RecordVideoSchema
+            {
+                Action = RecordVideoAction.start,
+                WindowName = "NoSuchWindow-uloop-test"
+            };
+
+            RecordVideoResponse response = await useCase.ExecuteAsync(parameters, CancellationToken.None);
+
+            Assert.That(response.Success, Is.False);
+            Assert.That(response.IsRecording, Is.False);
+            Assert.That(response.Message, Does.StartWith("Window 'NoSuchWindow-uloop-test' not found"));
+        }
+
+        /// <summary>
+        /// What: a window recording skips the Play Mode preflight, so Edit Mode does not fail on it.
+        /// </summary>
+        [Test]
+        public async Task ExecuteAsync_StartWithWindowNameInEditMode_DoesNotFailPreflight()
+        {
+            RecordVideoUseCase useCase = new RecordVideoUseCase();
+            RecordVideoSchema parameters = new RecordVideoSchema
+            {
+                Action = RecordVideoAction.start,
+                WindowName = "NoSuchWindow-uloop-test"
+            };
+
+            RecordVideoResponse response = await useCase.ExecuteAsync(parameters, CancellationToken.None);
+
+            Assert.That(response.Message, Is.Not.EqualTo(PlayModeToolPreflightService.PlayModeNotActiveMessage));
+        }
+
+        /// <summary>
         /// What: Status with no recording and no last-completed snapshot reports idle success.
         /// </summary>
         [Test]

--- a/Assets/Tests/Editor/UnityCLILoop.Tests.Editor.asmdef
+++ b/Assets/Tests/Editor/UnityCLILoop.Tests.Editor.asmdef
@@ -42,7 +42,8 @@
         "GUID:96b8d4624fb74ea2849fed17e7ad69d3",
         "GUID:e3fd8b49afd6f4e3cae09011028922b4",
         "GUID:75469ad4d38634e559750d17036d5f7c",
-        "GUID:548ac963c0508475482ff2c4c34f400d"
+        "GUID:548ac963c0508475482ff2c4c34f400d",
+        "GUID:f0b6c2c251d6442f0ad1dd53c07e5092"
     ],
     "includePlatforms": [
         "Editor"

--- a/Assets/Tests/Editor/VideoRecordingSessionTests.cs
+++ b/Assets/Tests/Editor/VideoRecordingSessionTests.cs
@@ -186,6 +186,17 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
 
         /// <summary>
+        /// What: the frame texture is marked HideAndDontSave so a texture created during Play Mode
+        /// is not destroyed when Play Mode ends. The transition itself cannot run in an EditMode
+        /// test and is covered by manual verification against a live Editor.
+        /// </summary>
+        [Test]
+        public void Constructor_MarksFrameTextureHideAndDontSave()
+        {
+            Assert.That(_session.FrameTextureForTests.hideFlags, Is.EqualTo(HideFlags.HideAndDontSave));
+        }
+
+        /// <summary>
         /// What: a second Stop is a no-op so the encoder is disposed only once.
         /// </summary>
         [Test]

--- a/Assets/Tests/Editor/VideoRecordingSessionTests.cs
+++ b/Assets/Tests/Editor/VideoRecordingSessionTests.cs
@@ -137,6 +137,38 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
 
         /// <summary>
+        /// What: a closed frame source stops the session with the window-closed reason and encodes nothing.
+        /// </summary>
+        [Test]
+        public void Tick_WhenSourceClosed_StopsWithWindowClosedReason()
+        {
+            _frameSource.IsSourceClosed = true;
+            _now = 0.5;
+
+            _session.Tick();
+
+            VideoRecordingSnapshot snapshot = _session.Snapshot();
+            Assert.That(snapshot.IsRecording, Is.False);
+            Assert.That(snapshot.StoppedBy, Is.EqualTo("window-closed"));
+            Assert.That(_encoder.AddFrameCallCount, Is.EqualTo(0));
+            Assert.That(snapshot.SkippedFrameCount, Is.EqualTo(0));
+        }
+
+        /// <summary>
+        /// What: max duration wins over a closed source so the existing stop reason does not change.
+        /// </summary>
+        [Test]
+        public void Tick_WhenSourceClosedAfterMaxDuration_StopsWithMaxDurationReason()
+        {
+            _frameSource.IsSourceClosed = true;
+            _now = 60.0;
+
+            _session.Tick();
+
+            Assert.That(_session.Snapshot().StoppedBy, Is.EqualTo("max-duration"));
+        }
+
+        /// <summary>
         /// What: a second Stop is a no-op so the encoder is disposed only once.
         /// </summary>
         [Test]
@@ -212,6 +244,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         private sealed class FakeGameViewFrameSource : IGameViewFrameSource
         {
             internal bool ReadSucceeds { get; set; } = true;
+
+            public bool IsSourceClosed { get; set; }
 
             public bool TryReadFrame(Texture2D destination)
             {

--- a/Assets/Tests/Editor/VideoRecordingSessionTests.cs
+++ b/Assets/Tests/Editor/VideoRecordingSessionTests.cs
@@ -169,6 +169,23 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
 
         /// <summary>
+        /// What: a destroyed frame texture stops the session instead of throwing on every tick.
+        /// </summary>
+        [Test]
+        public void Tick_WhenFrameTextureDestroyed_StopsWithFrameTextureLostReason()
+        {
+            UnityEngine.Object.DestroyImmediate(_session.FrameTextureForTests);
+            _now = 0.5;
+
+            Assert.DoesNotThrow(() => _session.Tick());
+
+            VideoRecordingSnapshot snapshot = _session.Snapshot();
+            Assert.That(snapshot.IsRecording, Is.False);
+            Assert.That(snapshot.StoppedBy, Is.EqualTo("frame-texture-lost"));
+            Assert.That(_encoder.AddFrameCallCount, Is.EqualTo(0));
+        }
+
+        /// <summary>
         /// What: a second Stop is a no-op so the encoder is disposed only once.
         /// </summary>
         [Test]

--- a/Packages/src/Editor/FirstPartyTools/Common/EditorWindowFinder.meta
+++ b/Packages/src/Editor/FirstPartyTools/Common/EditorWindowFinder.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: baa1b16813cb34431933d10526c7cb47
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/Common/EditorWindowFinder/EditorWindowFinder.cs
+++ b/Packages/src/Editor/FirstPartyTools/Common/EditorWindowFinder/EditorWindowFinder.cs
@@ -1,0 +1,76 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using UnityEditor;
+using UnityEngine;
+
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Finds open EditorWindows by title so multiple tools can target the same window the user sees.
+    /// </summary>
+    public static class EditorWindowFinder
+    {
+        /// <summary>
+        /// Find all EditorWindows matching the given name (title bar text).
+        /// </summary>
+        /// <param name="windowName">Window name displayed in the title bar (e.g., "Console", "Inspector")</param>
+        /// <param name="matchMode">Matching mode: exact, prefix, or contains (all case-insensitive)</param>
+        /// <returns>Array of matching EditorWindows (empty if none found)</returns>
+        public static EditorWindow[] FindWindowsByName(string windowName, WindowMatchMode matchMode = WindowMatchMode.exact)
+        {
+            if (string.IsNullOrEmpty(windowName))
+            {
+                return Array.Empty<EditorWindow>();
+            }
+
+            List<EditorWindow> matchingWindows = new();
+            EditorWindow[] allWindows = Resources.FindObjectsOfTypeAll<EditorWindow>();
+            foreach (EditorWindow window in allWindows)
+            {
+                if (window.titleContent == null)
+                {
+                    continue;
+                }
+
+                string title = window.titleContent.text;
+                bool isMatch = matchMode switch
+                {
+                    WindowMatchMode.exact => title.Equals(windowName, StringComparison.OrdinalIgnoreCase),
+                    WindowMatchMode.prefix => title.StartsWith(windowName, StringComparison.OrdinalIgnoreCase),
+                    WindowMatchMode.contains => title.Contains(windowName, StringComparison.OrdinalIgnoreCase),
+                    _ => title.Equals(windowName, StringComparison.OrdinalIgnoreCase)
+                };
+
+                if (isMatch)
+                {
+                    matchingWindows.Add(window);
+                }
+            }
+
+            return matchingWindows.ToArray();
+        }
+
+        /// <summary>
+        /// Get a list of all open EditorWindow names.
+        /// </summary>
+        /// <returns>Array of window names</returns>
+        public static string[] GetOpenWindowNames()
+        {
+            EditorWindow[] allWindows = Resources.FindObjectsOfTypeAll<EditorWindow>();
+            List<string> names = new();
+
+            foreach (EditorWindow window in allWindows)
+            {
+                if (window.titleContent != null && !string.IsNullOrEmpty(window.titleContent.text))
+                {
+                    names.Add(window.titleContent.text);
+                }
+            }
+
+            return names.ToArray();
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/Common/EditorWindowFinder/EditorWindowFinder.cs
+++ b/Packages/src/Editor/FirstPartyTools/Common/EditorWindowFinder/EditorWindowFinder.cs
@@ -35,7 +35,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     continue;
                 }
 
-                string title = window.titleContent.text;
+                // GUIContent.text can be assigned null by a window, and every match branch
+                // below calls an instance method on it.
+                string title = window.titleContent.text ?? string.Empty;
                 bool isMatch = matchMode switch
                 {
                     WindowMatchMode.exact => title.Equals(windowName, StringComparison.OrdinalIgnoreCase),

--- a/Packages/src/Editor/FirstPartyTools/Common/EditorWindowFinder/EditorWindowFinder.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/Common/EditorWindowFinder/EditorWindowFinder.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b978d4696750b434ab886ff4f119bafc
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/Common/EditorWindowFinder/UnityCLILoop.FirstPartyTools.Common.EditorWindowFinder.Editor.asmdef
+++ b/Packages/src/Editor/FirstPartyTools/Common/EditorWindowFinder/UnityCLILoop.FirstPartyTools.Common.EditorWindowFinder.Editor.asmdef
@@ -1,0 +1,18 @@
+{
+    "name": "UnityCLILoop.FirstPartyTools.Common.EditorWindowFinder.Editor",
+    "rootNamespace": "io.github.hatayama.UnityCliLoop.FirstPartyTools",
+    "references": [
+        "GUID:fc3fd32eddbee40e39c2d76dc184957b"
+    ],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": false,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Packages/src/Editor/FirstPartyTools/Common/EditorWindowFinder/UnityCLILoop.FirstPartyTools.Common.EditorWindowFinder.Editor.asmdef.meta
+++ b/Packages/src/Editor/FirstPartyTools/Common/EditorWindowFinder/UnityCLILoop.FirstPartyTools.Common.EditorWindowFinder.Editor.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: f0b6c2c251d6442f0ad1dd53c07e5092
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/RecordVideo/EditorWindowFrameSource.cs
+++ b/Packages/src/Editor/FirstPartyTools/RecordVideo/EditorWindowFrameSource.cs
@@ -1,0 +1,111 @@
+using UnityEditor;
+using UnityEngine;
+
+using io.github.hatayama.UnityCliLoop.InternalAPIBridge;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Reads an EditorWindow's last painted pixels into a reusable RGBA32 destination and requests the next repaint.
+    /// </summary>
+    internal sealed class EditorWindowFrameSource : IGameViewFrameSource
+    {
+        private readonly EditorWindow _window;
+        private readonly float _resolutionScale;
+
+        internal EditorWindowFrameSource(EditorWindow window, float resolutionScale)
+        {
+            _window = window;
+            _resolutionScale = resolutionScale;
+        }
+
+        // Unity's null comparison also reports a destroyed window, which is how a closed tab is detected.
+        public bool IsSourceClosed => _window == null;
+
+        public bool TryReadFrame(Texture2D destination)
+        {
+            if (_window == null)
+            {
+                return false;
+            }
+
+            float pixelsPerPoint = EditorGUIUtility.pixelsPerPoint;
+            int sourceWidth = Mathf.RoundToInt(_window.position.width * pixelsPerPoint);
+            int sourceHeight = Mathf.RoundToInt(_window.position.height * pixelsPerPoint);
+            if (sourceWidth <= 0 || sourceHeight <= 0)
+            {
+                return false;
+            }
+
+            // A resized window no longer matches the fixed encoder size, so that tick is skipped
+            // the same way the Play Mode view source handles a resized Game View.
+            if (!VideoFrameSizePolicy.MatchesEncoderSize(
+                    sourceWidth,
+                    sourceHeight,
+                    _resolutionScale,
+                    destination.width,
+                    destination.height))
+            {
+                return false;
+            }
+
+            ReadWindowPixels(destination, sourceWidth, sourceHeight);
+
+            // Repaint after reading: it only queues a redraw, so this tick reads the previous
+            // repaint's result and the next tick reads the one requested here.
+            _window.Repaint();
+            return true;
+        }
+
+        private void ReadWindowPixels(Texture2D destination, int sourceWidth, int sourceHeight)
+        {
+            RenderTextureDescriptor fullDescriptor = new RenderTextureDescriptor(
+                sourceWidth,
+                sourceHeight,
+                RenderTextureFormat.ARGB32,
+                24);
+            // Why sRGB: in Linear color space the window grab must not be gamma-converted twice.
+            if (QualitySettings.activeColorSpace == ColorSpace.Linear)
+            {
+                fullDescriptor.sRGB = false;
+            }
+
+            // Captured before the grab call, which reassigns RenderTexture.active internally;
+            // saving afterwards would release a still-active render texture.
+            RenderTexture previousActive = RenderTexture.active;
+            RenderTexture full = RenderTexture.GetTemporary(fullDescriptor);
+            RenderTexture scaled = null;
+            try
+            {
+                InternalEditorUtilityBridge.CaptureEditorWindow(_window, full);
+
+                RenderTexture readSource = full;
+                // ReadPixels cannot read beyond the active target, so a scaled recording needs
+                // the full grab downscaled into a destination-sized target first.
+                if (destination.width != sourceWidth || destination.height != sourceHeight)
+                {
+                    RenderTextureDescriptor scaledDescriptor = fullDescriptor;
+                    scaledDescriptor.width = destination.width;
+                    scaledDescriptor.height = destination.height;
+                    scaled = RenderTexture.GetTemporary(scaledDescriptor);
+                    Graphics.Blit(full, scaled);
+                    readSource = scaled;
+                }
+
+                RenderTexture.active = readSource;
+                destination.ReadPixels(new Rect(0, 0, destination.width, destination.height), 0, 0);
+                destination.Apply();
+            }
+            finally
+            {
+                RenderTexture.active = previousActive;
+                if (scaled != null)
+                {
+                    RenderTexture.ReleaseTemporary(scaled);
+                }
+
+                RenderTexture.ReleaseTemporary(full);
+            }
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/RecordVideo/EditorWindowFrameSource.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/RecordVideo/EditorWindowFrameSource.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f5347bf8e818f4e7dbd84f2b3ead87b5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/RecordVideo/IGameViewFrameSource.cs
+++ b/Packages/src/Editor/FirstPartyTools/RecordVideo/IGameViewFrameSource.cs
@@ -8,5 +8,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     internal interface IGameViewFrameSource
     {
         bool TryReadFrame(Texture2D destination);
+
+        /// <summary>
+        /// True once the source can never produce another frame (for example the target window was destroyed).
+        /// </summary>
+        bool IsSourceClosed { get; }
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/RecordVideo/PlayModeViewFrameSource.cs
+++ b/Packages/src/Editor/FirstPartyTools/RecordVideo/PlayModeViewFrameSource.cs
@@ -16,6 +16,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             _resolutionScale = resolutionScale;
         }
 
+        public bool IsSourceClosed => false;
+
         public bool TryReadFrame(Texture2D destination)
         {
             RenderTexture renderTexture = GameViewBridge.GetRenderTexture();

--- a/Packages/src/Editor/FirstPartyTools/RecordVideo/RecordVideoConstants.cs
+++ b/Packages/src/Editor/FirstPartyTools/RecordVideo/RecordVideoConstants.cs
@@ -10,7 +10,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         internal const string StoppedByPlayModeExit = "play-mode-exit";
         internal const string StoppedByAssemblyReload = "assembly-reload";
         internal const string StoppedByEditorQuit = "editor-quit";
+        internal const string StoppedByWindowClosed = "window-closed";
         internal const string WebmExtension = ".webm";
+        internal const string DefaultWindowFileNamePrefix = "window_";
 
         internal const string AlreadyRecordingMessage =
             "A recording is already in progress. Stop it first.";

--- a/Packages/src/Editor/FirstPartyTools/RecordVideo/RecordVideoConstants.cs
+++ b/Packages/src/Editor/FirstPartyTools/RecordVideo/RecordVideoConstants.cs
@@ -20,6 +20,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             "Play Mode view RenderTexture is not available. Open the Game View and make sure a camera renders.";
         internal const string FrameSizeTooSmallMessage =
             "Play Mode view size is too small to record after rounding to even encoder dimensions.";
+        internal const string WindowLayoutTimedOutMessage =
+            "Timed out waiting for the window to lay out; retry after focusing the Editor.";
         internal const string NoRecordingMessage = "No recording is in progress.";
         internal const string InvalidActionMessage = "Action must be Start, Stop, or Status.";
         internal const string StartedMessage = "Recording started.";

--- a/Packages/src/Editor/FirstPartyTools/RecordVideo/RecordVideoConstants.cs
+++ b/Packages/src/Editor/FirstPartyTools/RecordVideo/RecordVideoConstants.cs
@@ -11,6 +11,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         internal const string StoppedByAssemblyReload = "assembly-reload";
         internal const string StoppedByEditorQuit = "editor-quit";
         internal const string StoppedByWindowClosed = "window-closed";
+        internal const string StoppedByFrameTextureLost = "frame-texture-lost";
         internal const string WebmExtension = ".webm";
         internal const string DefaultWindowFileNamePrefix = "window_";
 

--- a/Packages/src/Editor/FirstPartyTools/RecordVideo/RecordVideoOutputPathResolver.cs
+++ b/Packages/src/Editor/FirstPartyTools/RecordVideo/RecordVideoOutputPathResolver.cs
@@ -12,19 +12,20 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     {
         private const string Mp4Extension = "mp4";
         private const string WebmExtension = "webm";
-        private const string DefaultFileNamePrefix = "gameview_";
+        internal const string DefaultFileNamePrefix = "gameview_";
         private const string TimestampFormat = "yyyyMMdd_HHmmss_fff";
 
         internal static string Resolve(
             string requestedPath,
             string projectRoot,
             DateTime now,
-            bool isLinux)
+            bool isLinux,
+            string fileNamePrefix)
         {
             if (string.IsNullOrEmpty(requestedPath))
             {
                 string extension = isLinux ? WebmExtension : Mp4Extension;
-                string fileName = $"{DefaultFileNamePrefix}{now.ToString(TimestampFormat)}.{extension}";
+                string fileName = $"{fileNamePrefix}{now.ToString(TimestampFormat)}.{extension}";
                 return Path.Combine(
                     projectRoot,
                     UnityCliLoopConstants.OUTPUT_ROOT_DIR,

--- a/Packages/src/Editor/FirstPartyTools/RecordVideo/RecordVideoParameterValidator.cs
+++ b/Packages/src/Editor/FirstPartyTools/RecordVideo/RecordVideoParameterValidator.cs
@@ -24,7 +24,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             string outputPath,
             bool isLinux,
             float resolutionScale,
-            RecordVideoQuality quality)
+            RecordVideoQuality quality,
+            WindowMatchMode matchMode)
         {
             if (frameRate < MinFrameRate || frameRate > MaxFrameRate)
             {
@@ -50,6 +51,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             if (!Enum.IsDefined(typeof(RecordVideoQuality), quality))
             {
                 return ValidationResult.Failure("Quality must be Low, Medium, or High.");
+            }
+
+            // Newtonsoft maps numeric JSON input onto undefined enum values, so range-check here.
+            if (!Enum.IsDefined(typeof(WindowMatchMode), matchMode))
+            {
+                return ValidationResult.Failure("MatchMode must be exact, prefix, or contains.");
             }
 
             if (string.IsNullOrEmpty(outputPath))

--- a/Packages/src/Editor/FirstPartyTools/RecordVideo/RecordVideoSchema.cs
+++ b/Packages/src/Editor/FirstPartyTools/RecordVideo/RecordVideoSchema.cs
@@ -15,6 +15,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
         public string OutputPath { get; set; } = "";
 
+        public string WindowName { get; set; } = "";
+
+        public WindowMatchMode MatchMode { get; set; } = WindowMatchMode.exact;
+
         public float ResolutionScale { get; set; } = 1.0f;
 
         public RecordVideoQuality Quality { get; set; } = RecordVideoQuality.medium;

--- a/Packages/src/Editor/FirstPartyTools/RecordVideo/RecordVideoService.cs
+++ b/Packages/src/Editor/FirstPartyTools/RecordVideo/RecordVideoService.cs
@@ -14,6 +14,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     {
         private static VideoRecordingSession _session;
         private static bool _usedDefaultOutputPath;
+        private static bool _stopOnPlayModeExit;
 
         internal static bool IsRecording => _session != null && _session.Snapshot().IsRecording;
 
@@ -34,7 +35,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             bool usedDefaultOutputPath,
             int width,
             int height,
-            float resolutionScale,
+            IGameViewFrameSource frameSource,
+            bool stopOnPlayModeExit,
             RecordVideoQuality quality)
         {
             Debug.Assert(!IsRecording, "Start must not run while a recording is already active.");
@@ -43,8 +45,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             Debug.Assert(height > 0, "encoder height must be a positive even size.");
             Debug.Assert((width & 1) == 0, "encoder width must be even.");
             Debug.Assert((height & 1) == 0, "encoder height must be even.");
-
-            PlayModeViewFrameSource frameSource = new PlayModeViewFrameSource(resolutionScale);
 
             string directory = Path.GetDirectoryName(outputPath);
             Debug.Assert(!string.IsNullOrEmpty(directory), "outputPath must include a directory.");
@@ -72,6 +72,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     outputPath,
                     quality);
                 _usedDefaultOutputPath = usedDefaultOutputPath;
+                _stopOnPlayModeExit = stopOnPlayModeExit;
                 LastCompletedRecordingStore.Clear();
                 EditorApplication.update -= OnEditorUpdate;
                 EditorApplication.update += OnEditorUpdate;
@@ -147,6 +148,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             {
                 _session = null;
                 _usedDefaultOutputPath = false;
+                _stopOnPlayModeExit = false;
             }
         }
 
@@ -168,6 +170,13 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             if (_session == null)
+            {
+                return;
+            }
+
+            // A window recording is independent of Play Mode, so only a Game View recording
+            // stops when Play Mode ends.
+            if (!_stopOnPlayModeExit)
             {
                 return;
             }

--- a/Packages/src/Editor/FirstPartyTools/RecordVideo/RecordVideoUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/RecordVideo/RecordVideoUseCase.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using UnityEditor;
 using UnityEngine;
 
 using io.github.hatayama.UnityCliLoop.InternalAPIBridge;
@@ -39,10 +40,15 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
         private static RecordVideoResponse ExecuteStart(RecordVideoSchema parameters, bool isLinux)
         {
-            PlayModeToolPreflightResult preflight = PlayModeToolPreflightService.RequireActive();
-            if (!preflight.IsValid)
+            bool isWindowRecording = !string.IsNullOrEmpty(parameters.WindowName);
+            // A window recording paints through the Editor loop, so it does not need Play Mode.
+            if (!isWindowRecording)
             {
-                return CreateFailure(RecordVideoAction.start, preflight.ErrorMessage);
+                PlayModeToolPreflightResult preflight = PlayModeToolPreflightService.RequireActive();
+                if (!preflight.IsValid)
+                {
+                    return CreateFailure(RecordVideoAction.start, preflight.ErrorMessage);
+                }
             }
 
             if (RecordVideoService.IsRecording)
@@ -60,23 +66,24 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 parameters.OutputPath,
                 isLinux,
                 parameters.ResolutionScale,
-                parameters.Quality);
+                parameters.Quality,
+                parameters.MatchMode);
             if (!validation.IsValid)
             {
                 return CreateFailure(RecordVideoAction.start, validation.ErrorMessage);
             }
 
-            RenderTexture renderTexture = GameViewBridge.GetRenderTexture();
-            if (renderTexture == null)
+            RecordVideoSourceResolution source = isWindowRecording
+                ? ResolveWindowSource(parameters)
+                : ResolvePlayModeViewSource(parameters);
+            if (source.FailureMessage != null)
             {
-                return CreateFailure(
-                    RecordVideoAction.start,
-                    RecordVideoConstants.RenderTextureUnavailableMessage);
+                return CreateFailure(RecordVideoAction.start, source.FailureMessage);
             }
 
             (int width, int height) size = VideoFrameSizePolicy.Resolve(
-                renderTexture.width,
-                renderTexture.height,
+                source.SourceWidth,
+                source.SourceHeight,
                 parameters.ResolutionScale);
             int width = size.width;
             int height = size.height;
@@ -89,7 +96,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 parameters.OutputPath,
                 UnityCliLoopPathResolver.GetProjectRoot(),
                 DateTime.Now,
-                isLinux);
+                isLinux,
+                source.FileNamePrefix);
             bool usedDefaultOutputPath = string.IsNullOrEmpty(parameters.OutputPath);
             VideoRecordingSnapshot snapshot = RecordVideoService.Start(
                 parameters.FrameRate,
@@ -98,13 +106,54 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 usedDefaultOutputPath,
                 width,
                 height,
-                parameters.ResolutionScale,
+                source.FrameSource,
+                !isWindowRecording,
                 parameters.Quality);
             return CreateResponse(
                 true,
                 RecordVideoConstants.StartedMessage,
                 RecordVideoAction.start,
                 snapshot);
+        }
+
+        private static RecordVideoSourceResolution ResolveWindowSource(RecordVideoSchema parameters)
+        {
+            EditorWindow[] windows = EditorWindowFinder.FindWindowsByName(
+                parameters.WindowName,
+                parameters.MatchMode);
+            if (windows.Length == 0)
+            {
+                string openWindows = string.Join(", ", EditorWindowFinder.GetOpenWindowNames());
+                return RecordVideoSourceResolution.Failure(
+                    $"Window '{parameters.WindowName}' not found (MatchMode: {parameters.MatchMode}). Open windows: {openWindows}");
+            }
+
+            EditorWindow window = windows[0];
+            // Shown before measuring: a background tab is never painted, and bringing it to the
+            // front can change its layout.
+            window.ShowTab();
+            float pixelsPerPoint = EditorGUIUtility.pixelsPerPoint;
+            return RecordVideoSourceResolution.Success(
+                new EditorWindowFrameSource(window, parameters.ResolutionScale),
+                Mathf.RoundToInt(window.position.width * pixelsPerPoint),
+                Mathf.RoundToInt(window.position.height * pixelsPerPoint),
+                RecordVideoConstants.DefaultWindowFileNamePrefix);
+        }
+
+        private static RecordVideoSourceResolution ResolvePlayModeViewSource(RecordVideoSchema parameters)
+        {
+            RenderTexture renderTexture = GameViewBridge.GetRenderTexture();
+            if (renderTexture == null)
+            {
+                return RecordVideoSourceResolution.Failure(
+                    RecordVideoConstants.RenderTextureUnavailableMessage);
+            }
+
+            return RecordVideoSourceResolution.Success(
+                new PlayModeViewFrameSource(parameters.ResolutionScale),
+                renderTexture.width,
+                renderTexture.height,
+                RecordVideoOutputPathResolver.DefaultFileNamePrefix);
         }
 
         private static RecordVideoResponse ExecuteStop()
@@ -196,6 +245,50 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 StoppedBy = snapshot.StoppedBy,
                 Quality = snapshot.Quality
             };
+        }
+    }
+
+    /// <summary>
+    /// Carries the frame source, source size, and file name prefix chosen for one recording start.
+    /// </summary>
+    internal readonly struct RecordVideoSourceResolution
+    {
+        internal IGameViewFrameSource FrameSource { get; }
+
+        internal int SourceWidth { get; }
+
+        internal int SourceHeight { get; }
+
+        internal string FileNamePrefix { get; }
+
+        internal string FailureMessage { get; }
+
+        private RecordVideoSourceResolution(
+            IGameViewFrameSource frameSource,
+            int sourceWidth,
+            int sourceHeight,
+            string fileNamePrefix,
+            string failureMessage)
+        {
+            FrameSource = frameSource;
+            SourceWidth = sourceWidth;
+            SourceHeight = sourceHeight;
+            FileNamePrefix = fileNamePrefix;
+            FailureMessage = failureMessage;
+        }
+
+        internal static RecordVideoSourceResolution Success(
+            IGameViewFrameSource frameSource,
+            int sourceWidth,
+            int sourceHeight,
+            string fileNamePrefix)
+        {
+            return new RecordVideoSourceResolution(frameSource, sourceWidth, sourceHeight, fileNamePrefix, null);
+        }
+
+        internal static RecordVideoSourceResolution Failure(string failureMessage)
+        {
+            return new RecordVideoSourceResolution(null, 0, 0, null, failureMessage);
         }
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/RecordVideo/RecordVideoUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/RecordVideo/RecordVideoUseCase.cs
@@ -79,8 +79,15 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             RecordVideoSourceResolution source = isWindowRecording
-                ? await ResolveWindowSourceAsync(parameters, ct)
+                ? await ResolveWindowSourceAsync(parameters, ct).ConfigureAwait(false)
                 : ResolvePlayModeViewSource(parameters);
+            if (isWindowRecording)
+            {
+                // ConfigureAwait(false) above leaves the continuation off Unity's context, and
+                // everything below touches Editor state.
+                await MainThreadSwitcher.SwitchToMainThread(ct);
+            }
+
             if (source.FailureMessage != null)
             {
                 return CreateFailure(RecordVideoAction.start, source.FailureMessage);
@@ -151,7 +158,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             bool laidOut = await EditorFrameWaiter.WaitFramesOrTimeoutAsync(
                 WindowLayoutWaitFrames,
                 UnityCliLoopConstants.EDITOR_FRAME_WAIT_TIMEOUT_MS,
-                ct);
+                ct).ConfigureAwait(false);
             await MainThreadSwitcher.SwitchToMainThread(ct);
             if (!laidOut)
             {

--- a/Packages/src/Editor/FirstPartyTools/RecordVideo/RecordVideoUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/RecordVideo/RecordVideoUseCase.cs
@@ -14,6 +14,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     /// </summary>
     public sealed class RecordVideoUseCase
     {
+        private const int WindowLayoutWaitFrames = 2;
+
         public Task<RecordVideoResponse> ExecuteAsync(RecordVideoSchema parameters, CancellationToken ct)
         {
             ct.ThrowIfCancellationRequested();
@@ -35,10 +37,13 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 return Task.FromResult(ExecuteStatus());
             }
 
-            return Task.FromResult(ExecuteStart(parameters, isLinux));
+            return ExecuteStartAsync(parameters, isLinux, ct);
         }
 
-        private static RecordVideoResponse ExecuteStart(RecordVideoSchema parameters, bool isLinux)
+        private static async Task<RecordVideoResponse> ExecuteStartAsync(
+            RecordVideoSchema parameters,
+            bool isLinux,
+            CancellationToken ct)
         {
             bool isWindowRecording = !string.IsNullOrEmpty(parameters.WindowName);
             // A window recording paints through the Editor loop, so it does not need Play Mode.
@@ -74,11 +79,22 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             RecordVideoSourceResolution source = isWindowRecording
-                ? ResolveWindowSource(parameters)
+                ? await ResolveWindowSourceAsync(parameters, ct)
                 : ResolvePlayModeViewSource(parameters);
             if (source.FailureMessage != null)
             {
                 return CreateFailure(RecordVideoAction.start, source.FailureMessage);
+            }
+
+            // Re-checked because the window path awaits editor frames, during which another
+            // command can start its own recording.
+            if (RecordVideoService.IsRecording)
+            {
+                return CreateResponse(
+                    false,
+                    RecordVideoConstants.AlreadyRecordingMessage,
+                    RecordVideoAction.start,
+                    RecordVideoService.GetSnapshot());
             }
 
             (int width, int height) size = VideoFrameSizePolicy.Resolve(
@@ -116,28 +132,49 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 snapshot);
         }
 
-        private static RecordVideoSourceResolution ResolveWindowSource(RecordVideoSchema parameters)
+        private static async Task<RecordVideoSourceResolution> ResolveWindowSourceAsync(
+            RecordVideoSchema parameters,
+            CancellationToken ct)
         {
             EditorWindow[] windows = EditorWindowFinder.FindWindowsByName(
                 parameters.WindowName,
                 parameters.MatchMode);
             if (windows.Length == 0)
             {
-                string openWindows = string.Join(", ", EditorWindowFinder.GetOpenWindowNames());
-                return RecordVideoSourceResolution.Failure(
-                    $"Window '{parameters.WindowName}' not found (MatchMode: {parameters.MatchMode}). Open windows: {openWindows}");
+                return RecordVideoSourceResolution.Failure(WindowNotFoundMessage(parameters));
             }
 
             EditorWindow window = windows[0];
-            // Shown before measuring: a background tab is never painted, and bringing it to the
-            // front can change its layout.
             window.ShowTab();
+            // A background tab keeps its old position until the layout settles, and measuring it
+            // then fixes the encoder to a size no later frame matches, which skips every frame.
+            bool laidOut = await EditorFrameWaiter.WaitFramesOrTimeoutAsync(
+                WindowLayoutWaitFrames,
+                UnityCliLoopConstants.EDITOR_FRAME_WAIT_TIMEOUT_MS,
+                ct);
+            await MainThreadSwitcher.SwitchToMainThread(ct);
+            if (!laidOut)
+            {
+                return RecordVideoSourceResolution.Failure(RecordVideoConstants.WindowLayoutTimedOutMessage);
+            }
+
+            if (window == null)
+            {
+                return RecordVideoSourceResolution.Failure(WindowNotFoundMessage(parameters));
+            }
+
             float pixelsPerPoint = EditorGUIUtility.pixelsPerPoint;
             return RecordVideoSourceResolution.Success(
                 new EditorWindowFrameSource(window, parameters.ResolutionScale),
                 Mathf.RoundToInt(window.position.width * pixelsPerPoint),
                 Mathf.RoundToInt(window.position.height * pixelsPerPoint),
                 RecordVideoConstants.DefaultWindowFileNamePrefix);
+        }
+
+        private static string WindowNotFoundMessage(RecordVideoSchema parameters)
+        {
+            string openWindows = string.Join(", ", EditorWindowFinder.GetOpenWindowNames());
+            return $"Window '{parameters.WindowName}' not found (MatchMode: {parameters.MatchMode}). Open windows: {openWindows}";
         }
 
         private static RecordVideoSourceResolution ResolvePlayModeViewSource(RecordVideoSchema parameters)

--- a/Packages/src/Editor/FirstPartyTools/RecordVideo/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/RecordVideo/Skill/SKILL.md
@@ -1,16 +1,16 @@
 ---
 name: uloop-record-video
 toolName: record-video
-description: "Record the Unity Game View to a video file (H.264 .mp4, or VP8 .webm) while Play Mode runs. Use when a still screenshot is not enough: motion, animation, transitions, physics, or a gameplay sequence to review later. `start` returns at once and other uloop commands keep working while it records."
+description: "Record the Unity Game View or any Editor window (Scene, Inspector, Console, ...) to a video file (H.264 .mp4, or VP8 .webm). Use when a still screenshot is not enough: motion, animation, transitions, physics, a gameplay sequence, or an Editor window changing over time. `start` returns at once and other uloop commands keep working while it records."
 ---
 
 # Task
 
-Record the Unity Game View to a video file while Play Mode is running, then hand the file path to the user or inspect frames from it.
+Record the Unity Game View while Play Mode is running, or any Editor window with `--window-name`, then hand the file path to the user or inspect frames from it.
 
 ## Workflow
 
-1. Ensure Play Mode is running (`uloop control-play-mode --action Play`) and the Game View is open. `start` fails in Edit Mode.
+1. For a Game View recording, ensure Play Mode is running (`uloop control-play-mode --action Play`) and the Game View is open; `start` fails in Edit Mode. With `--window-name` the recording targets that Editor window instead and needs no Play Mode.
 2. `uloop record-video --action start [options]`. It returns immediately; encoding continues inside the Editor.
 3. Drive the scene with other uloop commands (`simulate-keyboard`, `simulate-mouse-input`, `replay-input`, ...). Do **not** run `uloop compile` or exit Play Mode mid-recording: both auto-stop and finalize the file.
 4. `uloop record-video --action stop`. The file is playable only after this call (or after an auto-stop).
@@ -20,7 +20,7 @@ Record the Unity Game View to a video file while Play Mode is running, then hand
 ## Tool Reference
 
 ```bash
-uloop record-video --action start [--frame-rate <fps>] [--max-duration-seconds <sec>] [--resolution-scale <0.1-1.0>] [--quality <low|medium|high>] [--output-path <file>]
+uloop record-video --action start [--frame-rate <fps>] [--max-duration-seconds <sec>] [--resolution-scale <0.1-1.0>] [--quality <low|medium|high>] [--window-name <name>] [--match-mode <exact|prefix|contains>] [--output-path <file>]
 uloop record-video --action status
 uloop record-video --action stop
 ```
@@ -34,6 +34,8 @@ uloop record-video --action stop
 | `--max-duration-seconds` | integer | `60` | Auto-stop safety limit in seconds. Valid range 1–600. Used by `start` only. |
 | `--resolution-scale` | number | `1.0` | Resolution scale (0.1 to 1.0) applied to the Game View size before encoding. `0.5` cuts file size and encoding cost to about a quarter. Used by `start` only. |
 | `--quality` | enum | `medium` | Encoder bitrate preset: `low`, `medium`, or `high`. Used by `start` only. |
+| `--window-name` | string | empty | Editor window title to record instead of the Game View (for example Scene, Inspector, Console). Empty records the Game View and requires Play Mode. A window recording does not require Play Mode, brings the tab to the front, repaints it every frame, and keeps running across Play Mode changes. Used by `start` only. |
+| `--match-mode` | enum | `exact` | Window title matching for `--window-name`: `exact`, `prefix`, or `contains` (case-insensitive). Used by `start` only. |
 | `--output-path` | string | empty | Output file path. Empty uses `.uloop/outputs/Videos/gameview_<yyyyMMdd_HHmmss_fff>.mp4` (`.webm` on Linux). Extension must be `.mp4` (H.264) or `.webm` (VP8). Linux rejects `.mp4`. Used by `start` only. |
 
 ### Actions
@@ -52,14 +54,14 @@ Returns JSON containing:
 - `Message`: Human-readable status.
 - `Action`: Echoes the executed action.
 - `IsRecording`: Whether a recording is active after this call.
-- `OutputPath`: Absolute path of the video file. Open this path; do not search the directory.
+- `OutputPath`: Absolute path of the video file. Open this path; do not search the directory. A window recording uses the `window_` name prefix instead of `gameview_`.
 - `Width` / `Height`: Encoded resolution after `--resolution-scale` and even rounding (0 when none).
 - `FrameRate`: Output fps (0 when none).
 - `Quality`: Bitrate preset in use.
 - `EncodedFrameCount`: Frames written to the encoder.
 - `SkippedFrameCount`: Frame slots that could not be captured (Game View closed or resized, or encoder refused a frame). The video keeps its timeline; skipped slots are simply missing.
 - `ElapsedSeconds`: Seconds since start (frozen after stop).
-- `StoppedBy`: Why the recording ended — `"cli"`, `"max-duration"`, `"play-mode-exit"`, `"assembly-reload"`, or `"editor-quit"`. Omitted while recording.
+- `StoppedBy`: Why the recording ended — `"cli"`, `"max-duration"`, `"play-mode-exit"`, `"window-closed"`, `"assembly-reload"`, or `"editor-quit"`. Omitted while recording.
 
 ## Interpreting results
 
@@ -67,6 +69,7 @@ Returns JSON containing:
 - `Success: false` with "Play Mode view RenderTexture is not available" → open the Game View tab (`uloop focus-window`) and make sure a camera renders.
 - `SkippedFrameCount` growing while `EncodedFrameCount` stays flat → the Game View is closed, hidden, or resized. Restore it; recording resumes without restarting.
 - `EncodedFrameCount` far below `ElapsedSeconds × FrameRate` with few skips → the Editor is unfocused and throttling draws; run `uloop focus-window` before the next recording.
+- `Success: false` with "Window '...' not found" → pick the right title from the `Open windows:` list in the message, or use `--match-mode prefix`.
 - `StoppedBy` is not `"cli"` → the recording ended on its own; the file is still valid up to that point.
 
 ## Notes

--- a/Packages/src/Editor/FirstPartyTools/RecordVideo/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/RecordVideo/Skill/SKILL.md
@@ -34,7 +34,7 @@ uloop record-video --action stop
 | `--max-duration-seconds` | integer | `60` | Auto-stop safety limit in seconds. Valid range 1–600. Used by `start` only. |
 | `--resolution-scale` | number | `1.0` | Resolution scale (0.1 to 1.0) applied to the Game View size before encoding. `0.5` cuts file size and encoding cost to about a quarter. Used by `start` only. |
 | `--quality` | enum | `medium` | Encoder bitrate preset: `low`, `medium`, or `high`. Used by `start` only. |
-| `--window-name` | string | empty | Editor window title to record instead of the Game View (for example Scene, Inspector, Console). Empty records the Game View and requires Play Mode. A window recording does not require Play Mode, brings the tab to the front, repaints it every frame, and keeps running across Play Mode changes. Used by `start` only. |
+| `--window-name` | string | empty | Editor window title to record instead of the Game View (for example Scene, Inspector, Console). Empty records the Game View and requires Play Mode. A window recording does not require Play Mode, brings the tab to the front, repaints it every frame, and keeps running when Play Mode stops. Used by `start` only. |
 | `--match-mode` | enum | `exact` | Window title matching for `--window-name`: `exact`, `prefix`, or `contains` (case-insensitive). Used by `start` only. |
 | `--output-path` | string | empty | Output file path. Empty uses `.uloop/outputs/Videos/gameview_<yyyyMMdd_HHmmss_fff>.mp4` (`.webm` on Linux). Extension must be `.mp4` (H.264) or `.webm` (VP8). Linux rejects `.mp4`. Used by `start` only. |
 
@@ -76,5 +76,6 @@ Returns JSON containing:
 
 - Odd Game View sizes are rounded down to even for H.264 (for example 1286×723 → 1286×722; the last pixel row/column is dropped).
 - The recording is wall-clock paced, so Play Mode pause records a still image, not a gap.
+- A window recording survives Play Mode stopping, but entering Play Mode with domain reload enabled (Unity's default) ends it with `StoppedBy: "assembly-reload"`.
 - Default output is H.264 `.mp4` on macOS/Windows and VP8 `.webm` on Linux. An explicit `.webm` path uses VP8 on every host.
 - Default recordings under `.uloop/outputs/Videos/` keep only the newest 20 files per extension; a custom `--output-path` is never pruned.

--- a/Packages/src/Editor/FirstPartyTools/RecordVideo/UnityCLILoop.FirstPartyTools.RecordVideo.Editor.asmdef
+++ b/Packages/src/Editor/FirstPartyTools/RecordVideo/UnityCLILoop.FirstPartyTools.RecordVideo.Editor.asmdef
@@ -5,7 +5,8 @@
         "GUID:fc3fd32eddbee40e39c2d76dc184957b",
         "GUID:5079a8d3a72924a81aa1cbc25f65ed1b",
         "GUID:33fef506e6744f2982e8c13b1196f696",
-        "GUID:77087b1bb30a415e87a80cbf24e7430a"
+        "GUID:77087b1bb30a415e87a80cbf24e7430a",
+        "GUID:f0b6c2c251d6442f0ad1dd53c07e5092"
     ],
     "includePlatforms": [
         "Editor"

--- a/Packages/src/Editor/FirstPartyTools/RecordVideo/VideoRecordingSession.cs
+++ b/Packages/src/Editor/FirstPartyTools/RecordVideo/VideoRecordingSession.cs
@@ -1,6 +1,8 @@
 using System;
 using UnityEngine;
 
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
 namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 {
     /// <summary>
@@ -44,12 +46,26 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             _quality = quality;
             _startedAt = clock();
             _frameTexture = new Texture2D(encoder.Width, encoder.Height, TextureFormat.RGBA32, false);
+            // A texture created during Play Mode is destroyed when Play Mode ends, and a window
+            // recording outlives Play Mode, so the frame texture must not be owned by the scene.
+            _frameTexture.hideFlags = HideFlags.HideAndDontSave;
         }
 
         internal void Tick()
         {
             if (_stopped)
             {
+                return;
+            }
+
+            // Unity's null comparison reports a destroyed texture. Reading through it would throw
+            // on every editor update and break the update delegate chain for every other subscriber.
+            if (_frameTexture == null)
+            {
+                VibeLogger.LogError(
+                    "record_video_frame_texture_lost",
+                    "The recording frame texture was destroyed, so the recording was stopped.");
+                Stop(RecordVideoConstants.StoppedByFrameTextureLost);
                 return;
             }
 
@@ -110,6 +126,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             UnityEngine.Object.DestroyImmediate(_frameTexture);
             _frameTexture = null;
         }
+
+        internal Texture2D FrameTextureForTests => _frameTexture;
 
         internal VideoRecordingSnapshot Snapshot()
         {

--- a/Packages/src/Editor/FirstPartyTools/RecordVideo/VideoRecordingSession.cs
+++ b/Packages/src/Editor/FirstPartyTools/RecordVideo/VideoRecordingSession.cs
@@ -60,6 +60,14 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 return;
             }
 
+            // Checked after max-duration so a run that hits both still reports max-duration,
+            // and before FramesDue so a closed window's frames are not counted as skips.
+            if (_frameSource.IsSourceClosed)
+            {
+                Stop(RecordVideoConstants.StoppedByWindowClosed);
+                return;
+            }
+
             int due = VideoRecordingFramePacer.FramesDue(
                 elapsed,
                 _frameRate,

--- a/Packages/src/Editor/FirstPartyTools/Screenshot/EditorWindowCaptureUtility.cs
+++ b/Packages/src/Editor/FirstPartyTools/Screenshot/EditorWindowCaptureUtility.cs
@@ -28,36 +28,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         /// <returns>Array of matching EditorWindows (empty if none found)</returns>
         public static EditorWindow[] FindWindowsByName(string windowName, WindowMatchMode matchMode = WindowMatchMode.exact)
         {
-            if (string.IsNullOrEmpty(windowName))
-            {
-                return Array.Empty<EditorWindow>();
-            }
-
-            List<EditorWindow> matchingWindows = new();
-            EditorWindow[] allWindows = Resources.FindObjectsOfTypeAll<EditorWindow>();
-            foreach (EditorWindow window in allWindows)
-            {
-                if (window.titleContent == null)
-                {
-                    continue;
-                }
-
-                string title = window.titleContent.text;
-                bool isMatch = matchMode switch
-                {
-                    WindowMatchMode.exact => title.Equals(windowName, StringComparison.OrdinalIgnoreCase),
-                    WindowMatchMode.prefix => title.StartsWith(windowName, StringComparison.OrdinalIgnoreCase),
-                    WindowMatchMode.contains => title.Contains(windowName, StringComparison.OrdinalIgnoreCase),
-                    _ => title.Equals(windowName, StringComparison.OrdinalIgnoreCase)
-                };
-
-                if (isMatch)
-                {
-                    matchingWindows.Add(window);
-                }
-            }
-
-            return matchingWindows.ToArray();
+            return EditorWindowFinder.FindWindowsByName(windowName, matchMode);
         }
 
         /// <summary>
@@ -195,18 +166,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         /// <returns>Array of window names</returns>
         public static string[] GetOpenWindowNames()
         {
-            EditorWindow[] allWindows = Resources.FindObjectsOfTypeAll<EditorWindow>();
-            List<string> names = new();
-
-            foreach (EditorWindow window in allWindows)
-            {
-                if (window.titleContent != null && !string.IsNullOrEmpty(window.titleContent.text))
-                {
-                    names.Add(window.titleContent.text);
-                }
-            }
-
-            return names.ToArray();
+            return EditorWindowFinder.GetOpenWindowNames();
         }
 
         // Captures game rendering by reading the Play Mode view RenderTexture (PlayMode only).

--- a/Packages/src/Editor/FirstPartyTools/Screenshot/UnityCLILoop.FirstPartyTools.Screenshot.Editor.asmdef
+++ b/Packages/src/Editor/FirstPartyTools/Screenshot/UnityCLILoop.FirstPartyTools.Screenshot.Editor.asmdef
@@ -8,7 +8,8 @@
         "GUID:fc3fd32eddbee40e39c2d76dc184957b",
         "GUID:96b8d4624fb74ea2849fed17e7ad69d3",
         "GUID:77087b1bb30a415e87a80cbf24e7430a",
-        "GUID:aa7cf56cc5f074e57ba35272b877e116"
+        "GUID:aa7cf56cc5f074e57ba35272b877e116",
+        "GUID:f0b6c2c251d6442f0ad1dd53c07e5092"
     ],
     "includePlatforms": [
         "Editor"

--- a/cli/common/tools/default-tools.json
+++ b/cli/common/tools/default-tools.json
@@ -790,7 +790,7 @@
           },
           "WindowName": {
             "type": "string",
-            "description": "Editor window title to record instead of the Game View (for example Scene, Inspector, Console). Empty records the Game View and requires Play Mode. A window recording does not require Play Mode, brings the tab to the front, repaints it every frame, and keeps running across Play Mode changes. Used by start only.",
+            "description": "Editor window title to record instead of the Game View (for example Scene, Inspector, Console). Empty records the Game View and requires Play Mode. A window recording does not require Play Mode, brings the tab to the front, repaints it every frame, and keeps running when Play Mode stops. Used by start only.",
             "default": ""
           },
           "MatchMode": {

--- a/cli/common/tools/default-tools.json
+++ b/cli/common/tools/default-tools.json
@@ -764,7 +764,7 @@
     },
     {
       "name": "record-video",
-      "description": "Record the Unity Game View to a video file (H.264 .mp4, or VP8 .webm) while Play Mode runs. Use when a still screenshot is not enough: motion, animation, transitions, physics, or a gameplay sequence to review later. `start` returns at once and other uloop commands keep working while it records.",
+      "description": "Record the Unity Game View or any Editor window (Scene, Inspector, Console, ...) to a video file (H.264 .mp4, or VP8 .webm). Use when a still screenshot is not enough: motion, animation, transitions, physics, a gameplay sequence, or an Editor window changing over time. `start` returns at once and other uloop commands keep working while it records.",
       "inputSchema": {
         "type": "object",
         "properties": {
@@ -787,6 +787,21 @@
             "type": "integer",
             "description": "Auto-stop safety limit in seconds. Valid range 1–600. Used by start only.",
             "default": 60
+          },
+          "WindowName": {
+            "type": "string",
+            "description": "Editor window title to record instead of the Game View (for example Scene, Inspector, Console). Empty records the Game View and requires Play Mode. A window recording does not require Play Mode, brings the tab to the front, repaints it every frame, and keeps running across Play Mode changes. Used by start only.",
+            "default": ""
+          },
+          "MatchMode": {
+            "type": "string",
+            "description": "Window title matching for --window-name: exact, prefix, or contains (case-insensitive). Used by start only.",
+            "enum": [
+              "exact",
+              "prefix",
+              "contains"
+            ],
+            "default": "exact"
           },
           "OutputPath": {
             "type": "string",

--- a/cli/dispatcher/shared-inputs-stamp.json
+++ b/cli/dispatcher/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "686f299aad670051a9fb3d5cc6e3c3dbe3d12ce6"
+  "sharedInputsHash": "fea8d201acf3155b097e2b30a028befd0005845c"
 }

--- a/cli/project-runner/shared-inputs-stamp.json
+++ b/cli/project-runner/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "d95cae479447294b46f16e05ddff2b3b344c4f1e"
+  "sharedInputsHash": "2c60e13dcf79299532760ac03d02d9e408ac6e5f"
 }


### PR DESCRIPTION
## Summary

- `uloop record-video --action start --window-name Scene` now records any Editor window — Scene, Inspector, Console, and so on — to a video file, so motion that never appears in the Game View can be captured.
- A window recording does not need Play Mode and keeps running when Play Mode stops, so an Editor-side change can be recorded end to end. Entering Play Mode with Unity's default domain reload still ends it with `StoppedBy: "assembly-reload"`, as any recording does.

## User Impact

Before, `record-video` could only record the Game View, and only while Play Mode was running. Camera moves in the Scene view or values changing in the Inspector could be captured as stills with `screenshot --window-name`, but never as a video.

Now `--window-name <title>` selects the window to record (with `--match-mode exact|prefix|contains` for the title), and the default output is named `window_<timestamp>.mp4` instead of `gameview_<timestamp>.mp4`. Closing the recorded window stops the recording and reports `StoppedBy: "window-closed"`. When no window matches, the failure message lists the open window titles so the right one can be picked. Omitting `--window-name` behaves exactly as before: Game View, Play Mode required, stopped by `play-mode-exit`.

Two problems found while verifying this against a real Editor are fixed here as well.

`ShowTab` brings a background tab to the front, but the window keeps its old `position` until the layout settles. Measuring it immediately fixed the encoder to a size that no later frame matched, so recording the Scene view as a background tab produced 0 encoded frames and 177 skipped ones. The start path now waits two editor frames after `ShowTab` — the same wait the window screenshot path already uses — before measuring, and returns to the main thread before touching any window state.

The second is a latent bug in the existing recording session. Unity destroys objects created during Play Mode when Play Mode ends, so a recording started in Play Mode lost its frame texture on exit; every later tick threw `MissingReferenceException` from `ReadPixels`, which aborted the whole `EditorApplication.update` delegate chain. The recording silently stopped producing frames (97 encoded frames over a 60 second recording) and every other update subscriber stopped running too. Game View recordings always stop at Play Mode exit, so only a window recording — which deliberately outlives Play Mode — reaches it. The frame texture is now marked `HideAndDontSave`, and a destroyed texture stops the session instead of throwing.

## Changes

- New shared assembly `UnityCLILoop.FirstPartyTools.Common.EditorWindowFinder.Editor` holds the title-based window lookup; `EditorWindowCaptureUtility` delegates to it with unchanged public signatures, since the asmdef policy forbids one tool from referencing another.
- `record-video` gains `WindowName` and `MatchMode`, a `window_` output prefix, and a `window-closed` stop reason. `RecordVideoService.Start` now takes its frame source from the caller and only stops on Play Mode exit for the recording that asked for it.
- `EditorWindowFrameSource` grabs the window's last painted pixels and then queues the next repaint, because the grab never redraws by itself. A scaled recording downscales through a second render target first, since `ReadPixels` cannot read past the active one. The captured image needed no vertical flip — unlike the Game View path — which was confirmed against a `screenshot --capture-mode window` PNG of the same window.
- Skill reference and the embedded tool catalog document both new parameters; the catalog gains two schema keys, so the release-input stamps are refreshed in the same commit.

## Verification

Unity EditMode tests (filtered, single-flight):

- `run-tests --filter-type regex --filter-value "RecordVideo|VideoRecording|EditorWindowFinder"` — 57/57 passed.
- `run-tests --filter-type regex --filter-value "Screenshot"` — 62/62 passed (delegation regression).
- `run-tests --filter-type class --filter-value EditorWindowFinderTests` — 9/9 passed, confirming the new match-mode tests actually execute.

Two guards were verified by fault injection: removing the null-title normalization makes the new finder test fail with `NullReferenceException`, and removing `HideAndDontSave` makes the new frame-texture test fail with `Expected: HideAndDontSave But was: None`.

Real Editor verification, all with the development binary from this checkout:

1. Edit Mode, `--window-name Inspector --max-duration-seconds 5` → `Success: true`, 832x2828, then `EncodedFrameCount: 149`, `SkippedFrameCount: 0`, `StoppedBy: "max-duration"`, output under `<PROJECT_ROOT>/.uloop/outputs/Videos/window_<timestamp>.mp4`.
2. Orientation: a frame extracted with `ffmpeg -vf fps=1` matches the `screenshot --window-name Scene --capture-mode window` PNG — toolbar at the top, orientation gizmo at the top right. **No flip blit was added.**
3. Motion: `--window-name Scene` while moving the Scene camera → 179 encoded frames, 0 skipped, and the extracted frames visibly differ from each other.
4. Window closed mid-recording: `--window-name Console`, then closing that window → `StoppedBy: "window-closed"` after 317 frames.
5. Play Mode independence: start in Play Mode, then stop Play Mode → still recording, and `EncodedFrameCount` grew from 182 to 494 over the following 10.4 seconds (+312). No `MissingReferenceException` in the Console.
6. Game View regression: Play Mode, no `--window-name`, then stop Play Mode → `StoppedBy: "play-mode-exit"`, `gameview_` output prefix, 95 frames.
7. Not found: `--window-name NoSuchWindow` → `Success: false` and a message listing the open window titles.
8. Match modes: `--window-name insp --match-mode prefix` → `Success: true` (matched Inspector, 57 frames); the same name with `--match-mode exact` → `Success: false`.

Static checks, all exit 0: `check-asmdef-policy`, `sync-tool-docs --check`, `check-skill-size`, `scripts/check-go-cli.sh`.

https://claude.ai/code/session_01B9vM5nywnrMtCAiuVcqYjW
