### PR TITLE
chore: keep a pause point attached after a hot-reload revert that could not rebuild

### DIFF
--- a/Assets/Tests/Editor/HotReload/HotReloadPatcherTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadPatcherTests.cs
@@ -483,6 +483,48 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
+        /// What: a Harmony rebuild failure while reverting keeps the whole ledger entry of the
+        /// still-patched method, including the transplant locals and preamble length that
+        /// pause-point reads when it joins the shim chain.
+        /// </summary>
+        [Test]
+        public void Revert_WhenHarmonyCannotRebuild_KeepsTransplantLedgerForTheLivePatch()
+        {
+            MethodInfo failing = AccessTools.Method(
+                typeof(HotReloadCoreFixture), nameof(HotReloadCoreFixture.ReplaceableCompute));
+            MethodInfo failingShim = AccessTools.Method(
+                typeof(HotReloadHandwrittenShims), nameof(HotReloadHandwrittenShims.ReplaceableCompute__shim0));
+            Assert.That(
+                HotReloadPatcher.Apply(failing, failingShim, HotReloadPatchShape.Transplant, "Assets/Tests/Fixture.cs").Success,
+                Is.True);
+            Assert.That(
+                HotReloadPausePointCoordination.GetTransplantLocals(failing),
+                Is.Not.Null,
+                "A transplant apply must record the shim locals the test then checks are retained.");
+
+            HotReloadPatcher.UnpatchForTesting = _ => throw new InvalidOperationException("rebuild failed");
+            try
+            {
+                Assert.That(
+                    HotReloadPatcher.Revert(failing, out string _),
+                    Is.EqualTo(HotReloadRevertOutcome.UnpatchFailed));
+            }
+            finally
+            {
+                HotReloadPatcher.UnpatchForTesting = null;
+            }
+
+            Assert.That(
+                HotReloadPausePointCoordination.GetTransplantLocals(failing),
+                Is.Not.Null,
+                "The transpiler is still live, so pause-point must still find its transplant locals.");
+            Assert.That(
+                HotReloadPausePointCoordination.GetTransplantPreambleLength(failing),
+                Is.GreaterThan(0),
+                "The retained entry must keep the preamble length pause-point offsets against.");
+        }
+
+        /// <summary>
         /// What: Revert(method) clears that method's invocation count (RevertAll is not required).
         /// </summary>
         [Test]

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadActivePatchLedger.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadActivePatchLedger.cs
@@ -1,0 +1,215 @@
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Reflection;
+using System.Reflection.Emit;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Records the live hot-reload patch of each method (shim, source file, transplant locals,
+    /// transplant preamble length) so apply and revert can add, drop and restore one method's
+    /// state as a unit.
+    /// </summary>
+    // Why the transplant tables are written before the shim: the transpiler runs inside
+    // Harmony's Patch call and records them there, while the shim and source path are known only
+    // once Patch returns. Recording and activating are therefore separate operations.
+    internal sealed class HotReloadActivePatchLedger
+    {
+        private readonly Dictionary<MethodBase, MethodInfo> _shimByMethod =
+            new Dictionary<MethodBase, MethodInfo>();
+
+        private readonly Dictionary<MethodBase, string> _filePathByMethod =
+            new Dictionary<MethodBase, string>();
+
+        private readonly Dictionary<MethodBase, IReadOnlyList<LocalBuilder>> _transplantLocalsByMethod =
+            new Dictionary<MethodBase, IReadOnlyList<LocalBuilder>>();
+
+        private readonly Dictionary<MethodBase, int> _transplantPreambleLengthByMethod =
+            new Dictionary<MethodBase, int>();
+
+        /// <summary>How many methods have an active patch recorded.</summary>
+        internal int Count => _shimByMethod.Count;
+
+        /// <summary>The recorded method and source path of every active patch.</summary>
+        internal IEnumerable<KeyValuePair<MethodBase, string>> FilePathEntries => _filePathByMethod;
+
+        /// <summary>The recorded method and shim of every active patch.</summary>
+        internal IEnumerable<KeyValuePair<MethodBase, MethodInfo>> ShimEntries => _shimByMethod;
+
+        /// <summary>Whether a patch is recorded for this method.</summary>
+        internal bool IsActive(MethodBase method)
+        {
+            Debug.Assert(method != null, "method must not be null.");
+            return _shimByMethod.ContainsKey(method);
+        }
+
+        /// <summary>The shim that replaced this method, or null when no patch is recorded.</summary>
+        internal MethodInfo FindShim(MethodBase method)
+        {
+            Debug.Assert(method != null, "method must not be null.");
+            return _shimByMethod.TryGetValue(method, out MethodInfo shim) ? shim : null;
+        }
+
+        /// <summary>The source path recorded with this method's patch, or empty when none is.</summary>
+        internal string FindFilePath(MethodBase method)
+        {
+            Debug.Assert(method != null, "method must not be null.");
+            return _filePathByMethod.TryGetValue(method, out string filePath) ? filePath : string.Empty;
+        }
+
+        /// <summary>
+        /// The shim-slot locals of this method's latest transplant rebuild, or null when none was
+        /// recorded.
+        /// </summary>
+        internal IReadOnlyList<LocalBuilder> FindTransplantLocals(MethodBase method)
+        {
+            Debug.Assert(method != null, "method must not be null.");
+            return _transplantLocalsByMethod.TryGetValue(method, out IReadOnlyList<LocalBuilder> locals)
+                ? locals
+                : null;
+        }
+
+        /// <summary>
+        /// How many preamble instructions this method's latest transplant rebuild inserted, or 0
+        /// when none was recorded.
+        /// </summary>
+        internal int FindTransplantPreambleLength(MethodBase method)
+        {
+            Debug.Assert(method != null, "method must not be null.");
+            return _transplantPreambleLengthByMethod.TryGetValue(method, out int length) ? length : 0;
+        }
+
+        /// <summary>The methods that currently have an active patch.</summary>
+        internal List<MethodBase> ListMethods()
+        {
+            return new List<MethodBase>(_shimByMethod.Keys);
+        }
+
+        /// <summary>Records the shim-slot locals a transplant rebuild produced for this method.</summary>
+        internal void RecordTransplantLocals(MethodBase method, IReadOnlyList<LocalBuilder> locals)
+        {
+            Debug.Assert(method != null, "method must not be null.");
+            _transplantLocalsByMethod[method] = locals;
+        }
+
+        /// <summary>Records the preamble length a transplant rebuild produced for this method.</summary>
+        internal void RecordTransplantPreambleLength(MethodBase method, int length)
+        {
+            Debug.Assert(method != null, "method must not be null.");
+            _transplantPreambleLengthByMethod[method] = length;
+        }
+
+        /// <summary>
+        /// Marks this method as patched by the given shim. Any transplant state the rebuild
+        /// already recorded belongs to this same patch and is kept.
+        /// </summary>
+        internal void Activate(MethodBase method, MethodInfo shim, string filePath)
+        {
+            Debug.Assert(method != null, "method must not be null.");
+            Debug.Assert(shim != null, "shim must not be null.");
+            Debug.Assert(filePath != null, "filePath must not be null.");
+            _shimByMethod[method] = shim;
+            _filePathByMethod[method] = filePath;
+        }
+
+        /// <summary>
+        /// Drops everything recorded for this method and hands the removed state back, so a caller
+        /// whose unpatch fails can put the entry back whole. Returns null when no patch was
+        /// recorded — the transplant state is dropped either way, because a failed apply can leave
+        /// it behind with no shim ever registered.
+        /// </summary>
+        internal HotReloadActivePatchEntry Remove(MethodBase method)
+        {
+            Debug.Assert(method != null, "method must not be null.");
+            bool hasLocals = _transplantLocalsByMethod.TryGetValue(
+                method, out IReadOnlyList<LocalBuilder> locals);
+            bool hasPreambleLength = _transplantPreambleLengthByMethod.TryGetValue(
+                method, out int preambleLength);
+            _transplantLocalsByMethod.Remove(method);
+            _transplantPreambleLengthByMethod.Remove(method);
+
+            if (!_shimByMethod.TryGetValue(method, out MethodInfo shim))
+            {
+                _filePathByMethod.Remove(method);
+                return null;
+            }
+
+            string filePath = _filePathByMethod.TryGetValue(method, out string recordedPath)
+                ? recordedPath
+                : null;
+            _shimByMethod.Remove(method);
+            _filePathByMethod.Remove(method);
+            return new HotReloadActivePatchEntry(
+                shim,
+                filePath,
+                hasLocals ? locals : null,
+                hasPreambleLength,
+                preambleLength);
+        }
+
+        /// <summary>Puts back an entry a previous Remove handed out. A null entry restores nothing.</summary>
+        internal void Restore(MethodBase method, HotReloadActivePatchEntry entry)
+        {
+            Debug.Assert(method != null, "method must not be null.");
+            if (entry == null)
+            {
+                return;
+            }
+
+            _shimByMethod[method] = entry.Shim;
+            _filePathByMethod[method] = entry.FilePath ?? string.Empty;
+            if (entry.TransplantLocals != null)
+            {
+                _transplantLocalsByMethod[method] = entry.TransplantLocals;
+            }
+
+            if (entry.HasTransplantPreambleLength)
+            {
+                _transplantPreambleLengthByMethod[method] = entry.TransplantPreambleLength;
+            }
+        }
+
+        /// <summary>Drops every recorded patch.</summary>
+        internal void Clear()
+        {
+            _shimByMethod.Clear();
+            _filePathByMethod.Clear();
+            _transplantLocalsByMethod.Clear();
+            _transplantPreambleLengthByMethod.Clear();
+        }
+    }
+
+    /// <summary>
+    /// One method's patch state as it stood in the ledger, handed back by Remove so a failed
+    /// revert can put it back whole.
+    /// </summary>
+    internal sealed class HotReloadActivePatchEntry
+    {
+        internal HotReloadActivePatchEntry(
+            MethodInfo shim,
+            string filePath,
+            IReadOnlyList<LocalBuilder> transplantLocals,
+            bool hasTransplantPreambleLength,
+            int transplantPreambleLength)
+        {
+            Shim = shim;
+            FilePath = filePath;
+            TransplantLocals = transplantLocals;
+            HasTransplantPreambleLength = hasTransplantPreambleLength;
+            TransplantPreambleLength = transplantPreambleLength;
+        }
+
+        internal MethodInfo Shim { get; }
+
+        internal string FilePath { get; }
+
+        /// <summary>Null when the patch recorded no transplant locals.</summary>
+        internal IReadOnlyList<LocalBuilder> TransplantLocals { get; }
+
+        // Why a flag rather than a sentinel length: 0 is a real preamble length, so restoring an
+        // unrecorded entry as 0 would invent a record the patch never had.
+        internal bool HasTransplantPreambleLength { get; }
+
+        internal int TransplantPreambleLength { get; }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadActivePatchLedger.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadActivePatchLedger.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4e2201a67db2e4437ba365ec98c3cca7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadPatcher.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadPatcher.cs
@@ -37,22 +37,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 new[] { typeof(string) },
                 null);
 
-        // Ledger: key = patched original method, value = the shim whose call replaced it.
-        private static readonly Dictionary<MethodBase, MethodInfo> ShimByMethod =
-            new Dictionary<MethodBase, MethodInfo>();
-
-        // Parallel to ShimByMethod: project-relative (or test) path of the source that was applied.
-        private static readonly Dictionary<MethodBase, string> FilePathByMethod =
-            new Dictionary<MethodBase, string>();
-
-        // Transplant LocalBuilders (shim slot order) from the latest rebuild of each original.
-        private static readonly Dictionary<MethodBase, IReadOnlyList<LocalBuilder>> TransplantLocalsByMethod =
-            new Dictionary<MethodBase, IReadOnlyList<LocalBuilder>>();
-
-        // How many instructions PrependInvocationCountIncrement inserted on the latest transplant
-        // (or delegation) rebuild of each original. Pause-point reads this only for chain-join.
-        private static readonly Dictionary<MethodBase, int> TransplantPreambleLengthByMethod =
-            new Dictionary<MethodBase, int>();
+        // The live patch of each method: the shim whose call replaced it, the project-relative
+        // (or test) path of the applied source, the transplant LocalBuilders in shim slot order,
+        // and how many instructions PrependInvocationCountIncrement inserted on the latest
+        // rebuild. Pause-point reads the last two only for chain-join.
+        private static readonly HotReloadActivePatchLedger Ledger = new HotReloadActivePatchLedger();
 
         // Harmony resolves transpilers as static methods, so the shim cannot be a parameter.
         // Production looks up the target method in the ledger; the apply path also stashes the
@@ -68,13 +57,14 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             // shim pause-point would try to inject original-body indexes into the shim stream.
             HotReloadPausePointCoordination.GetActiveShimForMethod = method =>
             {
-                if (ShimByMethod.TryGetValue(method, out MethodInfo shimMethod))
+                MethodInfo shimMethod = Ledger.FindShim(method);
+                if (shimMethod != null)
                 {
                     return shimMethod;
                 }
 
                 // Why Equals (not ReferenceEquals): match MethodBase equality used by
-                // ShimByMethod.TryGetValue rather than Harmony's instance identity.
+                // the ledger lookup rather than Harmony's instance identity.
                 if (_pendingShimMethod != null
                     && _pendingOriginalMethod != null
                     && method != null
@@ -86,13 +76,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 return null;
             };
             HotReloadPausePointCoordination.GetTransplantLocals = method =>
-                TransplantLocalsByMethod.TryGetValue(method, out IReadOnlyList<LocalBuilder> locals)
-                    ? locals
-                    : null;
+                Ledger.FindTransplantLocals(method);
             HotReloadPausePointCoordination.GetTransplantPreambleLength = method =>
-                TransplantPreambleLengthByMethod.TryGetValue(method, out int length)
-                    ? length
-                    : 0;
+                Ledger.FindTransplantPreambleLength(method);
             HotReloadPausePointCoordination.GetAddedFieldsForType =
                 HotReloadAddedFieldRegistry.GetFieldsForType;
         }
@@ -130,17 +116,14 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 return patchability;
             }
 
