### PR TITLE
fix: hot reload now reports the compiler errors of a failed introduced-type compilation with the file they belong to

### DIFF
--- a/.agents/skills/uloop-hot-reload/references/introduced-types.md
+++ b/.agents/skills/uloop-hot-reload/references/introduced-types.md
@@ -67,8 +67,10 @@ method **of** an introduced type is out of scope for this stage.
 Any refused shape above; use of the type from another assembly, from a file that is neither
 passed to this reload nor already hot-reloaded, or from `uloop execute-dynamic-code`; anything
 that reaches the type through Unity (serialization, `[SerializeField]`, Inspector,
-`AddComponent`, `CreateInstance`, message discovery); and any new or changed `.asmdef` /
-`.asmref`.
+`AddComponent`, `CreateInstance`, message discovery); a call to a member an earlier or the same
+reload *added* to a compiled type (an `Added` row), because introduced types compile against the
+compiled assemblies and retained artifacts only, so the compile fails naming the missing member;
+and any new or changed `.asmdef` / `.asmref`.
 
 ## File selection and new files
 

--- a/.claude/skills/uloop-hot-reload/references/introduced-types.md
+++ b/.claude/skills/uloop-hot-reload/references/introduced-types.md
@@ -67,8 +67,10 @@ method **of** an introduced type is out of scope for this stage.
 Any refused shape above; use of the type from another assembly, from a file that is neither
 passed to this reload nor already hot-reloaded, or from `uloop execute-dynamic-code`; anything
 that reaches the type through Unity (serialization, `[SerializeField]`, Inspector,
-`AddComponent`, `CreateInstance`, message discovery); and any new or changed `.asmdef` /
-`.asmref`.
+`AddComponent`, `CreateInstance`, message discovery); a call to a member an earlier or the same
+reload *added* to a compiled type (an `Added` row), because introduced types compile against the
+compiled assemblies and retained artifacts only, so the compile fails naming the missing member;
+and any new or changed `.asmdef` / `.asmref`.
 
 ## File selection and new files
 

--- a/Assets/Tests/Editor/HotReload/HotReloadIntroducedTypeActivationTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadIntroducedTypeActivationTests.cs
@@ -521,6 +521,51 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
+        /// Verifies that a reload whose introduced type does not compile reports the compiler
+        /// error itself, with the file and the source position it belongs to, instead of one row
+        /// that names neither the declaration nor what was wrong with it.
+        /// </summary>
+        [Test]
+        public async Task Build_IntroducedTypeCompileFails_ReportsTheCompilerErrorWithItsOwnerFile()
+        {
+            string hostPath = FixturePath("HotReloadCrossFileAddedMemberHost.cs");
+            HotReloadOrchestratorResult result;
+
+            using (HotReloadIntroducedTypeHolder.BeginReplacement())
+            {
+                HotReloadIntroducedTypeHolder.Initialize();
+                result = await HotReloadOrchestrator.RunAsync(
+                    new[] { hostPath },
+                    HotReloadTestSourceWriter.WriteEditedSource(
+                        "IntroducedTypeCompileFailureHost.cs",
+                        InsertUncompilableIntroducedType(File.ReadAllText(hostPath))),
+                    CancellationToken.None);
+            }
+
+            HotReloadResponse response = HotReloadApplyResponseBuilder.Build(result, null);
+            Assert.That(response.Success, Is.False, "A refused declaration must fail the run.");
+            string ownerProjectRelativePath = HotReloadPatchTargetSupport.ToProjectRelativeScriptPath(hostPath);
+            List<HotReloadIntroducedTypeResult> failedRows = new List<HotReloadIntroducedTypeResult>();
+            foreach (HotReloadIntroducedTypeResult row in response.IntroducedTypes)
+            {
+                if (string.Equals(row.Kind, "Failed", StringComparison.Ordinal)
+                    && string.Equals(row.FilePath, ownerProjectRelativePath, StringComparison.Ordinal))
+                {
+                    failedRows.Add(row);
+                }
+            }
+
+            Assert.That(
+                failedRows,
+                Has.Count.EqualTo(1),
+                "The failure must be reported once, against the file that declares the type.");
+            Assert.That(failedRows[0].Reason, Does.StartWith("Introduced-type compilation failed: "));
+            Assert.That(failedRows[0].Reason, Does.Contain("CS0117"));
+            Assert.That(failedRows[0].Reason, Does.Contain("("));
+            Assert.That(failedRows[0].Reason, Does.Contain("): "));
+        }
+
+        /// <summary>
         /// Verifies that a reload whose introduced type derives from a type an earlier reload
         /// introduced compiles its artifact against the active artifact: the base type lives in
         /// neither the compiled assembly nor this run's sources, so only the record of the
