### PR TITLE
chore: generate hot-reload shim names from a single allocator

### DIFF
--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AddedPropertyClassifier.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AddedPropertyClassifier.cs
@@ -20,7 +20,7 @@ using Microsoft.CodeAnalysis.Text;
 /// </summary>
 internal static class AddedPropertyClassifier
 {
-    internal static (int ShimTypeCounter, int GlobalShimMethodCounter) ClassifyAddedProperties(
+    internal static void ClassifyAddedProperties(
         TypeEmitState typeState,
         SemanticModel semanticModel,
         IAssemblySymbol targetTypesAssemblySymbol,
@@ -33,22 +33,21 @@ internal static class AddedPropertyClassifier
         AddedMethodCatalog addedMethodCatalog,
         AddedFieldCatalog addedFieldCatalog,
         List<WorkerSkipped> skipped,
-        int shimTypeCounter,
-        int globalShimMethodCounter)
+        ShimNameAllocator shimNames)
     {
         INamedTypeSymbol compiledType = CompiledMemberMatcher.FindCompiledType(
             typeState.TypeSymbol,
             targetTypesAssemblySymbol);
         if (compiledType == null)
         {
-            return (shimTypeCounter, globalShimMethodCounter);
+            return;
         }
 
         typeState.CompiledType = compiledType;
         foreach (PropertyDeclarationSyntax declaration in typeState.TypeDeclaration.Members
             .OfType<PropertyDeclarationSyntax>())
         {
-            (shimTypeCounter, globalShimMethodCounter) = ClassifyProperty(
+            ClassifyProperty(
                 declaration,
                 typeState,
                 compiledType,
@@ -63,14 +62,11 @@ internal static class AddedPropertyClassifier
                 addedMethodCatalog,
                 addedFieldCatalog,
                 skipped,
-                shimTypeCounter,
-                globalShimMethodCounter);
+                shimNames);
         }
-
-        return (shimTypeCounter, globalShimMethodCounter);
     }
 
-    private static (int ShimTypeCounter, int GlobalShimMethodCounter) ClassifyProperty(
+    private static void ClassifyProperty(
         PropertyDeclarationSyntax declaration,
         TypeEmitState typeState,
         INamedTypeSymbol compiledType,
@@ -85,8 +81,7 @@ internal static class AddedPropertyClassifier
         AddedMethodCatalog addedMethodCatalog,
         AddedFieldCatalog addedFieldCatalog,
         List<WorkerSkipped> skipped,
-        int shimTypeCounter,
-        int globalShimMethodCounter)
+        ShimNameAllocator shimNames)
     {
         AddedPropertyCandidate candidate = CreateCandidateOrNull(
             declaration,
@@ -98,7 +93,7 @@ internal static class AddedPropertyClassifier
             addedMethodCatalog);
         if (candidate == null)
         {
-            return (shimTypeCounter, globalShimMethodCounter);
+            return;
         }
 
         MarkClassifiedAccessors(candidate, addedMethodCatalog);
@@ -108,7 +103,7 @@ internal static class AddedPropertyClassifier
                 ?? AddedPropertySkipReasons.UnavailableAddedProperty;
             addedPropertyCatalog.Register(candidate.Binding);
             AppendSkippedAccessors(candidate.Binding, skipped);
-            return (shimTypeCounter, globalShimMethodCounter);
+            return;
         }
 
         if (candidate.Binding.IsAuto)
@@ -116,26 +111,26 @@ internal static class AddedPropertyClassifier
             RegisterAutoPropertyStore(candidate.Binding, addedFieldCatalog);
         }
 
-        (ShimTypeBuilder shimType, int nextShimTypeCounter) = OrdinaryMethodQueue.EnsureShimType(
+        ShimTypeBuilder shimType = OrdinaryMethodQueue.EnsureShimType(
             typeState,
             root,
             assemblyGlobalUsings,
             shimTypes,
-            shimTypeCounter);
+            shimNames);
+        // Why the getter name is taken first: the accessors are numbered getter before setter,
+        // and the numbers appear in the emitted shim names.
         candidate.Binding.Getter = CreateBinding(
             candidate.GetterKey,
             candidate.Binding.Symbol.GetMethod,
             shimType,
-            globalShimMethodCounter);
-        globalShimMethodCounter++;
+            shimNames.NextShimMethodName(candidate.Binding.Symbol.GetMethod.Name));
         if (candidate.Binding.Symbol.SetMethod != null)
         {
             candidate.Binding.Setter = CreateBinding(
                 candidate.SetterKey,
                 candidate.Binding.Symbol.SetMethod,
                 shimType,
-                globalShimMethodCounter);
-            globalShimMethodCounter++;
+                shimNames.NextShimMethodName(candidate.Binding.Symbol.SetMethod.Name));
         }
 
         addedMethodCatalog.Register(candidate.Binding.Getter);