-            if (ShimByMethod.ContainsKey(method))
+            if (Ledger.IsActive(method))
             {
                 // Why ledger before Unpatch: same as Revert — during Unpatch Harmony rebuilds
                 // the method and pause-point ChainJoin must see GetActiveShimForMethod == null,
                 // or it injects donor instruction indexes into the restored original IL stream.
                 // Do not RemoveMethod from the shim registry here: ApplyEntry already registered
                 // this method into the new generation before calling Apply.
-                ShimByMethod.Remove(method);
-                FilePathByMethod.Remove(method);
-                TransplantLocalsByMethod.Remove(method);
-                TransplantPreambleLengthByMethod.Remove(method);
+                Ledger.Remove(method);
                 HotReloadInvocationRegistry.Remove(HotReloadMethodKeys.FormatMethodLabel(method));
                 HarmonyInstance.Unpatch(method, HarmonyPatchType.Transpiler, HotReloadConstants.HarmonyId);
                 // Mirror the ledger removal: if the re-Patch below fails, its contained Unpatch
@@ -168,8 +151,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     {
                         priority = Priority.First
                     });
-                ShimByMethod[method] = shimMethodInfo;
-                FilePathByMethod[method] = filePath ?? string.Empty;
+                Ledger.Activate(method, shimMethodInfo, filePath ?? string.Empty);
                 HotReloadPausePointCoordination.OnHotReloadPatchStateChanged?.Invoke(method, true);
             }
             catch (Exception exception)
