### PR TITLE
chore: explain why a type's methods were skipped instead of calling new types out of scope

### DIFF
--- a/Assets/Tests/Editor/HotReload/TransformWorkerAddedMemberTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerAddedMemberTests.cs
@@ -1189,11 +1189,11 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
-        /// What: a type absent from the compiled assembly skips every method with the new-type
-        /// out-of-scope reason instead of emitting MethodNotFound entries.
+        /// What: a type absent from the compiled assembly skips every method with the
+        /// not-introduced reason instead of emitting MethodNotFound entries.
         /// </summary>
         [Test]
-        public async Task Skip_NewTypeAbsentFromCompiledAssembly_UsesOutOfScopeReason()
+        public async Task Skip_NewTypeAbsentFromCompiledAssembly_UsesNotIntroducedReason()
         {
             string onDisk = File.ReadAllText(ResolveHostPath());
             string edited = onDisk.Replace(
@@ -1207,7 +1207,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 HostProjectRelativePath,
                 snapshotSource: onDisk);
             Assert.That(result.Success, Is.True, result.ErrorMessage);
-            AssertHasSkip(result, "HotReloadBrandNewType.Fresh", "New types are out of scope");
+            AssertHasSkip(result, "HotReloadBrandNewType.Fresh", "was not introduced by this run");
             Assert.That(FindEntry(result, "Fresh"), Is.Null);
             Assert.That(
                 result.Output.files[0].declarationDriftWarnings,
@@ -1236,7 +1236,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 HostProjectRelativePath,
                 snapshotSource: onDisk);
             Assert.That(result.Success, Is.True, result.ErrorMessage);
-            AssertHasSkip(result, "IHotReloadBrandNewInterface.Fresh", "New types are out of scope");
+            AssertHasSkip(result, "IHotReloadBrandNewInterface.Fresh", "was not introduced by this run");
             Assert.That(FindEntry(result, "Fresh"), Is.Null);
             Assert.That(
                 result.Output.files[0].declarationDriftWarnings,

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AddedFieldClassifier.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AddedFieldClassifier.cs
@@ -156,45 +156,49 @@ internal static class AddedFieldClassifier
 
         // Why after const: added consts on struct hosts still fold to literals; the store
         // identity problem only applies to instance/static storage.
-        return EvaluateStoreAvailability(
+        AddedFieldStoreAvailability availability = EvaluateStoreAvailability(
             hostType,
             semanticModel,
             targetTypesAssemblySymbol,
             fieldSymbol.Type,
             binding.Initializer,
-            artifactMap);
+            artifactMap,
+            out ITypeSymbol unresolvedStoreType);
+        return DescribeStoreAvailability(availability, unresolvedStoreType);
     }
 
     /// <summary>
-    /// Reports why a value cannot live in the added-field store, for any member backed by it.
-    /// Added auto-properties reuse this so their backing store follows the same rules as fields.
+    /// Reports whether a value can live in the added-field store, and on what grounds it cannot,
+    /// for any member backed by it. Added auto-properties classify against this so their backing
+    /// store follows the same rules as fields while wording the outcome as a property.
     /// </summary>
-    internal static string EvaluateStoreAvailability(
+    // unresolvedType names the type the compilation could not resolve, and is set only for
+    // ValueTypeUnresolved, whose reason has to repeat that name.
+    internal static AddedFieldStoreAvailability EvaluateStoreAvailability(
         INamedTypeSymbol hostType,
         SemanticModel semanticModel,
         IAssemblySymbol targetTypesAssemblySymbol,
         ITypeSymbol valueType,
         ExpressionSyntax initializer,
-        IntroducedTypeArtifactMap artifactMap)
+        IntroducedTypeArtifactMap artifactMap,
+        out ITypeSymbol unresolvedType)
     {
+        unresolvedType = null;
         if (hostType.TypeKind == TypeKind.Struct)
         {
-            return AddedFieldSkipReasons.StructHost;
+            return AddedFieldStoreAvailability.StructHost;
         }
 
         // Why unresolved types before visibility: TypeKind.Error is not externally
         // visible, so the shim-visibility reason would hide a missing using or typo.
-        if (TryFindUnresolvedType(valueType, out ITypeSymbol unresolvedType))
+        if (TryFindUnresolvedType(valueType, out unresolvedType))
         {
-            return string.Format(
-                CultureInfo.InvariantCulture,
-                AddedFieldSkipReasons.FieldTypeUnresolvedFormat,
-                unresolvedType.ToDisplayString());
+            return AddedFieldStoreAvailability.ValueTypeUnresolved;
         }
 
         if (!AccessibilityRules.IsExternallyVisibleType(valueType))
         {
-            return AddedFieldSkipReasons.FieldTypeNotExternallyVisible;
+            return AddedFieldStoreAvailability.ValueTypeNotExternallyVisible;
         }
 
         if (initializer != null
@@ -205,10 +209,33 @@ internal static class AddedFieldClassifier
                 targetTypesAssemblySymbol,
                 artifactMap))
         {
-            return AddedFieldSkipReasons.InitializerNotLiteralOrExternalStatic;
+            return AddedFieldStoreAvailability.InitializerNotEmittable;
         }
 
-        return null;
+        return AddedFieldStoreAvailability.Available;
+    }
+
+    /// <summary>Words a store outcome as the skip reason an added field reports.</summary>
+    private static string DescribeStoreAvailability(
+        AddedFieldStoreAvailability availability,
+        ITypeSymbol unresolvedType)
+    {
+        switch (availability)
+        {
+            case AddedFieldStoreAvailability.Available:
+                return null;
+            case AddedFieldStoreAvailability.StructHost:
+                return AddedFieldSkipReasons.StructHost;
+            case AddedFieldStoreAvailability.ValueTypeUnresolved:
+                return string.Format(
+                    CultureInfo.InvariantCulture,
+                    AddedFieldSkipReasons.FieldTypeUnresolvedFormat,
+                    unresolvedType.ToDisplayString());
+            case AddedFieldStoreAvailability.ValueTypeNotExternallyVisible:
+                return AddedFieldSkipReasons.FieldTypeNotExternallyVisible;
+            default:
+                return AddedFieldSkipReasons.InitializerNotLiteralOrExternalStatic;
+        }
     }
 
     // Why recurse array elements and type arguments: List<Missing> and Missing[]

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AddedFieldStoreAvailability.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AddedFieldStoreAvailability.cs
@@ -1,0 +1,12 @@
+/// <summary>
+/// Why a value can or cannot live in the added-field store. Fields and auto-properties share the
+/// store, so both classify against this and each phrase the outcome in their own wording.
+/// </summary>
+internal enum AddedFieldStoreAvailability
+{
+    Available,
+    StructHost,
+    ValueTypeUnresolved,
+    ValueTypeNotExternallyVisible,
+    InitializerNotEmittable
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AddedMethodSkipReasons.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AddedMethodSkipReasons.cs
@@ -36,8 +36,10 @@ internal static class AddedMethodSkipReasons
     public const string UnavailableAddedCall =
         "Calls an added method that hot reload cannot emit. Run 'uloop compile'.";
 
-    public const string NewTypeOutOfScope =
-        "New types are out of scope for hot reload; run 'uloop compile' to add them.";
+    public const string TypeNotIntroduced =
+        "Declared on a type that is not in the compiled assembly and was not introduced by this "
+        + "run. Run 'uloop compile'; when the file's introduced-type diagnostics name this type, "
+        + "that line gives the reason it was not introduced.";
 
     public const string InterfaceMember =
         "Interface members are not patchable. Run 'uloop compile'.";

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AddedPropertyClassifier.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AddedPropertyClassifier.cs
@@ -368,34 +368,27 @@ internal static class AddedPropertyClassifier
         IAssemblySymbol targetTypesAssemblySymbol,
         IntroducedTypeArtifactMap artifactMap)
     {
-        string storeReason = AddedFieldClassifier.EvaluateStoreAvailability(
+        AddedFieldStoreAvailability availability = AddedFieldClassifier.EvaluateStoreAvailability(
             hostType,
             semanticModel,
             targetTypesAssemblySymbol,
             symbol.Type,
             declaration.Initializer?.Value,
-            artifactMap);
-        if (storeReason == null)
+            artifactMap,
+            out ITypeSymbol _);
+        switch (availability)
         {
-            return null;
+            case AddedFieldStoreAvailability.Available:
+                return null;
+            case AddedFieldStoreAvailability.StructHost:
+                return AddedPropertySkipReasons.StructHost;
+            case AddedFieldStoreAvailability.InitializerNotEmittable:
+                return AddedPropertySkipReasons.InitializerNotEmittable;
+            default:
+                // The declaration check already rejects unresolved and non-visible value types, so
+                // anything left names a type the shim assembly cannot see.
+                return AddedPropertySkipReasons.ValueTypeNotExternallyVisible;
         }
-
-        if (string.Equals(storeReason, AddedFieldSkipReasons.StructHost, StringComparison.Ordinal))
-        {
-            return AddedPropertySkipReasons.StructHost;
-        }
-
-        if (string.Equals(
-                storeReason,
-                AddedFieldSkipReasons.InitializerNotLiteralOrExternalStatic,
-                StringComparison.Ordinal))
-        {
-            return AddedPropertySkipReasons.InitializerNotEmittable;
-        }
-
-        // The declaration check already rejects unresolved and non-visible value types, so
-        // anything left names a type the shim assembly cannot see.
-        return AddedPropertySkipReasons.ValueTypeNotExternallyVisible;
     }
 
     // Why register here and not at rewrite time: the accessor shims themselves read and write

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/OrdinaryMethodQueue.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/OrdinaryMethodQueue.cs
@@ -461,7 +461,7 @@ internal static class OrdinaryMethodQueue
             {
                 SourceProjectRelativePath = typeState.SourceUnit.Input.ProjectRelativePath,
                 Method = WorkerMethodKeys.FormatMethodLabel(methodSymbol),
-                Reason = AddedMethodSkipReasons.NewTypeOutOfScope
+                Reason = AddedMethodSkipReasons.TypeNotIntroduced
             });
         }
     }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/PropertyGetterClassifier.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/PropertyGetterClassifier.cs
