### PR TITLE
chore: remove unreferenced hot reload members and a duplicated worker output validation

### DIFF
--- a/Assets/Tests/Editor/HotReload/TransformWorkerClientTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerClientTests.cs
@@ -3061,7 +3061,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         /// source even when its compiled identity is otherwise correct.
         /// </summary>
         [Test]
-        public void TryValidateOutput_PrepareDescriptorOwnerMismatch_ReturnsFailure()
+        public void InterpretOutput_PrepareDescriptorOwnerMismatch_ReturnsFailure()
         {
             TransformWorkerInputDto input = new TransformWorkerInputDto
             {
@@ -3097,10 +3097,10 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 }
             };
 
-            bool valid = TransformWorkerClient.TryValidateOutput(input, output, out string errorMessage);
+            TransformWorkerClientResult result = TransformWorkerClient.InterpretOutput(input, output);
 
-            Assert.That(valid, Is.False);
-            Assert.That(errorMessage, Does.Contain("owner"));
+            Assert.That(result.Success, Is.False);
+            Assert.That(result.ErrorMessage, Does.Contain("owner"));
         }
 
         /// <summary>
@@ -3108,7 +3108,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         /// its owner and assembly MVID match the input row.
         /// </summary>
         [Test]
-        public void TryValidateOutput_PrepareDescriptorAssemblyNameMismatch_ReturnsFailure()
+        public void InterpretOutput_PrepareDescriptorAssemblyNameMismatch_ReturnsFailure()
         {
             TransformWorkerInputDto input = CreatePreparationValidationInput();
             TransformWorkerOutputDto output = CreatePreparationValidationOutput(
@@ -3116,10 +3116,10 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 "mvid",
                 "Assets/Edited.cs");
 
-            bool valid = TransformWorkerClient.TryValidateOutput(input, output, out string errorMessage);
+            TransformWorkerClientResult result = TransformWorkerClient.InterpretOutput(input, output);
 
-            Assert.That(valid, Is.False);
-            Assert.That(errorMessage, Does.Contain("assembly identity"));
+            Assert.That(result.Success, Is.False);
+            Assert.That(result.ErrorMessage, Does.Contain("assembly identity"));
         }
 
         /// <summary>
@@ -3127,7 +3127,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         /// its owner and assembly name match the input row.
         /// </summary>
         [Test]
-        public void TryValidateOutput_PrepareDescriptorAssemblyMvidMismatch_ReturnsFailure()
+        public void InterpretOutput_PrepareDescriptorAssemblyMvidMismatch_ReturnsFailure()
         {
             TransformWorkerInputDto input = CreatePreparationValidationInput();
             TransformWorkerOutputDto output = CreatePreparationValidationOutput(
@@ -3135,10 +3135,10 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 "other-mvid",
                 "Assets/Edited.cs");
 
-            bool valid = TransformWorkerClient.TryValidateOutput(input, output, out string errorMessage);
+            TransformWorkerClientResult result = TransformWorkerClient.InterpretOutput(input, output);
 
-            Assert.That(valid, Is.False);
-            Assert.That(errorMessage, Does.Contain("assembly identity"));
+            Assert.That(result.Success, Is.False);
+            Assert.That(result.ErrorMessage, Does.Contain("assembly identity"));
         }
 
         /// <summary>
@@ -3146,7 +3146,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         /// identity match the input row.
         /// </summary>
         [Test]
-        public void TryValidateOutput_PrepareDescriptorMatchingOwnerAndIdentity_ReturnsSuccess()
+        public void InterpretOutput_PrepareDescriptorMatchingOwnerAndIdentity_ReturnsSuccess()
         {
             TransformWorkerInputDto input = CreatePreparationValidationInput();
             TransformWorkerOutputDto output = CreatePreparationValidationOutput(
@@ -3154,9 +3154,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 "mvid",
                 "Assets/Edited.cs");
 
-            bool valid = TransformWorkerClient.TryValidateOutput(input, output, out string errorMessage);
+            TransformWorkerClientResult result = TransformWorkerClient.InterpretOutput(input, output);
 
-            Assert.That(valid, Is.True, errorMessage);
+            Assert.That(result.Success, Is.True, result.ErrorMessage);
         }
 
         /// <summary>

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadConstants.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadConstants.cs
@@ -382,10 +382,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         public const string UnimportedAsmdefCompilationAssemblyNotFoundReasonFormat =
             "Resolved assembly '{0}' was not found in the compilation pipeline. '{1}' sits under a .asmdef that Unity has not imported yet, so hot reload cannot target it. Run 'uloop compile' first.";
 