@@ -1624,6 +1669,23 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 + "        public int Read()\n"
                 + "        {\n"
                 + "            return 7;\n"
+                + "        }\n"
+                + "    }\n"
+                + "\n";
+            return hostSource.Replace(HostTypeAnchor, introduced + HostTypeAnchor, StringComparison.Ordinal);
+        }
+
+        // A new type whose body names a member the compiled host does not declare, so the artifact
+        // compilation fails with a CS0117 that belongs to the host file.
+        private static string InsertUncompilableIntroducedType(string hostSource)
+        {
+            Assert.That(hostSource, Does.Contain(HostTypeAnchor), "Precondition: host type anchor must exist.");
+            string introduced =
+                "    public sealed class HotReloadCrossFileIntroducedBroken\n"
+                + "    {\n"
+                + "        public int Value()\n"
+                + "        {\n"
+                + "            return HotReloadCrossFileAddedMemberHost.NoSuchMemberForThisTest();\n"
                 + "        }\n"
                 + "    }\n"
                 + "\n";

--- a/Assets/Tests/Editor/HotReload/HotReloadIntroducedTypeCompileFailureOutcomesTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadIntroducedTypeCompileFailureOutcomesTests.cs
@@ -1,0 +1,175 @@
+using System.Collections.Generic;
+
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
+{
+    /// <summary>
+    /// Covers how a failed introduced-type compilation turns into the response rows a run reports.
+    /// </summary>
+    public class HotReloadIntroducedTypeCompileFailureOutcomesTests
+    {
+        private const string Prefix = "Introduced-type compilation failed: ";
+
+        /// <summary>
+        /// Verifies that a failure carrying no diagnostic still reports one row that names no
+        /// owner, so a failure the compiler could not attribute is never dropped.
+        /// </summary>
+        [Test]
+        public void Build_NoDiagnostics_ReturnsOneUnattributedRow()
+        {
+            HotReloadIntroducedTypeCompilerResult compileResult = HotReloadIntroducedTypeCompilerResult.Failure(
+                "Introduced-type compilation did not produce both DLL and PDB files.");
+
+            List<HotReloadIntroducedTypeOutcome> rows = HotReloadIntroducedTypeCompileFailureOutcomes.Build(
+                compileResult,
+                new[] { CreateDescriptor("Example.First", "Assets/First.cs") },
+                "TargetAssembly");
+
+            Assert.That(rows, Has.Count.EqualTo(1));
+            Assert.That(rows[0].Kind, Is.EqualTo(HotReloadIntroducedTypeOutcomeKind.Failed));
+            Assert.That(rows[0].MetadataName, Is.EqualTo(string.Empty));
+            Assert.That(rows[0].OriginalAssemblyName, Is.EqualTo("TargetAssembly"));
+            Assert.That(rows[0].OwnerProjectRelativePath, Is.EqualTo(string.Empty));
+            Assert.That(
+                rows[0].Reason,
+                Is.EqualTo(Prefix + "Introduced-type compilation did not produce both DLL and PDB files."));
+        }
+
+        /// <summary>
+        /// Verifies that diagnostics are grouped into one row per owning file, in the order of the
+        /// descriptors, with every message of that file joined into the row's reason.
+        /// </summary>
+        [Test]
+        public void Build_DiagnosticsWithOwners_ReturnsOneRowPerOwnerWithItsMessages()
+        {
+            HotReloadIntroducedTypeCompilerResult compileResult = HotReloadIntroducedTypeCompilerResult.Failure(
+                "Introduced-type compilation reported errors.",
+                new[]
+                {
+                    new HotReloadIntroducedTypeCompilerDiagnostic(
+                        "Assets/Second.cs",
+                        "CS0117: 'Shapes' does not contain a definition for 'TopRow'",
+                        3,
+                        5),
+                    new HotReloadIntroducedTypeCompilerDiagnostic("Assets/Second.cs", "CS1002: ; expected", 9, 1),
+                    new HotReloadIntroducedTypeCompilerDiagnostic("Assets/First.cs", "CS0246: missing type", 1, 1)
+                });
+
+            List<HotReloadIntroducedTypeOutcome> rows = HotReloadIntroducedTypeCompileFailureOutcomes.Build(
+                compileResult,
+                new[]
+                {
+                    CreateDescriptor("Example.First", "Assets/First.cs"),
+                    CreateDescriptor("Example.Second", "Assets/Second.cs")
+                },
+                "TargetAssembly");
+
+            Assert.That(rows, Has.Count.EqualTo(2));
+            Assert.That(rows[0].MetadataName, Is.EqualTo("Example.First"));
+            Assert.That(rows[0].OwnerProjectRelativePath, Is.EqualTo("Assets/First.cs"));
+            Assert.That(rows[0].Reason, Is.EqualTo(Prefix + "Assets/First.cs(1,1): CS0246: missing type"));
+            Assert.That(rows[1].MetadataName, Is.EqualTo("Example.Second"));
+            Assert.That(rows[1].OwnerProjectRelativePath, Is.EqualTo("Assets/Second.cs"));
+            Assert.That(
+                rows[1].Reason,
+                Is.EqualTo(
+                    Prefix
+                    + "Assets/Second.cs(3,5): CS0117: 'Shapes' does not contain a definition for 'TopRow'; "
+                    + "Assets/Second.cs(9,1): CS1002: ; expected"));
+        }
+
+        /// <summary>
+        /// Verifies that a diagnostic the compiler could not attribute to a source file is still
+        /// reported, as a trailing row that names no owner.
+        /// </summary>
+        [Test]
+        public void Build_DiagnosticWithoutOwner_AppendsOneUnattributedRow()
+        {
+            HotReloadIntroducedTypeCompilerResult compileResult = HotReloadIntroducedTypeCompilerResult.Failure(
+                "Introduced-type compilation reported errors.",
+                new[]
+                {
+                    new HotReloadIntroducedTypeCompilerDiagnostic(string.Empty, "CS9999: something", 0, 0),
+                    new HotReloadIntroducedTypeCompilerDiagnostic("Assets/First.cs", "CS0246: missing type", 1, 1)
+                });
+
+            List<HotReloadIntroducedTypeOutcome> rows = HotReloadIntroducedTypeCompileFailureOutcomes.Build(
+                compileResult,
+                new[] { CreateDescriptor("Example.First", "Assets/First.cs") },
+                "TargetAssembly");
+
+            Assert.That(rows, Has.Count.EqualTo(2));
+            Assert.That(rows[0].MetadataName, Is.EqualTo("Example.First"));
+            Assert.That(rows[1].MetadataName, Is.EqualTo(string.Empty));
+            Assert.That(rows[1].OwnerProjectRelativePath, Is.EqualTo(string.Empty));
+            Assert.That(rows[1].Reason, Is.EqualTo(Prefix + "CS9999: something"));
+        }
+
+        /// <summary>
+        /// Verifies that two types declared in one file share the single row of that file, named
+        /// after the first descriptor, because a diagnostic identifies a file and not a type.
+        /// </summary>
+        [Test]
+        public void Build_TwoTypesInOneOwner_UsesTheFirstDescriptor()
+        {
+            HotReloadIntroducedTypeCompilerResult compileResult = HotReloadIntroducedTypeCompilerResult.Failure(
+                "Introduced-type compilation reported errors.",
+                new[]
+                {
+                    new HotReloadIntroducedTypeCompilerDiagnostic("Assets/First.cs", "CS0246: missing type", 1, 1)
+                });
+
+            List<HotReloadIntroducedTypeOutcome> rows = HotReloadIntroducedTypeCompileFailureOutcomes.Build(
+                compileResult,
+                new[]
+                {
+                    CreateDescriptor("Example.First", "Assets/First.cs"),
+                    CreateDescriptor("Example.Companion", "Assets/First.cs")
+                },
+                "TargetAssembly");
+
+            Assert.That(rows, Has.Count.EqualTo(1));
+            Assert.That(rows[0].MetadataName, Is.EqualTo("Example.First"));
+            Assert.That(rows[0].OwnerProjectRelativePath, Is.EqualTo("Assets/First.cs"));
+        }
+
+        /// <summary>
+        /// Verifies that a diagnostic without a source position reports its message alone, so a
+        /// meaningless "(0,0)" never reaches the response.
+        /// </summary>
+        [Test]
+        public void Build_DiagnosticWithoutPosition_OmitsThePosition()
+        {
+            HotReloadIntroducedTypeCompilerResult compileResult = HotReloadIntroducedTypeCompilerResult.Failure(
+                "Introduced-type compilation reported errors.",
+                new[]
+                {
+                    new HotReloadIntroducedTypeCompilerDiagnostic("Assets/First.cs", "CS0246: missing type", 0, 0)
+                });
+
+            List<HotReloadIntroducedTypeOutcome> rows = HotReloadIntroducedTypeCompileFailureOutcomes.Build(
+                compileResult,
+                new[] { CreateDescriptor("Example.First", "Assets/First.cs") },
+                "TargetAssembly");
+
+            Assert.That(rows, Has.Count.EqualTo(1));
+            Assert.That(rows[0].Reason, Is.EqualTo(Prefix + "CS0246: missing type"));
+        }
+
+        private static HotReloadIntroducedTypeDescriptor CreateDescriptor(
+            string metadataName,
+            string ownerProjectRelativePath)
+        {
+            return new HotReloadIntroducedTypeDescriptor(
+                "OriginalAssembly",
+                "original-mvid",
+                metadataName,
+                ownerProjectRelativePath,
+                "fingerprint",
+                "namespace Example { public class Placeholder { } }");
+        }
+    }
+}

--- a/Assets/Tests/Editor/HotReload/HotReloadIntroducedTypeCompileFailureOutcomesTests.cs.meta
+++ b/Assets/Tests/Editor/HotReload/HotReloadIntroducedTypeCompileFailureOutcomesTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5d02337c6b12d429d958af77c60d0585
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/HotReload/HotReloadIntroducedTypeCompilerTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadIntroducedTypeCompilerTests.cs
@@ -190,7 +190,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                     {
                         type = CompilerMessageType.Error,
                         file = "second.cs",
-                        message = "second source error"
+                        message = "second source error",
+                        line = 7,
+                        column = 12
                     }
                 }
             };