@@ -145,7 +140,6 @@ internal static class AddedPropertyClassifier
         }
 
         addedPropertyCatalog.Register(candidate.Binding);
-        return (nextShimTypeCounter, globalShimMethodCounter);
     }
 
     private static AddedPropertyCandidate CreateCandidateOrNull(
@@ -345,13 +339,13 @@ internal static class AddedPropertyClassifier
         string methodKey,
         IMethodSymbol accessorSymbol,
         ShimTypeBuilder shimType,
-        int shimMethodCounter)
+        string shimMethodName)
     {
         return new AddedMethodBinding
         {
             MethodKey = methodKey,
             ShimTypeName = shimType.ShimTypeName,
-            ShimMethodName = accessorSymbol.Name + "__shim" + shimMethodCounter,
+            ShimMethodName = shimMethodName,
             NamespaceName = shimType.NamespaceName,
             IsStatic = accessorSymbol.IsStatic,
             ParameterCount = accessorSymbol.Parameters.Length

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/OrdinaryMethodQueue.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/OrdinaryMethodQueue.cs
@@ -17,7 +17,7 @@ using Microsoft.CodeAnalysis.Text;
 
 internal static class OrdinaryMethodQueue
 {
-    internal static (int ShimTypeCounter, int GlobalShimMethodCounter) QueueOrdinaryMethod(
+    internal static void QueueOrdinaryMethod(
         MethodDeclarationSyntax methodDeclaration,
         TypeEmitState typeState,
         SemanticModel semanticModel,
@@ -35,13 +35,12 @@ internal static class OrdinaryMethodQueue
         List<string> declarationDriftWarnings,
         List<WorkerRemovedMember> removedMembers,
         List<WorkerRemovedMethodSignature> removedMethodSignatures,
-        int shimTypeCounter,
-        int globalShimMethodCounter)
+        ShimNameAllocator shimNames)
     {
         IMethodSymbol methodSymbol = semanticModel.GetDeclaredSymbol(methodDeclaration);
         if (methodSymbol == null)
         {
-            return (shimTypeCounter, globalShimMethodCounter);
+            return;
         }
 
         string[] parameterTypeFullNames = methodSymbol.Parameters
@@ -67,7 +66,7 @@ internal static class OrdinaryMethodQueue
             plainCurrentMethodMap,
             addedMethodCatalog))
         {
-            return (shimTypeCounter, globalShimMethodCounter);
+            return;
         }
 
         string syntaxMethodKey = WorkerSyntaxIndex.BuildSyntaxMethodKey(
@@ -85,7 +84,7 @@ internal static class OrdinaryMethodQueue
             addedMethodCatalog,
             skipped))
         {
-            return (shimTypeCounter, globalShimMethodCounter);
+            return;
         }
 
         if (TryRecordUnchangedOrdinaryMethod(
@@ -99,7 +98,7 @@ internal static class OrdinaryMethodQueue
             plainCurrentMethodMap,
             unchangedMethods))
         {
-            return (shimTypeCounter, globalShimMethodCounter);
+            return;
         }
 
         MethodTransformDecision decision = DecideOrdinaryMethodTransform(
@@ -128,10 +127,10 @@ internal static class OrdinaryMethodQueue
                     plainCurrentMethodMap);
             }
 
-            return (shimTypeCounter, globalShimMethodCounter);
+            return;
         }
 
-        return QueueDecidedOrdinaryMethod(
+        QueueDecidedOrdinaryMethod(
             methodDeclaration,
             methodSymbol,
             decision,
@@ -150,8 +149,7 @@ internal static class OrdinaryMethodQueue
             declarationDriftWarnings,
             removedMembers,
             removedMethodSignatures,
-            shimTypeCounter,
-            globalShimMethodCounter);
+            shimNames);
     }
 
     internal static (bool IsAddedMethod, bool ReplacesCompiledMethod) ClassifyOrdinaryMethodAddedState(
@@ -321,7 +319,7 @@ internal static class OrdinaryMethodQueue
         return decision;
     }
 