@@ -180,10 +162,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 // suppress that re-instrumentation (regression vs the old ContainsKey probe).
                 _pendingShimMethod = null;
                 _pendingOriginalMethod = null;
-                // Why Remove before Unpatch: Invoke(true) may have written ShimByMethod before
-                // a later failure; rebuild must not see an active shim (same as re-apply path).
-                ShimByMethod.Remove(method);
-                FilePathByMethod.Remove(method);
+                // Why Remove before Unpatch: Invoke(true) may have activated the ledger entry
+                // before a later failure; rebuild must not see an active shim (same as re-apply
+                // path). Dropping the transplant tables in the same call is safe: with no active
+                // shim, pause-point never picks TransplantChainJoin and so never reads them.
+                Ledger.Remove(method);
                 HotReloadInvocationRegistry.Remove(HotReloadMethodKeys.FormatMethodLabel(method));
                 // User-approved exception to the no-try-catch policy: Harmony emit/JIT
                 // failures cannot be pre-validated (the IL shape is only known inside
@@ -193,8 +176,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 // the transpiler this call registered before failing and rebuilds the
                 // wrapper, restoring the original body (verified by the extern-shim test).
                 HarmonyInstance.Unpatch(method, HarmonyPatchType.Transpiler, HotReloadConstants.HarmonyId);