@@ -205,6 +207,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             Assert.That(result.Diagnostics, Has.Count.EqualTo(1));
             Assert.That(result.Diagnostics[0].OwnerProjectRelativePath, Is.EqualTo("Assets/Second.cs"));
             Assert.That(result.Diagnostics[0].Message, Is.EqualTo("second source error"));
+            Assert.That(result.Diagnostics[0].Line, Is.EqualTo(7));
+            Assert.That(result.Diagnostics[0].Column, Is.EqualTo(12));
             Assert.That(environment.LoadCalls, Is.EqualTo(0));
         }
 
@@ -257,6 +261,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             Assert.That(result.Diagnostics, Has.Count.EqualTo(1));
             Assert.That(result.Diagnostics[0].OwnerProjectRelativePath, Is.EqualTo("Assets/Second.cs"));
             Assert.That(result.Diagnostics[0].Message, Does.Contain("MissingType"));
+            Assert.That(result.Diagnostics[0].Line, Is.GreaterThan(0));
+            Assert.That(result.Diagnostics[0].Column, Is.GreaterThan(0));
         }
 
         /// <summary>

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadIntroducedTypeCompileFailureOutcomes.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadIntroducedTypeCompileFailureOutcomes.cs
@@ -1,0 +1,147 @@
+using System.Collections.Generic;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Turns a failed introduced-type compilation into the response rows of that run, one row per
+    /// file the compiler blamed, so the reader sees which source each compiler error belongs to.
+    /// </summary>
+    internal static class HotReloadIntroducedTypeCompileFailureOutcomes
+    {
+        private const string ReasonPrefix = "Introduced-type compilation failed: ";
+
+        public static List<HotReloadIntroducedTypeOutcome> Build(
+            HotReloadIntroducedTypeCompilerResult compileResult,
+            IReadOnlyList<HotReloadIntroducedTypeDescriptor> descriptors,
+            string targetAssemblyName)
+        {
+            List<HotReloadIntroducedTypeOutcome> rows = new List<HotReloadIntroducedTypeOutcome>();
+
+            // Why one unattributed row: without a diagnostic the failure belongs to the batch and
+            // to no single owner, so attributing it to a declaration would be a guess.
+            if (compileResult.Diagnostics.Count == 0)
+            {
+                rows.Add(HotReloadIntroducedTypeOutcome.Failed(
+                    string.Empty,
+                    targetAssemblyName,
+                    string.Empty,
+                    ReasonPrefix + compileResult.ErrorMessage));
+                return rows;
+            }
+
+            List<string> ownerOrder = new List<string>();
+            Dictionary<string, List<string>> messagesByOwner = new Dictionary<string, List<string>>();
+            List<string> unattributed = new List<string>();
+            GroupDiagnostics(compileResult.Diagnostics, ownerOrder, messagesByOwner, unattributed);
+
+            HashSet<string> emittedOwners = new HashSet<string>();
+            AppendDescriptorRows(descriptors, messagesByOwner, emittedOwners, targetAssemblyName, rows);
+            AppendUnknownOwnerRows(ownerOrder, messagesByOwner, emittedOwners, targetAssemblyName, rows);
+            if (unattributed.Count > 0)
+            {
+                rows.Add(HotReloadIntroducedTypeOutcome.Failed(
+                    string.Empty,
+                    targetAssemblyName,
+                    string.Empty,
+                    ReasonPrefix + string.Join("; ", unattributed)));
+            }
+
+            return rows;
+        }
+
+        private static void GroupDiagnostics(
+            IReadOnlyList<HotReloadIntroducedTypeCompilerDiagnostic> diagnostics,
+            List<string> ownerOrder,
+            Dictionary<string, List<string>> messagesByOwner,
+            List<string> unattributed)
+        {
+            foreach (HotReloadIntroducedTypeCompilerDiagnostic diagnostic in diagnostics)
+            {
+                string formatted = FormatDiagnostic(diagnostic);
+                if (diagnostic.OwnerProjectRelativePath.Length == 0)
+                {
+                    unattributed.Add(formatted);
+                    continue;
+                }
+
+                if (!messagesByOwner.TryGetValue(diagnostic.OwnerProjectRelativePath, out List<string> messages))
+                {
+                    messages = new List<string>();
+                    messagesByOwner.Add(diagnostic.OwnerProjectRelativePath, messages);
+                    ownerOrder.Add(diagnostic.OwnerProjectRelativePath);
+                }
+
+                messages.Add(formatted);
+            }
+        }
+
+        // Why the descriptor order and not the diagnostic order: the other IntroducedTypes rows of
+        // the response follow the descriptors, so a different order here would read as a different
+        // set of types.
+        private static void AppendDescriptorRows(
+            IReadOnlyList<HotReloadIntroducedTypeDescriptor> descriptors,
+            Dictionary<string, List<string>> messagesByOwner,
+            HashSet<string> emittedOwners,
+            string targetAssemblyName,
+            List<HotReloadIntroducedTypeOutcome> rows)
+        {
+            foreach (HotReloadIntroducedTypeDescriptor descriptor in descriptors)
+            {
+                string owner = descriptor.OwnerProjectRelativePath ?? string.Empty;
+                if (!messagesByOwner.TryGetValue(owner, out List<string> messages))
+                {
+                    continue;
+                }
+
+                // Why the first descriptor wins: a compiler diagnostic identifies a file, so two
+                // types declared in one file cannot be told apart and share its row.
+                if (!emittedOwners.Add(owner))
+                {
+                    continue;
+                }
+
+                rows.Add(HotReloadIntroducedTypeOutcome.Failed(
+                    descriptor.MetadataName,
+                    targetAssemblyName,
+                    owner,
+                    ReasonPrefix + string.Join("; ", messages)));
+            }
+        }
+
+        // Why kept at all: a diagnostic naming a file this run declares no type in still carries
+        // the compiler error, and dropping it would leave the reader with nothing to act on.
+        private static void AppendUnknownOwnerRows(
+            List<string> ownerOrder,
+            Dictionary<string, List<string>> messagesByOwner,
+            HashSet<string> emittedOwners,
+            string targetAssemblyName,
+            List<HotReloadIntroducedTypeOutcome> rows)
+        {
+            foreach (string owner in ownerOrder)
+            {
+                if (!emittedOwners.Add(owner))
+                {
+                    continue;
+                }
+
+                rows.Add(HotReloadIntroducedTypeOutcome.Failed(
+                    string.Empty,
+                    targetAssemblyName,
+                    owner,
+                    ReasonPrefix + string.Join("; ", messagesByOwner[owner])));
+            }
+        }
+
+        private static string FormatDiagnostic(HotReloadIntroducedTypeCompilerDiagnostic diagnostic)
+        {
+            if (diagnostic.Line <= 0)
+            {
+                return diagnostic.Message;
+            }
+
+            return diagnostic.OwnerProjectRelativePath
+                + "(" + diagnostic.Line + "," + diagnostic.Column + "): "
+                + diagnostic.Message;
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadIntroducedTypeCompileFailureOutcomes.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadIntroducedTypeCompileFailureOutcomes.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5199353fdcb604b8d8e4b6f0cc4d743e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadIntroducedTypeCompiler.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadIntroducedTypeCompiler.cs
@@ -183,7 +183,14 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     }
                 }
 