-    internal static (int ShimTypeCounter, int GlobalShimMethodCounter) QueueDecidedOrdinaryMethod(
+    internal static void QueueDecidedOrdinaryMethod(
         MethodDeclarationSyntax methodDeclaration,
         IMethodSymbol methodSymbol,
         MethodTransformDecision decision,
@@ -340,18 +338,15 @@ internal static class OrdinaryMethodQueue
         List<string> declarationDriftWarnings,
         List<WorkerRemovedMember> removedMembers,
         List<WorkerRemovedMethodSignature> removedMethodSignatures,
-        int shimTypeCounter,
-        int globalShimMethodCounter)
+        ShimNameAllocator shimNames)
     {
-        ShimTypeBuilder shimType;
-        (shimType, shimTypeCounter) = EnsureShimType(
+        ShimTypeBuilder shimType = EnsureShimType(
             typeState,
             root,
             assemblyGlobalUsings,
             shimTypes,
-            shimTypeCounter);
-        string shimMethodName = methodSymbol.Name + "__shim" + globalShimMethodCounter;
-        globalShimMethodCounter++;
+            shimNames);
+        string shimMethodName = shimNames.NextShimMethodName(methodSymbol.Name);
 
         FileLinePositionSpan originalSpan = methodDeclaration.GetLocation().GetLineSpan();
         QueuedShimMethod queued = new QueuedShimMethod
@@ -409,24 +404,21 @@ internal static class OrdinaryMethodQueue
                 methodSymbol,
                 declarationDriftWarnings);
         }
-
-        return (shimTypeCounter, globalShimMethodCounter);
     }
 
-    internal static (ShimTypeBuilder ShimType, int ShimTypeCounter) EnsureShimType(
+    internal static ShimTypeBuilder EnsureShimType(
         TypeEmitState typeState,
         CompilationUnitSyntax root,
         List<UsingDirectiveSyntax> assemblyGlobalUsings,
         List<ShimTypeBuilder> shimTypes,
-        int shimTypeCounter)
+        ShimNameAllocator shimNames)
     {
         if (typeState.CurrentShimType != null)
         {
-            return (typeState.CurrentShimType, shimTypeCounter);
+            return typeState.CurrentShimType;
         }
 
-        string shimTypeName = typeState.TypeSymbol.Name + "_UloopHotReloadShims_" + shimTypeCounter;
-        shimTypeCounter++;
+        string shimTypeName = shimNames.NextShimTypeName(typeState.TypeSymbol.Name);
         string namespaceName = typeState.TypeSymbol.ContainingNamespace == null
             || typeState.TypeSymbol.ContainingNamespace.IsGlobalNamespace
             ? string.Empty
@@ -437,7 +429,7 @@ internal static class OrdinaryMethodQueue
             WorkerUsingCollector.CollectUsingsForType(root, typeState.TypeDeclaration, assemblyGlobalUsings),
             typeState.SourceUnit.Input.ProjectRelativePath);
         shimTypes.Add(typeState.CurrentShimType);