@@ -204,7 +204,7 @@ internal static class PropertyGetterClassifier
         {
             SourceProjectRelativePath = sourceProjectRelativePath,
             Method = WorkerMethodKeys.FormatMethodLabel(propertySymbol.GetMethod),
-            Reason = AddedMethodSkipReasons.NewTypeOutOfScope
+            Reason = AddedMethodSkipReasons.TypeNotIntroduced
         });
     }
 }


### PR DESCRIPTION
## Summary
- One skip reason stops claiming a limitation hot reload no longer has.
- The added-field store now reports an outcome rather than a message other code has to read.

## User Impact
One message changes. When a hot reload skips every method of a type, it used to
say:

> New types are out of scope for hot reload; run 'uloop compile' to add them.

Hot reload introduces new top-level types now, so that is no longer why the
methods were skipped. It now says:

> Declared on a type that is not in the compiled assembly and was not introduced
> by this run. Run 'uloop compile'; when the file's introduced-type diagnostics
> name this type, that line gives the reason it was not introduced.

Nothing else changes. Every added-field and added-property skip reason keeps the
exact wording it had.

## Changes

**Why the old reason was wrong.** A type reaches this skip only when it is
absent from the compiled assembly *and* this run did not introduce it: the
introduced-type planner refused it, it was passed over as a nested type, or the
run never went through the preparation step. Types the run did introduce are
removed from the binding tree before the queue sees them, so they never land
here. When the planner refused a type, it records the cause on the file's
introduced-type diagnostics, which is what the new reason points at. That
pointer is conditional because a run that skips preparation produces no
diagnostics line.

