### PR TITLE
fix: an unchanged introduced type is no longer rejected as changed when a compiled type it uses is part of the same reload

### DIFF
--- a/Assets/Tests/Editor/HotReload/HotReloadRetainedArtifactFixture.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadRetainedArtifactFixture.cs
@@ -77,9 +77,21 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
         public string RetainedFingerprint { get; private set; }
 
-        public static async Task<HotReloadRetainedArtifactFixture> CreateAsync(
+        public static Task<HotReloadRetainedArtifactFixture> CreateAsync(
             string name,
             string editedSource)
+        {
+            return CreateWithSiblingSourceAsync(name, editedSource, SiblingSource);
+        }
+
+        /// <summary>
+        /// Builds the same world with a caller-supplied sibling file, so a test can put the source
+        /// of a type the target assembly also holds into the same run.
+        /// </summary>
+        public static async Task<HotReloadRetainedArtifactFixture> CreateWithSiblingSourceAsync(
+            string name,
+            string editedSource,
+            string siblingSource)
         {
             string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
             string directory = Path.Combine(
@@ -93,7 +105,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             string sourcePath = Path.Combine(directory, "Edited.cs");
             File.WriteAllText(sourcePath, editedSource);
             string siblingSourcePath = Path.Combine(directory, "Sibling.cs");
-            File.WriteAllText(siblingSourcePath, SiblingSource);
+            File.WriteAllText(siblingSourcePath, siblingSource);
             string targetAssemblyPath = Path.Combine(directory, "RetainedTarget.dll");
             string targetAssemblyMvid = CreateTargetAssembly(targetAssemblyPath);
             string artifactPath = Path.Combine(directory, "RetainedArtifact.dll");
@@ -135,6 +147,18 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 "prepareIntroducedTypes",
                 Array.Empty<TransformWorkerIntroducedTypeArtifactDto>(),
                 includeSibling: false);
+        }
+
+        /// <summary>
+        /// Builds a prepare input covering both edited files of the group, so planning binds the
+        /// sibling's types from source instead of from the target assembly.
+        /// </summary>
+        public TransformWorkerInputDto BuildPrepareGroupInput()
+        {
+            return BuildInput(
+                "prepareIntroducedTypes",
+                Array.Empty<TransformWorkerIntroducedTypeArtifactDto>(),
+                includeSibling: true);
         }
 
         public TransformWorkerIntroducedTypeArtifactDto CreateRecordedArtifact(

--- a/Assets/Tests/Editor/HotReload/TransformWorkerIntroducedTypeTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerIntroducedTypeTests.cs
@@ -492,6 +492,61 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
+        /// Verifies that the fingerprint of a declaration that uses a compiled type is the same
+        /// whether that type is bound from the target assembly or from its source in the same run.
+        /// </summary>
+        [Test]
+        public async Task PrepareIntroducedTypes_CompiledTypeBoundFromSource_KeepsTheFingerprint()
+        {
+            // Why the caller is a parameter and not a `new Caller()`: the target assembly is built
+            // without a constructor, so a construction would fail to bind against metadata and the
+            // fingerprint would differ for that reason instead of the identity under test.
+            HotReloadRetainedArtifactFixture fixture = await HotReloadRetainedArtifactFixture
+                .CreateWithSiblingSourceAsync(
+                    "CompiledTypeFromSource",
+                    "namespace Example { public class Retained { public int Compute(Caller caller) { return caller.Read(); } } }",
+                    "namespace Example { public class Caller { public int Read() { return 0; } } }");
+
+            TransformWorkerClientResult alone = await TransformWorkerClient.RunAsync(
+                fixture.BuildPrepareInput(),
+                CancellationToken.None);
+            TransformWorkerClientResult grouped = await TransformWorkerClient.RunAsync(
+                fixture.BuildPrepareGroupInput(),
+                CancellationToken.None);
+
+            Assert.That(alone.Success, Is.True, alone.ErrorMessage);
+            Assert.That(grouped.Success, Is.True, grouped.ErrorMessage);
+            Assert.That(
+                FindRetainedFingerprint(grouped, fixture.ProjectRelativePath),
+                Is.EqualTo(FindRetainedFingerprint(alone, fixture.ProjectRelativePath)),
+                "A compiled type bound from source must fingerprint as the same dependency.");
+        }
+
+        private static string FindRetainedFingerprint(
+            TransformWorkerClientResult result,
+            string projectRelativePath)
+        {
+            foreach (TransformWorkerFileOutputDto file in result.Output.files)
+            {
+                if (file.projectRelativePath != projectRelativePath)
+                {
+                    continue;
+                }
+
+                foreach (TransformWorkerIntroducedTypeDto introducedType in file.introducedTypes)
+                {
+                    if (introducedType.metadataName == "Example.Retained")
+                    {
+                        return introducedType.declarationFingerprint;
+                    }
+                }
+            }
+
+            Assert.Fail("Planning did not report Example.Retained for " + projectRelativePath + ".");
+            return null;
+        }
+
+        /// <summary>
         /// Verifies that a fingerprint retains each semantic dependency at its stable declaration
         /// traversal position when aliases exchange their bound types without changing tokens.
         /// </summary>

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/IntroducedTypeDependencyWalker.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/IntroducedTypeDependencyWalker.cs
@@ -153,8 +153,15 @@ internal sealed class IntroducedTypeDependencyWalker
             return;
         }
 
-        if (SymbolEqualityComparer.Default.Equals(containingAssembly, compilationAssembly)
-            || SymbolEqualityComparer.Default.Equals(containingAssembly, targetAssembly))
+        // Why the target assembly is compared by identity and not by symbol: it is resolved from a
+        // separate compilation (one with different metadata import options), so a type this
+        // compilation bound from the target's metadata carries a different assembly symbol than
+        // that one. Comparing symbols would make the same compiled type fingerprint differently
+        // depending on whether its source happened to be part of the run.
+        bool boundFromSource = SymbolEqualityComparer.Default.Equals(containingAssembly, compilationAssembly);
+        bool boundFromTarget = targetAssembly != null
+            && containingAssembly.Identity.Equals(targetAssembly.Identity);
+        if (boundFromSource || boundFromTarget)
         {
             dependencies.Add((targetAssemblyName ?? string.Empty)
                 + "|" + (targetAssemblyMvid ?? string.Empty)


### PR DESCRIPTION
## Summary
- A hot reload no longer refuses a new type you did not touch just because a compiled type it uses happens to be part of the same reload.

## User Impact
Before, whether an untouched introduced type was accepted depended on which other files the reload carried. Reloading it alone reported `AlreadyActive`, as expected. Reloading it together with the source of a compiled type it uses — passed explicitly, or pulled in so an active patch could rebind — reported:

```
Changed introduced type requires a compile: <type>
```

Because a `Failed` type row leaves every file of that assembly unapplied, one unrelated file in the reload could stop the whole run, and the message pointed at a declaration that had not changed by a single byte. Types that referenced nothing from their own assembly were unaffected, which made the failure look arbitrary.

Now the declaration fingerprints the same either way, and such a reload applies.

## Changes
- The dependency identity of a type that belongs to the target assembly is now decided by comparing assembly identity rather than assembly symbol. The target assembly symbol comes from a separate compilation (it needs different metadata import options), so a metadata-bound type is never symbol-equal to it and used to fall through to a different identity form than its source-bound self. Assembly identity is a value comparison and holds across compilations.
- Identity of types served from a retained artifact is untouched.
- The retained-artifact test fixture can now be built with a caller-supplied sibling source and can produce a prepare input covering the whole group.

Artifacts recorded before this change may no longer match the fingerprint a run computes, but artifacts do not survive a domain reload, so no migration is needed.

## Verification
- `uloop run-tests --filter-type class --filter-value TransformWorkerIntroducedTypeTests` — 24/24 passed. The new test was confirmed red before the fix (1 failed, 23 passed: the two fingerprints differed).
- `uloop run-tests --filter-type class --filter-value TransformWorkerRetainedDeclarationTests` — 9/9 passed.
- `uloop run-tests --filter-type class --filter-value TransformWorkerIntroducedTypeBindingTests` — 14/14 passed.
- `uloop run-tests --filter-type class --filter-value HotReloadIntroducedTypeActivationTests` — 23/23 passed.
- `uloop compile` — 0 errors.

https://claude.ai/code/session_01H3pv1GH69HssoxHiHrYqWf


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2697?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