-        return (typeState.CurrentShimType, shimTypeCounter);
+        return typeState.CurrentShimType;
     }
 
     internal static void SkipAllMethodsOnUncompiledType(

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/PropertyGetterEmitter.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/PropertyGetterEmitter.cs
@@ -17,7 +17,7 @@ using Microsoft.CodeAnalysis.Text;
 
 internal static class PropertyGetterEmitter
 {
-    internal static (int ShimTypeCounter, int GlobalShimMethodCounter) EmitPropertyGettersForType(
+    internal static void EmitPropertyGettersForType(
         TypeEmitState typeState,
         AddedMethodCatalog addedMethodCatalog,
         AddedFieldCatalog addedFieldCatalog,
@@ -28,8 +28,7 @@ internal static class PropertyGetterEmitter
         List<WorkerUnchangedMethod> unchangedMethods,
         List<ShimTypeBuilder> shimTypes,
         List<UsingDirectiveSyntax> assemblyGlobalUsings,
-        int shimTypeCounter,
-        int globalShimMethodCounter)
+        ShimNameAllocator shimNames)
     {
         SemanticModel semanticModel = typeState.SourceUnit.SemanticModel;
         CompilationUnitSyntax root = typeState.SourceUnit.BindingRoot;
@@ -53,8 +52,7 @@ internal static class PropertyGetterEmitter
                 continue;
             }
 
-            (ShimTypeBuilder nextShimType, int nextShimTypeCounter, int nextGlobalShimMethodCounter) =
-                AppendPropertyGetterEntry(
+            typeState.CurrentShimType = AppendPropertyGetterEntry(
                     propertyDeclaration,
                     typeState.TypeDeclaration,
                     typeState.TypeSymbol,
@@ -71,24 +69,17 @@ internal static class PropertyGetterEmitter
                     skipped,
                     unchangedMethods,
                     shimTypes,
-                    shimTypeCounter,
-                    globalShimMethodCounter,
+                    shimNames,
                     typeState.CurrentShimType,
                     assemblyGlobalUsings,
                     addedMethodCatalog,
                     addedFieldCatalog,
                     addedPropertyCatalog);
-            typeState.CurrentShimType = nextShimType;
-            shimTypeCounter = nextShimTypeCounter;
-            globalShimMethodCounter = nextGlobalShimMethodCounter;
         }
-
-        return (shimTypeCounter, globalShimMethodCounter);
     }
 
     // What: emit a get_<Name> entry / unchanged row / skip for one property with a getter body.
-    internal static (ShimTypeBuilder CurrentShimType, int ShimTypeCounter, int GlobalShimMethodCounter)
-        AppendPropertyGetterEntry(
+    internal static ShimTypeBuilder AppendPropertyGetterEntry(
             PropertyDeclarationSyntax propertyDeclaration,
             TypeDeclarationSyntax typeDeclaration,
             INamedTypeSymbol typeSymbol,
@@ -105,8 +96,7 @@ internal static class PropertyGetterEmitter
             List<WorkerSkipped> skipped,
             List<WorkerUnchangedMethod> unchangedMethods,
             List<ShimTypeBuilder> shimTypes,
-            int shimTypeCounter,
-            int globalShimMethodCounter,
+            ShimNameAllocator shimNames,
             ShimTypeBuilder currentShimType,
             List<UsingDirectiveSyntax> assemblyGlobalUsings,
             AddedMethodCatalog addedMethodCatalog,
@@ -116,7 +106,7 @@ internal static class PropertyGetterEmitter
         IPropertySymbol propertySymbol = semanticModel.GetDeclaredSymbol(propertyDeclaration);
         if (propertySymbol == null || propertySymbol.GetMethod == null)
         {
-            return (currentShimType, shimTypeCounter, globalShimMethodCounter);
+            return currentShimType;
         }
 
         string propertyKey = AddedPropertyCatalog.FormatPropertyKey(
@@ -124,14 +114,14 @@ internal static class PropertyGetterEmitter
             propertySymbol.Name);
         if (addedPropertyCatalog.IsClassifiedAdded(propertyKey))
         {
-            return (currentShimType, shimTypeCounter, globalShimMethodCounter);
+            return currentShimType;
         }
 
         (bool hasGetterBody, AccessorDeclarationSyntax getAccessor) =
             PropertyGetterClassifier.TryGetPropertyGetterBody(propertyDeclaration);
         if (!hasGetterBody)
         {
-            return (currentShimType, shimTypeCounter, globalShimMethodCounter);
+            return currentShimType;
         }
 
         IMethodSymbol getterSymbol = propertySymbol.GetMethod;
@@ -143,7 +133,7 @@ internal static class PropertyGetterEmitter
             getterSymbol.Arity);
         if (input.ExcludedMethodKeys.Contains(methodKey))
         {
-            return (currentShimType, shimTypeCounter, globalShimMethodCounter);
+            return currentShimType;
         }
 
         if (PropertyGetterClassifier.TryRecordUnchangedPropertyGetter(
@@ -158,7 +148,7 @@ internal static class PropertyGetterEmitter
             parameterTypeFullNames,
             unchangedMethods))
         {
-            return (currentShimType, shimTypeCounter, globalShimMethodCounter);
+            return currentShimType;
         }
 
         if (propertyDeclaration.ExplicitInterfaceSpecifier != null)
@@ -169,7 +159,7 @@ internal static class PropertyGetterEmitter
                 Method = WorkerMethodKeys.FormatMethodLabel(getterSymbol),
                 Reason = "Explicit interface implementations are skipped in v1."
             });