**Why the store classification changed shape.** An added auto-property shares
its backing store with an added field, so it asks the field classifier whether a
value can live there. It received the field's user-facing reason string and
recovered the outcome from it with `string.Equals` against two field reason
constants. That made the wording of a field message part of the contract between
the two classifiers: rephrasing a field reason would have silently rerouted
properties to the fallback branch, and a property would have reported the wrong
cause with nothing failing.

The evaluation now answers with an `AddedFieldStoreAvailability` value, and each
classifier words that outcome in its own terms. The branch order is unchanged
and the unresolved type travels as a symbol, so the field reason can still name
it. The strings both classifiers emit are byte-for-byte what they were.

## Verification
- `uloop compile` — 0 errors.
- `uloop run-tests --filter-type class --filter-value ...`, one class at a time,
  after rebasing onto `main`: `TransformWorkerAddedMemberTests` 57 passed / 0
  failed, `TransformWorkerAddedFieldTests` 66 / 0,
  `TransformWorkerAddedPropertyTests` 40 / 0. The field and property suites
  assert the reason strings, so their passing is what shows the wording did not
  move.
- `sh scripts/check-code-complexity.sh` — 0 issues (Go), no CA1502 findings (C#).
- `sh scripts/check-file-length.sh` — no file over the limit.
- No reference to the old constant or its wording remains anywhere in the
  package or the tests.

https://claude.ai/code/session_01SfrW1agx2EpNUv7NnBuSNY


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2690?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

