### PR TITLE
fix: CLI update button now shows the version it will actually install

### DIFF
--- a/Assets/Tests/Editor/CliSetupApplicationServiceTests.cs
+++ b/Assets/Tests/Editor/CliSetupApplicationServiceTests.cs
@@ -49,6 +49,32 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
 
         [Test]
+        public void GetCliInstallTargetVersion_UsesDispatcherReleaseTagVersion()
+        {
+            // Verifies the install target version shown in the update button comes from the pinned release tag.
+            CliSetupApplicationService service = new(
+                new FakeCliInstallationDetector(new string[] { null }),
+                new FakeNativeCliInstaller(),
+                new StubBootstrapPinReader("dispatcher-v3.4.0", "3.0.0-beta.31"));
+
+            Assert.That(service.GetCliInstallTargetVersion(), Is.EqualTo("3.4.0"));
+        }
+
+        [Test]
+        public void GetCliInstallTargetVersion_WhenBootstrapPinIsUnavailableFallsBackToMinimumVersion()
+        {
+            // Verifies an unreadable bootstrap pin still renders a label by falling back to the minimum version.
+            CliSetupApplicationService service = new(
+                new FakeCliInstallationDetector(new string[] { null }),
+                new FakeNativeCliInstaller(),
+                new FailingBootstrapPinReader());
+
+            Assert.That(
+                service.GetCliInstallTargetVersion(),
+                Is.EqualTo(service.GetMinimumRequiredCliVersion()));
+        }
+
+        [Test]
         public void GetGlobalCliInstallCommand_UsesPinnedDispatcherReleaseTag()
         {
             // Verifies fallback manual commands use the immutable dispatcher tag from the bootstrap pin.
@@ -151,6 +177,33 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             public string LoadMinimumDispatcherVersionOrThrow()
             {
                 return "3.0.1";
+            }
+        }
+
+        private sealed class StubBootstrapPinReader : ICliPinReader
+        {
+            private readonly string _dispatcherReleaseTag;
+            private readonly string _minimumDispatcherVersion;
+
+            public StubBootstrapPinReader(string dispatcherReleaseTag, string minimumDispatcherVersion)
+            {
+                _dispatcherReleaseTag = dispatcherReleaseTag;
+                _minimumDispatcherVersion = minimumDispatcherVersion;
+            }
+
+            public CliPinLoadResult LoadPackagePin()
+            {
+                return CliPinLoadResult.FromFailure("not used by these tests");
+            }
+
+            public DispatcherBootstrapPinLoadResult LoadDispatcherBootstrapPin()
+            {
+                return DispatcherBootstrapPinLoadResult.FromSuccess(_dispatcherReleaseTag, "manifest");
+            }
+
+            public string LoadMinimumDispatcherVersionOrThrow()
+            {
+                return _minimumDispatcherVersion;
             }
         }
 

--- a/Assets/Tests/Editor/CliSetupSectionTests.cs
+++ b/Assets/Tests/Editor/CliSetupSectionTests.cs
@@ -23,6 +23,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         [TestCase(true, false, false, true, true, false, ManagedCliKind.None, "2.9.0", "3.0.0", "Update CLI (v2.9.0 \u2192 v3.0.0)")]
         [TestCase(true, false, false, true, true, true, ManagedCliKind.None, "2.9.0", "3.0.0", "Update CLI (v2.9.0 \u2192 v3.0.0)")]
         [TestCase(true, false, false, true, true, false, ManagedCliKind.None, "3.0.0", "3.0.0", "Update CLI (v3.0.0 required)")]
+        [TestCase(true, false, false, true, true, false, ManagedCliKind.None, "2.1.6", "3.4.0", "Update CLI (v2.1.6 \u2192 v3.4.0)")]
         [TestCase(true, true, false, false, true, false, ManagedCliKind.None, "3.0.0", "3.0.0", "Uninstalling...")]
         [TestCase(true, true, false, false, true, true, ManagedCliKind.None, "3.0.0", "3.0.0", "Fixing PATH...")]
         [TestCase(false, true, false, false, false, false, ManagedCliKind.None, null, "3.0.0", "Installing...")]
@@ -43,7 +44,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             bool needsCliPathSetup,
             ManagedCliKind managedCliKind,
             string cliVersion,