-                diagnostics.Add(new HotReloadIntroducedTypeCompilerDiagnostic(ownerProjectRelativePath, message.message));
+                // Why line and column travel separately: the parsed message keeps only the
+                // "CSxxxx: <text>" part, so dropping them here would leave the response without
+                // the position the reader needs to find the offending source line.
+                diagnostics.Add(new HotReloadIntroducedTypeCompilerDiagnostic(
+                    ownerProjectRelativePath,
+                    message.message,
+                    message.line,
+                    message.column));
             }
 
             return diagnostics;
@@ -504,10 +511,22 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
         public string Message { get; }
 
-        public HotReloadIntroducedTypeCompilerDiagnostic(string ownerProjectRelativePath, string message)
+        /// <summary>The one-based source line of the diagnostic, or zero when it carries none.</summary>
+        public int Line { get; }
+
+        /// <summary>The one-based source column of the diagnostic, or zero when it carries none.</summary>
+        public int Column { get; }
+
+        public HotReloadIntroducedTypeCompilerDiagnostic(
+            string ownerProjectRelativePath,
+            string message,
+            int line,
+            int column)
         {
             OwnerProjectRelativePath = ownerProjectRelativePath ?? string.Empty;
             Message = message ?? string.Empty;
+            Line = line;
+            Column = column;
         }
     }
 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadIntroducedTypePreparation.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadIntroducedTypePreparation.cs