-                TransplantLocalsByMethod.Remove(method);
-                TransplantPreambleLengthByMethod.Remove(method);
                 // Why after Unpatch: retarget may have already replaced markers onto the shim;
                 // restore them onto the original body now that GetActiveShim is null.
                 HotReloadPausePointCoordination.OnHotReloadPatchStateChanged?.Invoke(method, false);
@@ -232,14 +213,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             // must see those methods as unpatched so armed markers are re-instrumented
             // into the restored original IL. Shim registration clears in the same window
             // so GetActiveShimForMethod / GetShimLookupForFile agree during rebuild.
-            List<MethodBase> revertedMethods = new List<MethodBase>(ShimByMethod.Keys);
-            ShimByMethod.Clear();
-            FilePathByMethod.Clear();
+            List<MethodBase> revertedMethods = Ledger.ListMethods();
+            Ledger.Clear();
             HotReloadFileGenerations.ClearAll();
             HotReloadAddedFieldStore.Clear();
             HotReloadAddedFieldRegistry.ClearAll();
-            TransplantLocalsByMethod.Clear();
-            TransplantPreambleLengthByMethod.Clear();
             HotReloadInvocationRegistry.Clear();
             HotReloadAppliedSourceLedger.ClearAll();
             HotReloadSupersededSignatureRegistry.ClearAll();