-            string requiredCliVersion,
+            string installTargetCliVersion,
             string expectedText)
         {
             string text = CliSetupSection.GetInstallCliButtonText(
@@ -55,7 +56,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 needsCliPathSetup,
                 managedCliKind,
                 cliVersion,
-                requiredCliVersion);
+                installTargetCliVersion);
 
             Assert.That(text, Is.EqualTo(expectedText));
         }
@@ -602,6 +603,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 isCliInstalled,
                 cliVersion,
                 requiredCliVersion: "3.0.0",
+                installTargetCliVersion: "3.0.0",
                 needsUpdate,
                 canUninstallCli: true,
                 needsCliPathSetup,

--- a/Assets/Tests/Editor/CliSetupSectionTests.cs
+++ b/Assets/Tests/Editor/CliSetupSectionTests.cs
@@ -103,6 +103,27 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
 
         [Test]
+        public void Update_WhenUpdateIsNeeded_ShowsInstallTargetVersionInsteadOfMinimumVersion()
+        {
+            // Verifies the Settings update button is wired to the install target version, not the minimum required one.
+            VisualElement root = CreateRootElement();
+            CliSetupSection section = new(root);
+            CliSetupData data = CreateData(
+                isCliInstalled: true,
+                isChecking: false,
+                selectedTargetInstallState: SkillInstallState.Installed,
+                needsUpdate: true,
+                cliVersion: "2.1.6",
+                requiredCliVersion: "3.0.0-beta.31",
+                installTargetCliVersion: "3.4.0");
+
+            section.Update(data);
+
+            Button installCliButton = root.Q<Button>("install-cli-button");
+            Assert.That(installCliButton.text, Is.EqualTo("Update CLI (v2.1.6 \u2192 v3.4.0)"));
+        }
+
+        [Test]
         public void Update_WhenCliIsHomebrewManaged_DisablesPrimaryButton()
         {
             // Verifies the Settings primary button cannot trigger an install for a Homebrew-managed CLI.
@@ -597,13 +618,15 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             ManagedCliKind managedCliKind = ManagedCliKind.None,
             bool needsUpdate = false,
             string cliVersion = "3.0.0",
-            bool needsCliPathSetup = false)
+            bool needsCliPathSetup = false,
+            string requiredCliVersion = "3.0.0",
+            string installTargetCliVersion = "3.0.0")
         {
             return new CliSetupData(
                 isCliInstalled,
                 cliVersion,
-                requiredCliVersion: "3.0.0",
-                installTargetCliVersion: "3.0.0",
+                requiredCliVersion,
+                installTargetCliVersion,
                 needsUpdate,
                 canUninstallCli: true,
                 needsCliPathSetup,

--- a/Assets/Tests/Editor/DispatcherReleaseTagVersionTests.cs
+++ b/Assets/Tests/Editor/DispatcherReleaseTagVersionTests.cs
@@ -1,0 +1,38 @@
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.Domain;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor
+{
+    /// <summary>
+    /// Test fixture that verifies dispatcher release tag to version extraction.
+    /// </summary>
+    public class DispatcherReleaseTagVersionTests
+    {
+        [TestCase("dispatcher-v3.4.0", "3.4.0")]
+        [TestCase("dispatcher-v3.0.0-beta.31", "3.0.0-beta.31")]
+        public void TryParse_WhenTagHasVersionSuffix_ReturnsVersionWithoutPrefix(
+            string dispatcherReleaseTag,
+            string expectedVersion)
+        {
+            // Verifies that a well-formed dispatcher release tag yields the bare semver string.
+            bool parsed = DispatcherReleaseTagVersion.TryParse(dispatcherReleaseTag, out string version);
+
+            Assert.That(parsed, Is.True);
+            Assert.That(version, Is.EqualTo(expectedVersion));
+        }
+
+        [TestCase(null)]
+        [TestCase("")]
+        [TestCase("v3.4.0")]
+        [TestCase("dispatcher-v")]
+        public void TryParse_WhenTagIsEmptyOrMalformed_ReturnsFalse(string dispatcherReleaseTag)
+        {
+            // Verifies that empty, prefix-less, and version-less tags are rejected without producing a version.
+            bool parsed = DispatcherReleaseTagVersion.TryParse(dispatcherReleaseTag, out string version);
+
+            Assert.That(parsed, Is.False);
+            Assert.That(version, Is.Null);
+        }
+    }
+}

--- a/Assets/Tests/Editor/DispatcherReleaseTagVersionTests.cs.meta
+++ b/Assets/Tests/Editor/DispatcherReleaseTagVersionTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 821bc045412d444c5896e8110c636ae0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/SetupWizardWindowTests.cs
+++ b/Assets/Tests/Editor/SetupWizardWindowTests.cs
@@ -612,6 +612,34 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(homebrewUpgradeMessage.text, Is.EqualTo(expectedText));
         }
 
+        [Test]
+        public void Update_WhenUpdateIsNeeded_ShowsInstallTargetVersionInsteadOfMinimumVersion()
+        {
+            // Verifies the wizard update button is wired to the install target version, not the minimum required one.
+            VisualElement statusIcon = new();
+            Label statusLabel = new();
+            Label homebrewUpgradeMessage = new() { name = "cli-homebrew-upgrade-message" };
+            Button installButton = new();
+            SetupWizardCliStepPresenter presenter = new(
+                statusIcon,
+                statusLabel,
+                homebrewUpgradeMessage,
+                installButton,
+                () => { });
+
+            presenter.Update(
+                cliInstalled: true,
+                cliVersion: "2.1.6",
+                cliIsDispatcher: true,
+                requiredCliVersion: "3.0.0-beta.31",
+                installTargetCliVersion: "3.4.0",
+                isInstallingCli: false,
+                needsCliPathSetup: false,
+                managedCliKind: ManagedCliKind.None);
+
+            Assert.That(installButton.text, Is.EqualTo("Update CLI (v2.1.6 \u2192 v3.4.0)"));
+        }
+
         [TestCase(false, false, false, false, false, ManagedCliKind.None, true)]
         [TestCase(true, false, true, false, false, ManagedCliKind.None, true)]
         [TestCase(true, false, false, false, false, ManagedCliKind.None, true)]

--- a/Assets/Tests/Editor/SetupWizardWindowTests.cs
+++ b/Assets/Tests/Editor/SetupWizardWindowTests.cs
@@ -485,6 +485,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         [TestCase(true, false, false, true, false, ManagedCliKind.None, "2.9.0", "3.0.0", "Update CLI (v2.9.0 \u2192 v3.0.0)")]
         [TestCase(true, false, false, true, true, ManagedCliKind.None, "2.9.0", "3.0.0", "Update CLI (v2.9.0 \u2192 v3.0.0)")]
         [TestCase(true, false, false, true, false, ManagedCliKind.None, "3.0.0", "3.0.0", "Update CLI (v3.0.0 required)")]
+        [TestCase(true, false, false, true, false, ManagedCliKind.None, "2.1.6", "3.4.0", "Update CLI (v2.1.6 \u2192 v3.4.0)")]
         [TestCase(true, true, false, false, false, ManagedCliKind.None, "3.0.0", "3.0.0", "Installing...")]
         [TestCase(true, true, false, false, true, ManagedCliKind.None, "3.0.0", "3.0.0", "Fixing PATH...")]
         [TestCase(false, false, true, false, false, ManagedCliKind.None, null, "3.0.0", "Checking...")]
@@ -502,7 +503,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             bool needsCliPathSetup,
             ManagedCliKind managedCliKind,
             string cliVersion,
-            string requiredCliVersion,
+            string installTargetCliVersion,
             string expectedLabel)
         {
             string label = SetupWizardCliStepPresenter.GetCliButtonTextForSetupWizard(
@@ -513,7 +514,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 needsCliPathSetup,
                 managedCliKind,
                 cliVersion,
-                requiredCliVersion);
+                installTargetCliVersion);
 
             Assert.That(label, Is.EqualTo(expectedLabel));
         }