@@ -81,17 +81,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     .ConfigureAwait(false);
             if (!compileResult.Success)
             {
-                // Why one unattributed row: the batch compiles every declaration of the run at
-                // once, so a failure of it belongs to no single owner.
                 return HotReloadIntroducedTypePreparationResult.TypeFailures(
-                    new[]
-                    {
-                        HotReloadIntroducedTypeOutcome.Failed(
-                            string.Empty,
-                            transformInput.targetAssemblyName,
-                            string.Empty,
-                            "Introduced-type compilation failed: " + compileResult.ErrorMessage)
-                    },
+                    HotReloadIntroducedTypeCompileFailureOutcomes.Build(
+                        compileResult,
+                        descriptors,
+                        transformInput.targetAssemblyName),
                     alreadyActiveTypes,
                     notices);
             }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/Skill/references/introduced-types.md
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/Skill/references/introduced-types.md
@@ -67,8 +67,10 @@ method **of** an introduced type is out of scope for this stage.
 Any refused shape above; use of the type from another assembly, from a file that is neither
 passed to this reload nor already hot-reloaded, or from `uloop execute-dynamic-code`; anything
 that reaches the type through Unity (serialization, `[SerializeField]`, Inspector,
-`AddComponent`, `CreateInstance`, message discovery); and any new or changed `.asmdef` /
-`.asmref`.
+`AddComponent`, `CreateInstance`, message discovery); a call to a member an earlier or the same
+reload *added* to a compiled type (an `Added` row), because introduced types compile against the
+compiled assemblies and retained artifacts only, so the compile fails naming the missing member;
+and any new or changed `.asmdef` / `.asmref`.
 
 ## File selection and new files
 

