### PR TITLE
chore: stop printing the same expired pause-point guidance twice

### DIFF
--- a/cli/project-runner/internal/projectrunner/pause_point_errors.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_errors.go
@@ -201,10 +201,8 @@ const (
 
 	pausePointHintTimeoutAutoCleared    = "This command disarmed the marker on timeout; re-enable the pause point (enable-pause-point) before waiting again. "
 	pausePointHitWhenNoMatchTimeoutHint = "The marker's line executed, but no hit matched --hit-when. Adjust the --hit-when condition or trigger input so a hit matches, then wait again."
-	pausePointHitWhenNoMatchExpiredHint = "The marker expired after its line executed, but no hit matched --hit-when. Re-enable it with a longer --timeout-seconds, then adjust the --hit-when condition or trigger input so a hit matches."
 	pausePointExpiredNoHitPrefix        = "The enable-pause-point --timeout-seconds window (measured from enable, not from this wait) ran out before the marker was hit. "
 	pausePointExpiredNoHitSuffix        = " Once the cause is addressed, re-enable the marker (raise --timeout-seconds only if the window itself was too short) and trigger the code path again."
-	pausePointExpiredAfterHitHint       = "The marker was hit before its --timeout-seconds window closed, so this is not a missed code path. Read the recorded hit with 'uloop pause-point-status --id <marker-id>' (HitCount, CapturedVariables, CapturedVariableHistory survive expiry); re-enable the marker if you need to capture another hit."
 
 	// Explains how to read resolved-line Details on Expired when HitCount is still 0.
 	// Why not mention ResolvedLineText: C# omits empty text, so Details may carry only ResolvedLine.
@@ -296,6 +294,11 @@ func pausePointTimeoutHint(
 // pausePointExpiredHint mirrors the timeout diagnosis for expired markers, because a marker
 // whose enable window ends before the wait deadline surfaces as PAUSE_POINT_EXPIRED instead
 // of a timeout and would otherwise carry no hint at all.
+//
+// Why it says nothing about a recorded hit or a --hit-when mismatch: the Editor already
+// diagnoses both in RecommendedNextAction, which leads NextActions, so a hint here would
+// print the same guidance a second time in the same error. Only the branches the Editor
+// cannot see stay: hot-reload suppression, a rejected trigger, and the Editor's Play state.
 func pausePointExpiredHint(response pausePointStatusResponse, triggerResult *pausePointTriggerResult) string {
 	if response.SuppressedByHotReload {
 		return pausePointSuppressedByHotReloadHint(response)
@@ -309,16 +312,15 @@ func pausePointExpiredHint(response pausePointStatusResponse, triggerResult *pau
 	if response.EditorState.IsPaused {
 		return pausePointHintEditorAlreadyPaused
 	}
+	// Why != 0 rather than > 0: a recorded hit is diagnosed by RecommendedNextAction, and a
+	// malformed negative count is no evidence that the line never ran, so neither may claim it.
+	if response.HitCount != 0 {
+		return ""
+	}
 	if pausePointHasHitWhenSkips(response) {
-		return pausePointHitWhenNoMatchExpiredHint
+		return ""
 	}
-	if response.HitCount == 0 {
-		return pausePointExpiredNoHitPrefix + pausePointNonFiringPatternsHint + pausePointExpiredNoHitSuffix
-	}
-	if response.HitCount > 0 {
-		return pausePointExpiredAfterHitHint
-	}
-	return ""
+	return pausePointExpiredNoHitPrefix + pausePointNonFiringPatternsHint + pausePointExpiredNoHitSuffix
 }
 
 // pausePointHasHitWhenSkips identifies the state that proves the line executed

--- a/cli/project-runner/internal/projectrunner/pause_point_errors_test.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_errors_test.go
@@ -203,10 +203,11 @@ func TestPausePointStateErrorDetailsIncludeHitWhenDiagnostics(t *testing.T) {
 // markers whose line did not execute.
 func TestPausePointWaitHintsDifferentiateHitWhenSkips(t *testing.T) {
 	cases := []struct {
-		name     string
-		state    pausePointWaitState
-		response pausePointStatusResponse
-		wantHint string
+		name       string
+		state      pausePointWaitState
+		response   pausePointStatusResponse
+		wantHint   string
+		wantNoHint bool
 	}{
 		{
 			name:  "timeout with skipped conditional hits",
@@ -228,7 +229,9 @@ func TestPausePointWaitHintsDifferentiateHitWhenSkips(t *testing.T) {
 				HitWhenSkippedCount: 3,
 				EditorState:         pausePointEditorState{IsPlaying: true},
 			},
-			wantHint: "The marker expired after its line executed, but no hit matched --hit-when. Re-enable it with a longer --timeout-seconds, then adjust the --hit-when condition or trigger input so a hit matches.",
+			// The RecommendedNextAction the Editor sends already carries this diagnosis and
+			// leads NextActions, so no Hint is set at all.
+			wantNoHint: true,
 		},
 		{
 			name:  "timeout without skipped conditional hits",
@@ -256,6 +259,12 @@ func TestPausePointWaitHintsDifferentiateHitWhenSkips(t *testing.T) {
 				id:             "marker",
 				timeoutSeconds: 30,
 			}, testCase.response, testCase.state, false, false, nil)
+			if testCase.wantNoHint {
+				if hint, exists := cliErr.Details["Hint"]; exists {
+					t.Fatalf("expected no Hint, got %#v", hint)
+				}
+				return
+			}
 			if cliErr.Details["Hint"] != testCase.wantHint {
 				t.Fatalf("Hint mismatch: got %#v, want %#v", cliErr.Details["Hint"], testCase.wantHint)
 			}
@@ -283,7 +292,9 @@ func TestPausePointHitWhenHintsRequireZeroMatchingHits(t *testing.T) {
 		HitWhenSkippedCount: 3,
 		EditorState:         pausePointEditorState{IsPlaying: true},
 	}, nil)
-	if expiredMatchingHitHint != "The marker was hit before its --timeout-seconds window closed, so this is not a missed code path. Read the recorded hit with 'uloop pause-point-status --id <marker-id>' (HitCount, CapturedVariables, CapturedVariableHistory survive expiry); re-enable the marker if you need to capture another hit." {
+	// The Editor's RecommendedNextAction already reports the recorded hit, so the expired
+	// hint stays empty rather than repeating it.
+	if expiredMatchingHitHint != "" {
 		t.Fatalf("expired matching-hit hint mismatch: got %q", expiredMatchingHitHint)
 	}
 

--- a/cli/project-runner/internal/projectrunner/pause_point_wait_test.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_wait_test.go
@@ -602,13 +602,15 @@ func TestPausePointExpiredErrorPrependsRecommendedNextAction(t *testing.T) {
 // Verifies skipped conditional hits suppress the resolved-line guidance that
 // would otherwise contradict the expired hint by claiming the line never ran.
 func TestPausePointExpiredErrorWithSkippedHitsOmitsNeverExecutedGuidance(t *testing.T) {
+	const recommendedNextAction = "The armed line executed 3 time(s) but no hit matched --hit-when. Re-enable the marker, then adjust the --hit-when condition or the trigger input so a hit matches; clearing the expired marker first is not required."
 	response := pausePointStatusResponse{
-		Id:                  "Assets/Scripts/Foo.cs:72",
-		Status:              pausePointStatusExpired,
-		HitWhen:             "speed > 5",
-		HitWhenSkippedCount: 3,
-		ResolvedLine:        72,
-		EditorState:         pausePointEditorState{IsPlaying: true, CapturedAt: "Current"},
+		Id:                    "Assets/Scripts/Foo.cs:72",
+		Status:                pausePointStatusExpired,
+		HitWhen:               "speed > 5",
+		HitWhenSkippedCount:   3,
+		ResolvedLine:          72,
+		RecommendedNextAction: recommendedNextAction,
+		EditorState:           pausePointEditorState{IsPlaying: true, CapturedAt: "Current"},
 	}
 
 	cliErr := pausePointWaitError("/tmp/project", waitForPausePointOptions{
@@ -619,8 +621,13 @@ func TestPausePointExpiredErrorWithSkippedHitsOmitsNeverExecutedGuidance(t *test
 	if cliErr.Message != "Pause point expired before it was hit." {
 		t.Fatalf("Message mismatch: got %#v, want %#v", cliErr.Message, "Pause point expired before it was hit.")
 	}
-	if cliErr.Details["Hint"] != "The marker expired after its line executed, but no hit matched --hit-when. Re-enable it with a longer --timeout-seconds, then adjust the --hit-when condition or trigger input so a hit matches." {
-		t.Fatalf("Hint mismatch: got %#v", cliErr.Details["Hint"])
+	// The Editor's RecommendedNextAction leads NextActions with this diagnosis, so repeating
+	// it in Hint would print the same guidance twice.
+	if hint, exists := cliErr.Details["Hint"]; exists {
+		t.Fatalf("expected no Hint, got %#v", hint)
+	}
+	if len(cliErr.NextActions) == 0 || cliErr.NextActions[0] != recommendedNextAction {
+		t.Fatalf("NextActions must lead with the recommended next action: got %#v", cliErr.NextActions)
 	}
 }
 
@@ -1625,10 +1632,12 @@ func TestPausePointExpiredErrorIncludesDiagnosisHint(t *testing.T) {
 
 // Verifies an expired marker with a recorded hit reports a message and hint that agree on that hit.
 func TestPausePointExpiredErrorAfterHit_ReportsConsistentMessageAndHint(t *testing.T) {
+	const recommendedNextAction = "The marker was hit before its --timeout-seconds window closed, so this is not a missed code path. Read the recorded hit with pause-point-status --id <marker-id> (HitCount, CapturedVariables, CapturedVariableHistory survive expiry); re-enable the marker if you need to capture another hit."
 	response := pausePointStatusResponse{
-		Id:       "jump",
-		Status:   pausePointStatusExpired,
-		HitCount: 1,
+		Id:                    "jump",
+		Status:                pausePointStatusExpired,
+		HitCount:              1,
+		RecommendedNextAction: recommendedNextAction,
 		EditorState: pausePointEditorState{
 			IsPlaying:  true,
 			CapturedAt: "Current",
@@ -1643,8 +1652,13 @@ func TestPausePointExpiredErrorAfterHit_ReportsConsistentMessageAndHint(t *testi
 	if cliErr.Message != "Pause point expired after it was hit." {
 		t.Fatalf("Message mismatch: got %q", cliErr.Message)
 	}
-	if cliErr.Details["Hint"] != "The marker was hit before its --timeout-seconds window closed, so this is not a missed code path. Read the recorded hit with 'uloop pause-point-status --id <marker-id>' (HitCount, CapturedVariables, CapturedVariableHistory survive expiry); re-enable the marker if you need to capture another hit." {
-		t.Fatalf("Hint mismatch: got %#v", cliErr.Details["Hint"])
+	// The Editor's RecommendedNextAction leads NextActions with this diagnosis, so repeating
+	// it in Hint would print the same guidance twice.
+	if hint, exists := cliErr.Details["Hint"]; exists {
+		t.Fatalf("expected no Hint, got %#v", hint)
+	}
+	if len(cliErr.NextActions) == 0 || cliErr.NextActions[0] != recommendedNextAction {
+		t.Fatalf("NextActions must lead with the recommended next action: got %#v", cliErr.NextActions)
 	}
 }
 


### PR DESCRIPTION
## Summary
- An expired pause-point error no longer prints the same diagnosis twice.

## User Impact
When a pause point expires, the Editor sends a recommended next action and the
runner puts it at the head of `NextActions`. For two of those cases the runner
*also* built a nearly identical sentence of its own and set it as
`Details.Hint`, so a single error told the reader the same thing in two places:

- the marker was hit before its `--timeout-seconds` window closed
- the marker's line executed, but no hit matched `--hit-when`

Both now appear once, in `NextActions[0]`. `Details.Hint` is simply absent for
these two cases — the runner sets the key only when it has a hint to give.
Nothing is lost: the Editor's wording covers the same ground, and for the
`--hit-when` case it is strictly more informative, because it reports how many
times the armed line actually ran.

Every other expired diagnosis keeps its hint, since the Editor cannot see those
conditions: hot-reload suppression, a rejected `--trigger`, Play Mode not
running, an Editor already paused by an earlier hit, and a marker whose line
never ran at all.

## Changes
- Dropped the two duplicated hint constants and the branches that returned them.
- Documented on the hint builder why those two cases are deliberately silent, so
  the next reader does not restore them as a missing diagnosis.
- Kept the guard that a malformed negative `HitCount` produces no hint. A
  negative count is not evidence that the line never ran, so it must not reach
  the never-executed guidance. There is an existing test for this, which is what
  caught it.

## Verification
Tests were changed first and confirmed failing before the implementation moved
(4 failing: the expired case of the hint-differentiation table, the hit-when
zero-match test, and the two expired-error tests). After the change:

- `cd cli/project-runner && go test ./internal/projectrunner/ -run 'PausePoint'` — ok.
- `sh scripts/check-go-cli.sh` — exit 0 (format, vet, lint, tests, rebuild across all four Go modules).
- No reference to either removed constant remains under `cli/`.

The two expired-error tests now also assert that `NextActions[0]` is the
recommended next action from the response, so the single remaining copy is
covered rather than merely un-asserted.

https://claude.ai/code/session_01SfrW1agx2EpNUv7NnBuSNY


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2691?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