@@ -265,27 +243,21 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             Debug.Assert(method != null, "method must not be null.");
 
             failureReason = null;
-            if (!ShimByMethod.TryGetValue(method, out MethodInfo recordedShim))
-            {
-                return HotReloadRevertOutcome.NotPatched;
-            }
-
-            // Kept for the failure path: status, the Auto Refresh hold and the next apply's
-            // "unpatch the previous transpiler first" decision all read these two, so a rebuild
-            // failure that leaves the patch live must leave them describing that patch.
-            string recordedFilePath = FilePathByMethod.TryGetValue(method, out string filePathValue)
-                ? filePathValue
-                : null;
-            ShimByMethod.Remove(method);
-
             // Why Remove before Unpatch: Harmony rebuilds the method during Unpatch, and the
             // pause-point guard sees GetActiveShimForMethod == null so surviving markers are
             // re-instrumented into the restored original IL. Registry removal stays in the same
             // pre-Unpatch window so lookup and ledger never disagree mid-rebuild.
-            FilePathByMethod.Remove(method);
+            // The removed entry is kept for the failure path: status, the Auto Refresh hold, the
+            // next apply's "unpatch the previous transpiler first" decision and pause-point's
+            // chain-join offsets all read it, so a rebuild failure that leaves the patch live must
+            // leave the whole entry describing that patch.
+            HotReloadActivePatchEntry removedEntry = Ledger.Remove(method);
+            if (removedEntry == null)
+            {
+                return HotReloadRevertOutcome.NotPatched;
+            }
+
             HotReloadShimRegistry.RemoveMethod(method);