@@ -600,6 +601,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 cliVersion,
                 cliIsDispatcher,
                 requiredCliVersion: "3.0.0",
+                installTargetCliVersion: "3.0.0",
                 isInstallingCli: false,
                 needsCliPathSetup: false,
                 managedCliKind);

--- a/Assets/Tests/Editor/SkillsTargetSelectionResolverTests.cs
+++ b/Assets/Tests/Editor/SkillsTargetSelectionResolverTests.cs
@@ -58,6 +58,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 isCliInstalled: true,
                 cliVersion: "1.7.3",
                 requiredCliVersion: "1.7.3",
+                installTargetCliVersion: "1.7.3",
                 needsUpdate: false,
                 canUninstallCli: true,
                 needsCliPathSetup: false,

--- a/Packages/src/Editor/Application/CliSetupApplicationService.cs
+++ b/Packages/src/Editor/Application/CliSetupApplicationService.cs
@@ -163,6 +163,28 @@ namespace io.github.hatayama.UnityCliLoop.Application
             return _cliPinReader.LoadMinimumDispatcherVersionOrThrow();
         }
 
+        /// <summary>
+        /// Returns the CLI version an install would actually put in place.
+        /// </summary>
+        public string GetCliInstallTargetVersion()
+        {
+            // Why: the update button must name the version the pinned dispatcher release tag installs, not the
+            // minimum required version. When the bootstrap pin cannot be read the install itself surfaces the
+            // error, so the label falls back to the minimum version instead of blocking the whole view.
+            DispatcherBootstrapPinLoadResult bootstrapPin = _cliPinReader.LoadDispatcherBootstrapPin();
+            if (!bootstrapPin.Success)
+            {
+                return GetMinimumRequiredCliVersion();
+            }
+
+            if (!DispatcherReleaseTagVersion.TryParse(bootstrapPin.DispatcherReleaseTag, out string version))
+            {
+                return GetMinimumRequiredCliVersion();
+            }
+
+            return version;
+        }
+
         public bool IsPackageOwnedCurrentUserInstallPath(
             string cliExecutablePath,
             RuntimePlatform platform)