-        // Format: project-relative script path, compiled assembly name.
-        public const string SourceFileNotInCompiledAssemblyReasonFormat =
-            "'{0}' is not part of the last compiled assembly '{1}' (a newly added script). New files require a real compile; run 'uloop compile' first.";
-
         // Why "declarations or methods": a run can fail on a refused type declaration alone, and
         // Methods is then empty, so a next action naming only methods would send the reader to a
         // section with nothing in it.

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadFileAtomicIsolationPlan.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadFileAtomicIsolationPlan.cs
@@ -41,9 +41,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             AtomicSkipOutcomesByFile = atomicSkipOutcomesByFile;
         }
 
-        // The project-relative paths of the files a compile error was attributed to.
-        internal IReadOnlyCollection<string> FailedFiles => failedFiles;
-
         internal bool AllFilesFailed { get; }
 
         internal bool IsFailedFile(string projectRelativePath)

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadRunAccumulator.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadRunAccumulator.cs
@@ -58,10 +58,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         public List<HotReloadOneShotCallerNoteEnricher.Candidate> OneShotCallerNoteCandidates =>
             _oneShotCallerNoteCandidates;
 
-        public IReadOnlyList<HotReloadMethodOutcome> Outcomes => _outcomes;
-
-        public int PatchedTotal => _patchedTotal;
-
         /// <summary>Merges one processed file into the run.</summary>
         public void Add(string projectRelativePath, HotReloadFileProcessResult fileResult)
         {

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerClient.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerClient.cs
@@ -352,11 +352,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             TransformWorkerOutputDto output,
             out string errorMessage)
         {
-            if (!TryValidateRequiredPreparationOutput(input, output, out errorMessage))
-            {
-                return false;
-            }
-
             if (output.files == null || output.files.Length != input.sources.Length)
             {
                 errorMessage = "Transform worker output files must have the same count as input sources.";

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerDtos.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerDtos.cs
@@ -69,7 +69,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     /// <summary>
     /// One retained type inside an introduced-type artifact assembly.
     /// </summary>
-    // Keep in sync with TransformWorker~/WorkerIntroducedTypeArtifactType.cs.
+    // Keep in sync with WorkerIntroducedTypeArtifactType in TransformWorker~/WorkerIntroducedTypeArtifact.cs.
     [Serializable]
     internal sealed class TransformWorkerIntroducedTypeArtifactTypeDto
     {

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerHostResult.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorkerHostResult.cs
@@ -43,11 +43,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         public TransformWorkerOutputDto Output { get; }
         public string ErrorMessage { get; }
 
-        public bool Success
-        {
-            get { return Kind == TransformWorkerHostResultKind.Completed; }
-        }
-
         private TransformWorkerHostResult(TransformWorkerHostResultKind kind, TransformWorkerOutputDto output, string errorMessage)
         {
             Kind = kind;


### PR DESCRIPTION
## Summary
- Housekeeping inside the hot reload package: nothing an end user runs behaves differently.
- Removes members no code reads and stops the worker output path from running one validation twice.

## User Impact
None. Every hot reload command produces exactly the same output as before. The
preparation validation that ran twice already returned the same verdict both
times, so no message, exit code, or skip reason changes.

## Changes
- Deleted five members the dead-code scanner reports with no reference in
  production or test code: a reason-format constant that nothing formats, a
  read-only view over a collection nobody enumerates, two accumulator views over
  fields the accumulator itself still uses, and a `Success` convenience property
  on a worker host result. The backing fields stay wherever the owning type
  still uses them.
- Fixed a "keep in sync" comment that named a file which does not exist. The
  worker type it mirrors is declared inside `WorkerIntroducedTypeArtifact.cs`,
  so the comment now names the type and its real file.
- The worker output path validated the preparation document twice per run: once
  before coalescing, and once more from inside the row-shape validation a few
  lines later. The first call has to stay, because it must observe the omitted
  arrays before coalescing replaces them with empty ones; the nested call could
  only repeat a check that had already passed. Dropped the nested call.
- Four tests reached the preparation validation through the row-shape helper.
  They now go through `InterpretOutput`, which is the boundary that owns the
  behavior. The source-order test still calls the row-shape helper, whose checks
  it covers directly.

## Verification
- `dotnet run --project tools/UnityCliLoop.DeadCodeScanner -- --scope public --include-types true --include-members true --include-locals false --include-test-only true --include-kept false --format table` — all five removed members report as `PublicCandidate` with "No references were found in production or non-production code".
- `uloop compile` — 0 errors.
- `uloop run-tests --filter-type class --filter-value ...`, one class at a time:
  `TransformWorkerClientTests` 77 passed / 0 failed, `TransformWorkerHostTests`
  20 / 0, `HotReloadFileAtomicIsolationPlanTests` 2 / 0,
  `HotReloadGroupProcessorTests` 15 / 0.
- `sh scripts/check-file-length.sh` — no file over the limit.
- `sh scripts/check-code-complexity.sh` — 0 issues (Go), no CA1502 findings (C#).

https://claude.ai/code/session_01SfrW1agx2EpNUv7NnBuSNY


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2687?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