-            TransplantLocalsByMethod.Remove(method);
-            TransplantPreambleLengthByMethod.Remove(method);
             string methodKey = HotReloadMethodKeys.FormatMethodLabel(method);
             HotReloadInvocationRegistry.Remove(methodKey);
             // Why here, not only RevertAll: RevertUnchangedPatches uses this path, and a
@@ -307,8 +279,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 HotReloadOrchestratorLog.LogHotReloadRevertFailed(methodKey, exception);
                 if (HasLiveHotReloadTranspiler(method))
                 {
-                    ShimByMethod[method] = recordedShim;
-                    FilePathByMethod[method] = recordedFilePath ?? string.Empty;
+                    Ledger.Restore(method, removedEntry);
                     return HotReloadRevertOutcome.UnpatchFailed;
                 }
 
@@ -355,14 +326,14 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         /// <summary>
         /// How many methods currently have an active patch recorded in the ledger.
         /// </summary>
-        public static int ActivePatchCount => ShimByMethod.Count;
+        public static int ActivePatchCount => Ledger.Count;
 
         /// <summary>
         /// Harmony patches plus added-method shims. Domain reload drops both, so Play-entry
         /// warnings and ActivePatchTotal count this sum.
         /// </summary>
         public static int ActiveChangeCount =>
-            ShimByMethod.Count + HotReloadAddedMemberRegistry.Count;
+            Ledger.Count + HotReloadAddedMemberRegistry.Count;
 
         /// <summary>
         /// Returns a sorted list of active patches (method key + source file path) for status