--- a/Packages/src/Editor/Application/CliSetupLabelFormatter.cs
+++ b/Packages/src/Editor/Application/CliSetupLabelFormatter.cs
@@ -72,14 +72,14 @@ namespace io.github.hatayama.UnityCliLoop.Application
                 + upgradeCommand;
         }
 
-        public static string GetCliReplacementButtonText(string action, string cliVersion, string requiredCliVersion)
+        public static string GetCliReplacementButtonText(string action, string cliVersion, string targetCliVersion)
         {
-            if (ShouldShowRequiredVersionText(cliVersion, requiredCliVersion))
+            if (ShouldShowRequiredVersionText(cliVersion, targetCliVersion))
             {
-                return $"{action} CLI (v{requiredCliVersion} required)";
+                return $"{action} CLI (v{targetCliVersion} required)";
             }
 
-            return $"{action} CLI (v{cliVersion} \u2192 v{requiredCliVersion})";
+            return $"{action} CLI (v{cliVersion} \u2192 v{targetCliVersion})";
         }
 
         public static bool ShouldShowRequiredVersionText(string cliVersion, string requiredCliVersion)

--- a/Packages/src/Editor/Domain/DispatcherReleaseTagVersion.cs
+++ b/Packages/src/Editor/Domain/DispatcherReleaseTagVersion.cs
@@ -1,0 +1,34 @@
+using System;
+
+namespace io.github.hatayama.UnityCliLoop.Domain
+{
+    /// <summary>
+    /// Extracts the semver string from a dispatcher release tag such as "dispatcher-v3.4.0".
+    /// </summary>
+    public static class DispatcherReleaseTagVersion
+    {
+        public static bool TryParse(string dispatcherReleaseTag, out string version)
+        {
+            version = null;
+            if (string.IsNullOrEmpty(dispatcherReleaseTag))
+            {
+                return false;
+            }
+
+            if (!dispatcherReleaseTag.StartsWith(CliConstants.DISPATCHER_RELEASE_TAG_PREFIX, StringComparison.Ordinal))
+            {
+                return false;
+            }
+
+            // The pin reader already validates the character set of the tag, so the remainder is not re-checked here.
+            string remainder = dispatcherReleaseTag.Substring(CliConstants.DISPATCHER_RELEASE_TAG_PREFIX.Length);
+            if (string.IsNullOrEmpty(remainder))
+            {
+                return false;
+            }
+
+            version = remainder;
+            return true;
+        }
+    }
+}

