### PR TITLE
chore: repair a hot reload test that edited its fixture into an unparsable file

### DIFF
--- a/Assets/Tests/Editor/HotReload/TransformWorkerAddedMemberTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerAddedMemberTests.cs
@@ -1682,7 +1682,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         {
             string onDisk = File.ReadAllText(ResolveHostPath());
             string edited = onDisk.Replace(
-                "        public int PartialRemoved()\n        {\n            return 2;\n        }\n",
+                "        [MethodImpl(MethodImplOptions.NoInlining)]\n"
+                + "        public int PartialRemoved()\n        {\n            return 2;\n        }\n",
                 string.Empty,
                 StringComparison.Ordinal);
             string sourcePath = WriteEdited("PartialMethodDeletion.cs", edited);


### PR DESCRIPTION
## Summary
- Repairs a hot reload test that fails on `main` today.
- Test-only change: no production code is touched.

## User Impact
None. This corrects the edit a test applies to its own fixture, so nothing an
end user runs changes.

## User Impact for maintainers
`TransformWorkerAddedMemberTests.Classify_PartialTypeMethodDeletion_OmitsRemovedSignatures`
fails on `main` (56 passed / 1 failed) with `Expected removed member name
'PartialRemoved'.`, which reads as a regression in removed-member reporting. It
is not one — the test hands the worker a source file that does not parse.

## Changes
The test simulates deleting `PartialRemoved` from a partial host by removing the
method's declaration and body from the fixture text. The fixture carries a
`[MethodImpl(MethodImplOptions.NoInlining)]` attribute directly above that
method, and the edit left it behind, so the edited source ended with an
attribute attached to nothing — a parse error.

The test still passed while the worker classified files off a Roslyn recovery
tree. Since a file with parse errors is excluded from the transform, the worker
reports no removed members for that file and the assertion fails for a reason
unrelated to what the test covers.

The edit now removes the attribute together with the method, which is what
deleting the method means. What the test verifies is unchanged, so its `What:`
comment stays as it was.

## Verification
- `uloop compile` — 0 errors.
- `uloop run-tests --filter-type class --filter-value TransformWorkerAddedMemberTests` — 57 passed / 0 failed (before this change on the same checkout: 56 passed / 1 failed, reproduced twice, and reproduced again from a detached checkout of `main` to rule out local state).

https://claude.ai/code/session_01SfrW1agx2EpNUv7NnBuSNY


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2688?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