@@ -371,17 +342,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         public static IReadOnlyList<HotReloadActivePatchInfo> DescribeActivePatches()
         {
             List<HotReloadActivePatchInfo> patches =
-                new List<HotReloadActivePatchInfo>(ShimByMethod.Count);
-            foreach (KeyValuePair<MethodBase, MethodInfo> pair in ShimByMethod)
+                new List<HotReloadActivePatchInfo>(Ledger.Count);
+            foreach (KeyValuePair<MethodBase, MethodInfo> pair in Ledger.ShimEntries)
             {
                 string methodKey = HotReloadMethodKeys.FormatMethodLabel(pair.Key);
-                string filePath = string.Empty;
-                if (FilePathByMethod.TryGetValue(pair.Key, out string recordedPath))
-                {
-                    filePath = recordedPath;
-                }
-
-                patches.Add(new HotReloadActivePatchInfo(methodKey, filePath));
+                patches.Add(new HotReloadActivePatchInfo(methodKey, Ledger.FindFilePath(pair.Key)));
             }
 
             patches.Sort(
@@ -390,12 +355,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         }
 
         // Why projectRelativePath, not DescribeActivePatches FilePath filtering by callers:
-        // FilePathByMethod is written with the orchestrator's project-relative path.
+        // the ledger records the orchestrator's project-relative path.
         public static IReadOnlyList<string> ListActiveMethodKeys(string projectRelativePath)
         {
             Debug.Assert(!string.IsNullOrEmpty(projectRelativePath), "projectRelativePath must not be empty.");
             List<string> keys = new List<string>();
-            foreach (KeyValuePair<MethodBase, string> pair in FilePathByMethod)
+            foreach (KeyValuePair<MethodBase, string> pair in Ledger.FilePathEntries)
             {
                 if (!string.Equals(pair.Value, projectRelativePath, StringComparison.Ordinal))
                 {
@@ -411,7 +376,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         public static IReadOnlyList<string> ListActiveFilePaths()
         {
             HashSet<string> paths = new HashSet<string>(StringComparer.Ordinal);
-            foreach (KeyValuePair<MethodBase, string> pair in FilePathByMethod)
+            foreach (KeyValuePair<MethodBase, string> pair in Ledger.FilePathEntries)
             {
                 if (string.IsNullOrEmpty(pair.Value))
                 {
@@ -442,7 +407,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 new List<CodeInstruction>(PatchProcessor.GetOriginalInstructions(shimMethod));
             IReadOnlyList<LocalBuilder> transplantLocals =
                 HotReloadPatchIlRebind.RebindShortFormLocals(shimMethod, generator, transplanted);
-            TransplantLocalsByMethod[original] = transplantLocals;
+            Ledger.RecordTransplantLocals(original, transplantLocals);
             HotReloadPatchIlRebind.RebindLabels(generator, transplanted);
             PrependInvocationCountIncrement(transplanted, original);
             return transplanted;
@@ -495,7 +460,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             int countBeforeInsert = instructions.Count;
             instructions.Insert(0, increment);
             instructions.Insert(0, loadKey);
-            TransplantPreambleLengthByMethod[original] = instructions.Count - countBeforeInsert;
+            Ledger.RecordTransplantPreambleLength(original, instructions.Count - countBeforeInsert);
         }
 
         private static CodeInstruction CreateLoadArgumentInstruction(int slot)
@@ -529,7 +494,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
         private static MethodInfo ResolveShimMethod(MethodBase original)
         {
-            if (ShimByMethod.TryGetValue(original, out MethodInfo shimMethod))
+            MethodInfo shimMethod = Ledger.FindShim(original);
+            if (shimMethod != null)
             {
                 return shimMethod;
             }


### PR DESCRIPTION
## Summary
- A hot reload whose revert fails no longer loses the offsets a pause point needs to stay attached to the still-patched method.

## User Impact
When `uloop hot-reload --revert` cannot rebuild a method, the patch stays
live and the command reports that. Until now the failure path also threw
away two pieces of bookkeeping that belong to the still-live patch: the
transplant locals and the preamble length a pause point reads to join the
shim chain. A pause point armed on that method afterwards could no longer
find them, even though the very patch they describe was still running.

The failed-revert path now puts back everything it took, so the method's
state after a failed revert is the state it had before it.

## Changes
- Extracted the four parallel static dictionaries that tracked a live
  patch (shim, source path, transplant locals, transplant preamble length)
  into one class that owns a method's whole entry.
- `Remove` hands the removed entry back, so the failed-revert path restores
  exactly what it dropped instead of re-adding two of four fields by hand.
- Call ordering is otherwise unchanged: the transplant tables are still
  written during the transpiler run before the shim is known, and removal
  still precedes Harmony's `Unpatch` so surviving markers are re-instrumented
  into the restored original.
- Two ordering differences are deliberate, and are the point of the change:
  - A revert that cannot rebuild now restores the whole entry it removed,
    where it previously put back only the shim and the source path.
  - A failed apply now drops the two transplant tables *before* `Unpatch`
    rather than after it, because dropping the entry is one call. This is
    safe: with no active shim registered, pause-point never selects the
    transplant chain-join path, so nothing reads those two tables in the
    window that moved. The reason is recorded in a comment at the call site.

## Verification
The test was written first and confirmed failing before the implementation
moved. Red output for the new test, with the other 17 in the class passing:

```
FAIL ...HotReloadPatcherTests.Revert_WhenHarmonyCannotRebuild_KeepsTransplantLedgerForTheLivePatch
  MSG   The transpiler is still live, so pause-point must still find its transplant locals.
  Expected: not null
  But was:  null
```

After the change (all single-flight, class/regex filtered):

- `--filter-value HotReloadPatcherTests` — 18/18 pass
- `--filter-value "HotReloadToolTests|HotReloadGroupProcessorTests|HotReloadPausePointCoordinationTests"` — 74/74 pass
- `--filter-value HotReloadShimRegistryTests` — 5/5 pass
- `uloop compile` — 0 errors
- No reference to any of the four removed dictionaries remains under the package.

https://claude.ai/code/session_01SfrW1agx2EpNUv7NnBuSNY