--- a/Packages/src/Editor/Domain/DispatcherReleaseTagVersion.cs.meta
+++ b/Packages/src/Editor/Domain/DispatcherReleaseTagVersion.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a399d2a60788d44119ced751dae516a7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/Presentation/Setup/SetupWizardCliStepPresenter.cs
+++ b/Packages/src/Editor/Presentation/Setup/SetupWizardCliStepPresenter.cs
@@ -67,6 +67,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             string cliVersion,
             bool cliIsDispatcher,
             string requiredCliVersion,
+            string installTargetCliVersion,
             bool isInstallingCli,
             bool needsCliPathSetup,
             ManagedCliKind managedCliKind)
@@ -83,7 +84,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
                 needsCliPathSetup,
                 managedCliKind,
                 cliVersion,
-                requiredCliVersion);
+                installTargetCliVersion);
             bool cliVersionMatched = state.IsCompatible && cliInstalled;
             bool buttonEnabled = IsCliButtonEnabledForSetupWizard(
                 cliInstalled,
@@ -157,7 +158,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             bool needsCliPathSetup,
             ManagedCliKind managedCliKind,
             string cliVersion,
-            string requiredCliVersion)
+            string installTargetCliVersion)
         {
             if (isChecking)
             {
@@ -188,7 +189,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
 
             if (needsUpdate)
             {
-                return CliSetupLabelFormatter.GetCliReplacementButtonText("Update", cliVersion, requiredCliVersion);
+                return CliSetupLabelFormatter.GetCliReplacementButtonText("Update", cliVersion, installTargetCliVersion);
             }
 
             if (needsCliPathSetup)

--- a/Packages/src/Editor/Presentation/Setup/SetupWizardCliWorkflowController.cs
+++ b/Packages/src/Editor/Presentation/Setup/SetupWizardCliWorkflowController.cs
@@ -84,6 +84,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
                 cliVersion,
                 cliIsDispatcher,
                 requiredCliVersion,
+                GetCliInstallTargetVersion(),
                 _isInstallingCli,
                 _needsCliPathSetup,
                 ResolveManagedCliKind());
@@ -139,6 +140,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
                 cliVersion: null,
                 cliIsDispatcher: false,
                 requiredCliVersion: GetMinimumRequiredCliVersion(),
+                installTargetCliVersion: GetCliInstallTargetVersion(),
                 isInstallingCli: _isInstallingCli,
                 needsCliPathSetup: _needsCliPathSetup,
                 managedCliKind: ResolveManagedCliKind());
@@ -211,6 +213,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
                 cliVersion: _cliSetupApplicationService.GetCachedCliVersion(),
                 cliIsDispatcher: _cliSetupApplicationService.GetCachedCliIsDispatcher(),
                 requiredCliVersion: GetMinimumRequiredCliVersion(),
+                installTargetCliVersion: GetCliInstallTargetVersion(),
                 isInstallingCli: _isInstallingCli,
                 needsCliPathSetup: _needsCliPathSetup,
                 managedCliKind: ResolveManagedCliKind());
@@ -261,6 +264,11 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
         private string GetMinimumRequiredCliVersion()
         {
             return _cliSetupApplicationService.GetMinimumRequiredCliVersion();
+        }
+
+        private string GetCliInstallTargetVersion()
+        {
+            return _cliSetupApplicationService.GetCliInstallTargetVersion();
         }
 
         private static bool IsCliInstalled(string cliVersion)

--- a/Packages/src/Editor/Presentation/UIToolkit/Components/CliSetupSection.cs
+++ b/Packages/src/Editor/Presentation/UIToolkit/Components/CliSetupSection.cs
@@ -145,7 +145,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
                 data.NeedsCliPathSetup,
                 data.ManagedCliKind,
                 data.CliVersion,