--- a/docs/hot-reload-introduced-types.md
+++ b/docs/hot-reload-introduced-types.md
@@ -90,6 +90,9 @@ recovery: the types stay loaded whatever the methods did, so a re-apply is not a
 - Use from `uloop execute-dynamic-code`. Dynamic code compiles against the compiled assemblies,
   not against the reload's artifact.
 - A new or changed `.asmdef` / `.asmref`. Assembly layout is decided at compile time.
+- A call to a member an earlier or the same reload *added* to a compiled type (an `Added` row).
+  Introduced types compile against the compiled assemblies and the retained artifacts only, so
+  the artifact compilation fails with the compiler error naming the missing member.
 
 ## Lifecycle
 


### PR DESCRIPTION
## Summary
- A hot reload whose new type fails to compile now reports the compiler errors themselves, next to the file and source position they belong to.
- The list of shapes that still need `uloop compile` now names calls into members a reload added to a compiled type.

## User Impact
Before, a failed introduced-type compilation produced exactly one `IntroducedTypes` row with an empty type name, an empty file and the reason `Introduced-type compilation failed: Introduced-type compilation reported errors.` The compiler diagnostics existed but were discarded, so there was no way to tell which new type was wrong, or why, other than bisecting the reload by hand.

Now each failing file gets its own `Failed` row naming the declaration, the file and every compiler error of that file with its line and column, for example:

```
Introduced-type compilation failed: Assets/Scripts/Piece.cs(12,20): CS0117: 'Shapes' does not contain a definition for 'TopRow'
```

A failure that carries no diagnostic at all (a missing DLL or PDB, an identity mismatch) keeps the previous single row, so nothing that used to be reported disappears.

## Changes
- Introduced-type compiler diagnostics now carry the source line and column, which the parsed message does not include.
- A new builder groups the diagnostics of a failed compilation by owning file and produces one response row per owning declaration, in the order the run's declarations are reported. Diagnostics whose file matches no declaration, and diagnostics with no file at all, are still emitted as their own rows instead of being dropped.
- Documented the added-member limitation in the hot-reload skill reference and the developer document, and regenerated the skill copies.

## Verification
- `uloop run-tests --filter-type class --filter-value HotReloadIntroducedTypeCompileFailureOutcomesTests` — 5/5 passed (fails to compile before the change: the builder does not exist).
- `uloop run-tests --filter-type class --filter-value HotReloadIntroducedTypeActivationTests` — 24/24 passed. The new end-to-end test was confirmed red first by temporarily restoring the old single-row behaviour (1 failed, 23 passed).
- `uloop run-tests --filter-type class --filter-value HotReloadIntroducedTypeCompilerTests` — 22/22 passed.
- `uloop run-tests --filter-type class --filter-value HotReloadIntroducedTypeResponseTests` — 15/15 passed.
- `uloop compile` — 0 errors.
- `go run ./cmd/check-skill-size` — exit 0. `sh scripts/check-file-length.sh` — no findings.

https://claude.ai/code/session_01H3pv1GH69HssoxHiHrYqWf


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2696?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