-            return (currentShimType, shimTypeCounter, globalShimMethodCounter);
+            return currentShimType;
         }
 
         // Why body stays on the property tree: SemanticModel rejects nodes re-parented onto a
@@ -191,7 +181,7 @@ internal static class PropertyGetterEmitter
             skipped);
         if (skipGetter)
         {
-            return (currentShimType, shimTypeCounter, globalShimMethodCounter);
+            return currentShimType;
         }
 
         return EmitPropertyGetterShim(
@@ -208,8 +198,7 @@ internal static class PropertyGetterEmitter
             sourceProjectRelativePath,
             entries,
             shimTypes,
-            shimTypeCounter,
-            globalShimMethodCounter,
+            shimNames,
             currentShimType,
             assemblyGlobalUsings,
             addedMethodCatalog,
@@ -217,8 +206,7 @@ internal static class PropertyGetterEmitter
             addedPropertyCatalog);
     }
 
-    internal static (ShimTypeBuilder CurrentShimType, int ShimTypeCounter, int GlobalShimMethodCounter)
-        EmitPropertyGetterShim(
+    internal static ShimTypeBuilder EmitPropertyGetterShim(
             PropertyDeclarationSyntax propertyDeclaration,
             TypeDeclarationSyntax typeDeclaration,
             INamedTypeSymbol typeSymbol,
@@ -232,8 +220,7 @@ internal static class PropertyGetterEmitter
             string sourceProjectRelativePath,
             List<WorkerEntry> entries,
             List<ShimTypeBuilder> shimTypes,
-            int shimTypeCounter,
-            int globalShimMethodCounter,
+            ShimNameAllocator shimNames,
             ShimTypeBuilder currentShimType,
             List<UsingDirectiveSyntax> assemblyGlobalUsings,
             AddedMethodCatalog addedMethodCatalog,
@@ -242,8 +229,7 @@ internal static class PropertyGetterEmitter
     {
         if (currentShimType == null)
         {
-            string shimTypeName = typeSymbol.Name + "_UloopHotReloadShims_" + shimTypeCounter;
-            shimTypeCounter++;
+            string shimTypeName = shimNames.NextShimTypeName(typeSymbol.Name);
             string namespaceName = typeSymbol.ContainingNamespace == null
                 || typeSymbol.ContainingNamespace.IsGlobalNamespace
                 ? string.Empty
@@ -256,8 +242,7 @@ internal static class PropertyGetterEmitter
             shimTypes.Add(currentShimType);
         }
 
-        string shimMethodName = getterSymbol.Name + "__shim" + globalShimMethodCounter;
-        globalShimMethodCounter++;
+        string shimMethodName = shimNames.NextShimMethodName(getterSymbol.Name);
 
         FileLinePositionSpan originalSpan = propertyDeclaration.GetLocation().GetLineSpan();
         int sourceStartLine = originalSpan.StartLinePosition.Line + 1;
@@ -299,7 +284,7 @@ internal static class PropertyGetterEmitter
             LifecycleNote = null
         });
 
-        return (currentShimType, shimTypeCounter, globalShimMethodCounter);
+        return currentShimType;
     }
 
     // What: rewrite a getter body while it is still in the bound tree, then wrap as a shim method.

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/ShimMethodEmitter.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/ShimMethodEmitter.cs
@@ -17,7 +17,7 @@ using Microsoft.CodeAnalysis.Text;
 
 internal static class ShimMethodEmitter
 {
-    internal static (int ShimTypeCounter, int GlobalShimMethodCounter) EmitQueuedMethodsAndPropertyGetters(
+    internal static void EmitQueuedMethodsAndPropertyGetters(
         List<TypeEmitState> typeEmitStates,
         AddedMethodCatalog addedMethodCatalog,
         AddedFieldCatalog addedFieldCatalog,
@@ -28,8 +28,7 @@ internal static class ShimMethodEmitter
         List<WorkerUnchangedMethod> unchangedMethods,
         List<ShimTypeBuilder> shimTypes,
         List<UsingDirectiveSyntax> assemblyGlobalUsings,
-        int shimTypeCounter,
-        int globalShimMethodCounter)
+        ShimNameAllocator shimNames)
     {
         foreach (TypeEmitState typeState in typeEmitStates)
         {
@@ -45,7 +44,7 @@ internal static class ShimMethodEmitter
                 addedMethodCatalog,
                 addedFieldCatalog,
                 entries);
-            (shimTypeCounter, globalShimMethodCounter) = PropertyGetterEmitter.EmitPropertyGettersForType(
+            PropertyGetterEmitter.EmitPropertyGettersForType(
                 typeState,
                 addedMethodCatalog,
                 addedFieldCatalog,
@@ -56,11 +55,8 @@ internal static class ShimMethodEmitter
                 unchangedMethods,
                 shimTypes,
                 assemblyGlobalUsings,
-                shimTypeCounter,
-                globalShimMethodCounter);
+                shimNames);
         }
-
-        return (shimTypeCounter, globalShimMethodCounter);
     }
 
     internal static void EmitQueuedMethods(

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/ShimNameAllocator.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/ShimNameAllocator.cs
@@ -1,0 +1,27 @@
+/// <summary>
+/// Hands out the shim type and shim method names of one worker run.
+/// </summary>
+// Why one object for the whole group rather than a counter per file: two files of a group may
+// declare types of the same name, so both counters must keep running across units for the names
+// they produce to stay unique.
+internal sealed class ShimNameAllocator
+{
+    private int _shimTypeCounter;
+    private int _shimMethodCounter;
+
+    /// <summary>The next shim type name for a host type, consuming one type number.</summary>
+    internal string NextShimTypeName(string hostTypeName)
+    {
+        string shimTypeName = hostTypeName + "_UloopHotReloadShims_" + _shimTypeCounter;
+        _shimTypeCounter++;
+        return shimTypeName;
+    }
+
+    /// <summary>The next shim method name for a member, consuming one method number.</summary>
+    internal string NextShimMethodName(string memberName)
+    {
+        string shimMethodName = memberName + "__shim" + _shimMethodCounter;
+        _shimMethodCounter++;
+        return shimMethodName;
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TypeEmitPlanner.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TypeEmitPlanner.cs
@@ -17,8 +17,7 @@ using Microsoft.CodeAnalysis.Text;
 
 internal static class TypeEmitPlanner
 {
-    internal static (List<TypeEmitState> TypeEmitStates, int ShimTypeCounter, int GlobalShimMethodCounter)
-        QueueAllTypeEmitStates(
+    internal static List<TypeEmitState> QueueAllTypeEmitStates(
             WorkerSourceUnit sourceUnit,
             IAssemblySymbol targetTypesAssemblySymbol,
             WorkerInput input,
@@ -32,8 +31,7 @@ internal static class TypeEmitPlanner
             List<string> declarationDriftWarnings,
             List<WorkerRemovedMember> removedMembers,
             List<WorkerRemovedMethodSignature> removedMethodSignatures,
-            int shimTypeCounter,
-            int globalShimMethodCounter)
+            ShimNameAllocator shimNames)
     {
         CompilationUnitSyntax root = sourceUnit.BindingRoot;
         SemanticModel semanticModel = sourceUnit.SemanticModel;
@@ -56,7 +54,7 @@ internal static class TypeEmitPlanner
                 TypeSymbol = typeSymbol,
                 TypeMetadataNameFromSyntax = typeMetadataNameFromSyntax
             };
-            (shimTypeCounter, globalShimMethodCounter) = AddedPropertyClassifier.ClassifyAddedProperties(
+            AddedPropertyClassifier.ClassifyAddedProperties(
                 typeState,
                 semanticModel,
                 targetTypesAssemblySymbol,
@@ -69,8 +67,7 @@ internal static class TypeEmitPlanner
                 addedMethodCatalog,
                 addedFieldCatalog,
                 skipped,
-                shimTypeCounter,
-                globalShimMethodCounter);
+                shimNames);
 
             // Existing property setters/init and all indexer accessors with bodies stay Skipped.
             // Added properties were classified above and must not receive duplicate skip rows.
@@ -111,7 +108,7 @@ internal static class TypeEmitPlanner
                 plainCurrentOperatorMap,
                 plainCurrentEventMap);
 
-            (int nextShimTypeCounter, int nextGlobalShimMethodCounter) = QueueTypeMethods(
+            QueueTypeMethods(
                 typeState,
                 semanticModel,
                 targetTypesAssemblySymbol,
@@ -129,17 +126,14 @@ internal static class TypeEmitPlanner
                 declarationDriftWarnings,
                 removedMembers,
                 removedMethodSignatures,
-                shimTypeCounter,
-                globalShimMethodCounter);
-            shimTypeCounter = nextShimTypeCounter;
-            globalShimMethodCounter = nextGlobalShimMethodCounter;
+                shimNames);
             typeEmitStates.Add(typeState);
         }
 
-        return (typeEmitStates, shimTypeCounter, globalShimMethodCounter);
+        return typeEmitStates;
     }
 
-    internal static (int ShimTypeCounter, int GlobalShimMethodCounter) QueueTypeMethods(
+    internal static void QueueTypeMethods(
         TypeEmitState typeState,
         SemanticModel semanticModel,
         IAssemblySymbol targetTypesAssemblySymbol,
@@ -157,14 +151,13 @@ internal static class TypeEmitPlanner
         List<string> declarationDriftWarnings,
         List<WorkerRemovedMember> removedMembers,
         List<WorkerRemovedMethodSignature> removedMethodSignatures,
-        int shimTypeCounter,
-        int globalShimMethodCounter)
+        ShimNameAllocator shimNames)
     {
         INamedTypeSymbol compiledType = CompiledMemberMatcher.FindCompiledType(typeState.TypeSymbol, targetTypesAssemblySymbol);
         if (compiledType == null)
         {
             OrdinaryMethodQueue.SkipAllMethodsOnUncompiledType(typeState, semanticModel, skipped, addedMethodCatalog);
-            return (shimTypeCounter, globalShimMethodCounter);
+            return;
         }
 
         typeState.CompiledType = compiledType;
@@ -180,7 +173,7 @@ internal static class TypeEmitPlanner
         foreach (MethodDeclarationSyntax methodDeclaration in typeState.TypeDeclaration.Members
             .OfType<MethodDeclarationSyntax>())
         {
-            (shimTypeCounter, globalShimMethodCounter) = OrdinaryMethodQueue.QueueOrdinaryMethod(
+            OrdinaryMethodQueue.QueueOrdinaryMethod(
                 methodDeclaration,
                 typeState,
                 semanticModel,
@@ -198,10 +191,7 @@ internal static class TypeEmitPlanner
                 declarationDriftWarnings,
                 removedMembers,
                 removedMethodSignatures,
-                shimTypeCounter,
-                globalShimMethodCounter);
+                shimNames);
         }
-
-        return (shimTypeCounter, globalShimMethodCounter);
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/WorkerGroupPipeline.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/WorkerGroupPipeline.cs
@@ -122,13 +122,10 @@ internal static class WorkerGroupPipeline
         AddedMethodCatalog addedMethodCatalog = new AddedMethodCatalog();
         AddedFieldCatalog addedFieldCatalog = new AddedFieldCatalog();
         AddedPropertyCatalog addedPropertyCatalog = new AddedPropertyCatalog();
-        // Why counters run across units: shim type and method names must stay unique when two
-        // files of the group declare types of the same name.
-        int shimTypeCounter = 0;
-        int globalShimMethodCounter = 0;
+        ShimNameAllocator shimNames = new ShimNameAllocator();
         foreach (WorkerSourceUnit unit in transformUnits)
         {
-            (shimTypeCounter, globalShimMethodCounter) = QueueUnit(
+            QueueUnit(
                 unit,
                 input,
                 parseOptions,
@@ -140,8 +137,7 @@ internal static class WorkerGroupPipeline
                 addedPropertyCatalog,
                 skipped,
                 unchangedMethods,
-                shimTypeCounter,
-                globalShimMethodCounter);
+                shimNames);
         }
 
         foreach (WorkerSourceUnit unit in transformUnits)
@@ -184,8 +180,7 @@ internal static class WorkerGroupPipeline
             unchangedMethods,
             shimTypes,
             assemblyGlobalUsings,
-            shimTypeCounter,
-            globalShimMethodCounter);
+            shimNames);
 
         foreach (WorkerSourceUnit unit in transformUnits)
         {
@@ -341,7 +336,7 @@ internal static class WorkerGroupPipeline
 
     // Everything one unit contributes before the group-wide guard and emit: its drift warnings,
     // its baseline, and the queued shim methods of its types.
-    private static (int ShimTypeCounter, int GlobalShimMethodCounter) QueueUnit(
+    private static void QueueUnit(
         WorkerSourceUnit unit,
         WorkerInput input,
         CSharpParseOptions parseOptions,
@@ -353,8 +348,7 @@ internal static class WorkerGroupPipeline
         AddedPropertyCatalog addedPropertyCatalog,
         List<WorkerSkipped> skipped,
         List<WorkerUnchangedMethod> unchangedMethods,
-        int shimTypeCounter,
-        int globalShimMethodCounter)
+        ShimNameAllocator shimNames)
     {
         unit.DeclarationDriftWarnings.AddRange(
             ConstDriftCollector.CollectConstDriftWarnings(
@@ -374,25 +368,22 @@ internal static class WorkerGroupPipeline
             parseOptions,
             unit.PlainRoot);
 
-        (List<TypeEmitState> typeEmitStates, int nextShimTypeCounter, int nextGlobalShimMethodCounter) =
-            TypeEmitPlanner.QueueAllTypeEmitStates(
-                unit,
-                targetTypesAssemblySymbol,
-                input,
-                assemblyGlobalUsings,
-                shimTypes,
-                addedMethodCatalog,
-                addedFieldCatalog,
-                addedPropertyCatalog,
-                skipped,
-                unchangedMethods,
-                unit.DeclarationDriftWarnings,
-                unit.RemovedMembers,
-                unit.RemovedMethodSignatures,
-                shimTypeCounter,
-                globalShimMethodCounter);
+        List<TypeEmitState> typeEmitStates = TypeEmitPlanner.QueueAllTypeEmitStates(
+            unit,
+            targetTypesAssemblySymbol,
+            input,
+            assemblyGlobalUsings,
+            shimTypes,
+            addedMethodCatalog,
+            addedFieldCatalog,
+            addedPropertyCatalog,
+            skipped,
+            unchangedMethods,
+            unit.DeclarationDriftWarnings,
+            unit.RemovedMembers,
+            unit.RemovedMethodSignatures,
+            shimNames);
         unit.TypeEmitStates = typeEmitStates;
-        return (nextShimTypeCounter, nextGlobalShimMethodCounter);
     }
 
     private static void AppendOutsideMethodBodyDriftWarnings(


### PR DESCRIPTION
## Summary
- Internal cleanup in the hot-reload transform worker. No user-visible change: the generated shim names, and the order they are handed out in, are identical.

## User Impact
None. This is a refactoring of how the worker names the shim types and shim
methods it generates. The names themselves, and the numbers in them, come
out exactly as before — including the getter-before-setter order on an added
property, which several tests assert as literal strings.

## Changes
The two counters behind every generated name were threaded by hand through
seven functions across six files: a pair of `int` parameters, returned as a
tuple that each caller had to destructure and re-thread into the next call.
Four call sites built a name and then incremented a counter on the following
line, so the numbering order held only as long as every reader kept that
pairing intact.

- Added `ShimNameAllocator`, which owns both counters and hands out a
  finished name, consuming its own number.
- The parameter pair collapses to one object. The tuple returns become
  `void`, or the single value the caller actually wanted
  (`List<TypeEmitState>`, `ShimTypeBuilder`).
- No call site reads or increments a counter any more.

One object serves the whole group rather than one per file, as before: two
files of a group may declare types of the same name, so both counters have
to keep running across units for the names to stay unique. That reason now
lives on the allocator instead of on a local variable.

## Verification
The worker is built out of process and is not covered by `uloop compile`, so
it is exercised through the test suites that run it. All run single-flight,
filtered by class:

- `TransformWorkerClientTests` — 77/77
- `TransformWorkerAddedMemberTests` — 57/57
- `TransformWorkerAddedPropertyTests` — 40/40
- `TransformWorkerAddedFieldTests` — 66/66
- `TransformWorkerIntroducedTypeTests` — 23/23
- `TransformWorkerIntroducedTypeBindingTests` — 14/14
- `HotReloadToolTests` — 59/59

Several of these assert generated shim names as literal strings, so a break
in the numbering order would fail them rather than pass silently.

- `uloop compile` — 0 errors
- `scripts/check-code-complexity.sh` — 0 Go issues, no CA1502 findings
- No counter parameter, field, or tuple element remains outside the allocator.

https://claude.ai/code/session_01SfrW1agx2EpNUv7NnBuSNY


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2693?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