-                data.RequiredCliVersion);
+                data.InstallTargetCliVersion);
             bool enabled = IsInstallCliButtonEnabled(
                 data.IsInstallingCli,
                 data.IsChecking,
@@ -207,7 +207,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             bool needsCliPathSetup,
             ManagedCliKind managedCliKind,
             string cliVersion,
-            string requiredCliVersion)
+            string installTargetCliVersion)
         {
             if (isChecking)
             {
@@ -239,7 +239,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
 
             if (needsUpdate)
             {
-                return CliSetupLabelFormatter.GetCliReplacementButtonText("Update", cliVersion, requiredCliVersion);
+                return CliSetupLabelFormatter.GetCliReplacementButtonText("Update", cliVersion, installTargetCliVersion);
             }
 
             if (needsCliPathSetup)

--- a/Packages/src/Editor/Presentation/UnityCliLoopSettingsCliSetupPresenter.cs
+++ b/Packages/src/Editor/Presentation/UnityCliLoopSettingsCliSetupPresenter.cs
@@ -441,6 +441,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             bool cliIsDispatcher = _cliSetupApplicationService.GetCachedCliIsDispatcher();
             string cliExecutablePath = _cliSetupApplicationService.GetCachedCliExecutablePath();
             string requiredCliVersion = _cliSetupApplicationService.GetMinimumRequiredCliVersion();
+            string installTargetCliVersion = _cliSetupApplicationService.GetCliInstallTargetVersion();
 
             bool isCliInstalled = !string.IsNullOrEmpty(cliVersion) || needsCliPathSetup;
             bool canUninstallCli = _cliSetupApplicationService.IsPackageOwnedCurrentUserInstallPath(
@@ -467,6 +468,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
                 isCliInstalled,
                 cliVersion,
                 requiredCliVersion,
+                installTargetCliVersion,
                 state.NeedsUpdate,
                 canUninstallCli,
                 needsCliPathSetup,

--- a/Packages/src/Editor/Presentation/UnityCliLoopSettingsWindowViewData.cs
+++ b/Packages/src/Editor/Presentation/UnityCliLoopSettingsWindowViewData.cs
@@ -83,6 +83,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
         public readonly bool IsCliInstalled;
         public readonly string CliVersion;
         public readonly string RequiredCliVersion;
+        public readonly string InstallTargetCliVersion;
         public readonly bool NeedsUpdate;
         public readonly bool CanUninstallCli;
         public readonly bool NeedsCliPathSetup;
@@ -104,6 +105,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             bool isCliInstalled,
             string cliVersion,
             string requiredCliVersion,
+            string installTargetCliVersion,
             bool needsUpdate,
             bool canUninstallCli,
             bool needsCliPathSetup,
@@ -124,6 +126,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             IsCliInstalled = isCliInstalled;
             CliVersion = cliVersion;
             RequiredCliVersion = requiredCliVersion;
+            InstallTargetCliVersion = installTargetCliVersion;
             NeedsUpdate = needsUpdate;
             CanUninstallCli = canUninstallCli;
             NeedsCliPathSetup = needsCliPathSetup;


### PR DESCRIPTION
## Summary
- The CLI update button now names the version that pressing it actually installs.

## User Impact
- Before: Settings and the Setup Wizard showed `Update CLI (v2.1.6 → v3.0.0-beta.31)`. The version after the arrow came from the pin's minimum required version, which only moves by hand, while pressing the button installed the pinned dispatcher release instead. Users were told they would get one version and got another.
- After: the arrow shows the version the pinned dispatcher release installs, e.g. `Update CLI (v2.1.6 → v3.4.0)`.
- Compatibility evaluation and the "requires vX" / managed-CLI upgrade texts still use the minimum required version, so no update prompt appears or disappears because of this change.

## Changes
- Add a domain helper that extracts the semver from a `dispatcher-v...` release tag.
- Add `GetCliInstallTargetVersion()` to the CLI setup application service. It reads the bootstrap pin, and falls back to the minimum required version when that pin cannot be read so the view still renders (the install path already surfaces its own error in that case).
- Pass the install target version through the settings view data and the setup wizard step presenter, and use it only for the update button label.
- The pin files themselves are untouched.

## Verification
- `uloop compile`: 0 errors.
- `uloop run-tests` per class (single-flight): `DispatcherReleaseTagVersionTests` 6 passed, `CliSetupApplicationServiceTests` 6 passed, `CliSetupSectionTests` 50 passed, `SetupWizardWindowTests` 104 passed, `CliPinReaderServiceTests` 12 passed, `CliPathSetupFlowTests` 4 passed, `SkillsTargetSelectionResolverTests` 9 passed. 0 failures in all runs.
- New label cases cover an install target that differs from the minimum required version in both the settings section and the setup wizard.
- Not verified: the on-screen label in an environment that still has a v2 CLI installed. That state cannot be reproduced here, so the visual check is left to a reviewer with such an environment.

https://claude.ai/code/session_01Ggy1L13ZLvP7QnGzUpGfb8


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2686?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

