### PR TITLE
fix: execute-dynamic-code now explains when a missing type is one hot reload introduced

### DIFF
--- a/.agents/skills/uloop-hot-reload/references/introduced-types.md
+++ b/.agents/skills/uloop-hot-reload/references/introduced-types.md
@@ -70,7 +70,9 @@ that reaches the type through Unity (serialization, `[SerializeField]`, Inspecto
 `AddComponent`, `CreateInstance`, message discovery); a call to a member an earlier or the same
 reload *added* to a compiled type (an `Added` row), because introduced types compile against the
 compiled assemblies and retained artifacts only, so the compile fails naming the missing member;
-and any new or changed `.asmdef` / `.asmref`.
+and any new or changed `.asmdef` / `.asmref`. When `execute-dynamic-code` fails on an introduced
+type, the diagnostic's `Hint` names it and points to reflection through the loaded assembly or to
+`uloop compile`.
 
 ## File selection and new files
 

--- a/.claude/skills/uloop-hot-reload/references/introduced-types.md
+++ b/.claude/skills/uloop-hot-reload/references/introduced-types.md
@@ -70,7 +70,9 @@ that reaches the type through Unity (serialization, `[SerializeField]`, Inspecto
 `AddComponent`, `CreateInstance`, message discovery); a call to a member an earlier or the same
 reload *added* to a compiled type (an `Added` row), because introduced types compile against the
 compiled assemblies and retained artifacts only, so the compile fails naming the missing member;
-and any new or changed `.asmdef` / `.asmref`.
+and any new or changed `.asmdef` / `.asmref`. When `execute-dynamic-code` fails on an introduced
+type, the diagnostic's `Hint` names it and points to reflection through the loaded assembly or to
+`uloop compile`.
 
 ## File selection and new files
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -162,6 +162,20 @@ When you touch a reported file, split it before adding behavior. Commands, the
 exclusion list, and the two places the threshold is declared:
 `docs/file-length.md`.
 
+## Nested Type Name Forms
+
+A nested type has three spellings, and a name that crosses a boundary between them silently
+fails to match: Cecil / worker metadata names nest with `/` (`Outer/Inner`), CLR reflection
+names (`Type.FullName`, `Assembly.GetType`) nest with `+` (`Outer+Inner`), and Roslyn display
+strings and C# source nest with `.` (`Outer.Inner`). Every value that leaves the transform
+worker or a Cecil reader is a metadata name; every value handed to reflection or compared
+against `Type.FullName` must be the reflection form. Convert at the boundary where the value
+changes world, never at the point of use, and never split or end-match a name on one
+separator only — a matcher that sees `.` and `+` but not `/` never matches a nested type
+that came from the worker. When you add a conversion, add a test with a nested type; a
+top-level-only test passes with the conversion missing. Definitions: `docs/glossary.md`
+("Metadata name", "Reflection name").
+
 ## Asmdef Reference Policy
 
 Assembly definitions under `Packages/src` may only reference each other in the directions the

--- a/Assets/Tests/Editor/CompilationDiagnosticMessageParserTests.cs
+++ b/Assets/Tests/Editor/CompilationDiagnosticMessageParserTests.cs
@@ -16,5 +16,30 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
 
             Assert.That(result, Is.Null);
         }
+
+        /// <summary>
+        /// Verifies the namespace of a CS0234 message is read from its second quoted phrase, not
+        /// the first one that carries the missing type name.
+        /// </summary>
+        [Test]
+        public void ExtractNamespaceNameFromMessage_ReturnsNamespace_WhenMessageNamesOne()
+        {
+            string result = CompilationDiagnosticMessageParser.ExtractNamespaceNameFromMessage(
+                "The type or namespace name 'Widget' does not exist in the namespace 'Example' (are you missing an assembly reference?)");
+
+            Assert.That(result, Is.EqualTo("Example"));
+        }
+
+        /// <summary>
+        /// Verifies a message with a single quoted phrase, such as CS0246, reports no namespace.
+        /// </summary>
+        [Test]
+        public void ExtractNamespaceNameFromMessage_ReturnsNull_WhenMessageHasOneQuotedPhrase()
+        {
+            string result = CompilationDiagnosticMessageParser.ExtractNamespaceNameFromMessage(
+                "The type or namespace name 'Widget' could not be found");
+
+            Assert.That(result, Is.Null);
+        }
     }
 }

--- a/Assets/Tests/Editor/DynamicCodeToolTests/DynamicCodeExecutionResponseFactoryTests.cs
+++ b/Assets/Tests/Editor/DynamicCodeToolTests/DynamicCodeExecutionResponseFactoryTests.cs
@@ -453,5 +453,63 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
             Assert.That(response.Diagnostics[0].Suggestions, Contains.Item(
                 "Cast each component explicitly, for example: new Color32((byte)255, (byte)0, (byte)0, (byte)255)."));
         }
+
+        /// <summary>
+        /// Verifies a missing type that names an active hot-reload introduced type is explained as
+        /// one, and that the ambiguous-candidate suggestions stay behind the introduced-type ones
+        /// because the diagnostic alone cannot tell which route the caller meant.
+        /// </summary>
+        [Test]
+        public void ConvertExecutionResultToResponse_WhenMissingTypeIsIntroducedByHotReload_ExplainsTheIntroducedType()
+        {
+            Func<IReadOnlyList<string>> previousDescribe =
+                HotReloadIntroducedTypeCoordination.DescribeActiveTypeNames;
+            HotReloadIntroducedTypeCoordination.DescribeActiveTypeNames =
+                () => new List<string> { "Example.Widget" };
+            try
+            {
+                DynamicCodeExecutionResponseFactory factory = new();
+                ExecutionResult result = new()
+                {
+                    Success = false,
+                    ErrorMessage = "Compilation error occurred",
+                    UpdatedCode = "return new Widget();",
+                    CompilationErrors = new List<CompilationError>
+                    {
+                        new CompilationError
+                        {
+                            ErrorCode = "CS0246",
+                            Message = "The type or namespace name 'Widget' could not be found",
+                            Line = 1,
+                            Column = 12
+                        }
+                    },
+                    AmbiguousTypeCandidates = new Dictionary<string, List<string>>
+                    {
+                        { "Widget", new List<string> { "Namespace.One", "Namespace.Two" } }
+                    }
+                };
+
+                ExecuteDynamicCodeResponse response = factory.ConvertExecutionResultToResponse(result);
+
+                Assert.That(
+                    response.Diagnostics[0].Hint,
+                    Is.EqualTo(
+                        "'Widget' is a hot-reload introduced type (Example.Widget). execute-dynamic-code compiles against the compiled assemblies only, so an introduced type is not visible here until it is compiled. Use reflection through the loaded assembly (AppDomain.CurrentDomain.GetAssemblies) while it is active, or run 'uloop compile' to make it a compiled type."));
+                Assert.That(
+                    response.Diagnostics[0].Suggestions,
+                    Is.EqualTo(new[]
+                    {
+                        "Locate the type with AppDomain.CurrentDomain.GetAssemblies().SelectMany(a => a.GetTypes()).First(t => t.FullName == \"Example.Widget\") and drive it through reflection",
+                        "Run 'uloop compile' when the type is final, then reference it directly",
+                        "Use Namespace.One.Widget",
+                        "Use Namespace.Two.Widget"
+                    }));
+            }
+            finally
+            {
+                HotReloadIntroducedTypeCoordination.DescribeActiveTypeNames = previousDescribe;
+            }
+        }
     }
 }

--- a/Assets/Tests/Editor/DynamicCodeToolTests/IntroducedTypeDiagnosticHintTests.cs
+++ b/Assets/Tests/Editor/DynamicCodeToolTests/IntroducedTypeDiagnosticHintTests.cs
@@ -63,8 +63,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
         }
 
         /// <summary>
-        /// Verifies a nested introduced type matches on its simple name while its namespace prefix
-        /// still gates the CS0234 match.
+        /// Verifies a nested introduced type matches on its simple name, its namespace prefix still
+        /// gates the CS0234 match, and the Cecil metadata name is reported in reflection form.
         /// </summary>
         [Test]
         public void TryBuild_WhenIntroducedTypeIsNested_MatchesOnTheSimpleName()
@@ -72,7 +72,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
             bool built = IntroducedTypeDiagnosticHint.TryBuild(
                 "CS0234",
                 "The type or namespace name 'Widget' does not exist in the namespace 'Example'",
-                new List<string> { "Example.Outer+Widget" },
+                new List<string> { "Example.Outer/Widget" },
                 out string hint,
                 out List<string> suggestions);
 

--- a/Assets/Tests/Editor/DynamicCodeToolTests/IntroducedTypeDiagnosticHintTests.cs
+++ b/Assets/Tests/Editor/DynamicCodeToolTests/IntroducedTypeDiagnosticHintTests.cs
@@ -1,0 +1,196 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
+{
+    /// <summary>
+    /// Covers the missing-type diagnostic explanation for hot-reload introduced types.
+    /// </summary>
+    [TestFixture]
+    public sealed class IntroducedTypeDiagnosticHintTests
+    {
+        private const string SingleMatchHint =
+            "'Widget' is a hot-reload introduced type (Example.Widget). execute-dynamic-code compiles against the compiled assemblies only, so an introduced type is not visible here until it is compiled. Use reflection through the loaded assembly (AppDomain.CurrentDomain.GetAssemblies) while it is active, or run 'uloop compile' to make it a compiled type.";
+
+        private const string SingleMatchReflectionSuggestion =
+            "Locate the type with AppDomain.CurrentDomain.GetAssemblies().SelectMany(a => a.GetTypes()).First(t => t.FullName == \"Example.Widget\") and drive it through reflection";
+
+        private const string CompileSuggestion =
+            "Run 'uloop compile' when the type is final, then reference it directly";
+
+        /// <summary>
+        /// Verifies a CS0246 whose type name is an active introduced type gets the introduced-type
+        /// hint and both suggestions.
+        /// </summary>
+        [Test]
+        public void TryBuild_WhenTypeNotFoundNamesAnActiveIntroducedType_ExplainsTheIntroducedType()
+        {
+            bool built = IntroducedTypeDiagnosticHint.TryBuild(
+                "CS0246",
+                "The type or namespace name 'Widget' could not be found",
+                new List<string> { "Example.Widget" },
+                out string hint,
+                out List<string> suggestions);
+
+            Assert.That(built, Is.True);
+            Assert.That(hint, Is.EqualTo(SingleMatchHint));
+            Assert.That(
+                suggestions,
+                Is.EqualTo(new[] { SingleMatchReflectionSuggestion, CompileSuggestion }));
+        }
+
+        /// <summary>
+        /// Verifies a CS0234 whose type name and namespace match an active introduced type gets the
+        /// same explanation as CS0246.
+        /// </summary>
+        [Test]
+        public void TryBuild_WhenNamespaceMemberMissingMatchesAnIntroducedType_ExplainsTheIntroducedType()
+        {
+            bool built = IntroducedTypeDiagnosticHint.TryBuild(
+                "CS0234",
+                "The type or namespace name 'Widget' does not exist in the namespace 'Example' (are you missing an assembly reference?)",
+                new List<string> { "Example.Widget" },
+                out string hint,
+                out List<string> suggestions);
+
+            Assert.That(built, Is.True);
+            Assert.That(hint, Is.EqualTo(SingleMatchHint));
+            Assert.That(
+                suggestions,
+                Is.EqualTo(new[] { SingleMatchReflectionSuggestion, CompileSuggestion }));
+        }
+
+        /// <summary>
+        /// Verifies a nested introduced type matches on its simple name while its namespace prefix
+        /// still gates the CS0234 match.
+        /// </summary>
+        [Test]
+        public void TryBuild_WhenIntroducedTypeIsNested_MatchesOnTheSimpleName()
+        {
+            bool built = IntroducedTypeDiagnosticHint.TryBuild(
+                "CS0234",
+                "The type or namespace name 'Widget' does not exist in the namespace 'Example'",
+                new List<string> { "Example.Outer+Widget" },
+                out string hint,
+                out List<string> suggestions);
+
+            Assert.That(built, Is.True);
+            Assert.That(
+                hint,
+                Is.EqualTo(
+                    "'Widget' is a hot-reload introduced type (Example.Outer+Widget). execute-dynamic-code compiles against the compiled assemblies only, so an introduced type is not visible here until it is compiled. Use reflection through the loaded assembly (AppDomain.CurrentDomain.GetAssemblies) while it is active, or run 'uloop compile' to make it a compiled type."));
+            Assert.That(
+                suggestions,
+                Is.EqualTo(new[]
+                {
+                    "Locate the type with AppDomain.CurrentDomain.GetAssemblies().SelectMany(a => a.GetTypes()).First(t => t.FullName == \"Example.Outer+Widget\") and drive it through reflection",
+                    CompileSuggestion
+                }));
+        }
+
+        /// <summary>
+        /// Verifies no explanation is produced when this domain holds no active introduced type.
+        /// </summary>
+        [Test]
+        public void TryBuild_WhenNoIntroducedTypeIsActive_ProducesNothing()
+        {
+            bool built = IntroducedTypeDiagnosticHint.TryBuild(
+                "CS0246",
+                "The type or namespace name 'Widget' could not be found",
+                new List<string>(),
+                out string hint,
+                out List<string> suggestions);
+
+            Assert.That(built, Is.False);
+            Assert.That(hint, Is.Empty);
+            Assert.That(suggestions, Is.Null);
+        }
+
+        /// <summary>
+        /// Verifies an identifier diagnostic is left to the existing hints even when an introduced
+        /// type shares the name.
+        /// </summary>
+        [Test]
+        public void TryBuild_WhenErrorCodeIsIdentifierNotFound_ProducesNothing()
+        {
+            bool built = IntroducedTypeDiagnosticHint.TryBuild(
+                "CS0103",
+                "The name 'Widget' does not exist in the current context",
+                new List<string> { "Example.Widget" },
+                out string hint,
+                out List<string> suggestions);
+
+            Assert.That(built, Is.False);
+            Assert.That(hint, Is.Empty);
+            Assert.That(suggestions, Is.Null);
+        }
+
+        /// <summary>
+        /// Verifies a missing type that no introduced type is named after produces nothing.
+        /// </summary>
+        [Test]
+        public void TryBuild_WhenNoIntroducedTypeSharesTheName_ProducesNothing()
+        {
+            bool built = IntroducedTypeDiagnosticHint.TryBuild(
+                "CS0246",
+                "The type or namespace name 'Widget' could not be found",
+                new List<string> { "Example.Gadget" },
+                out string hint,
+                out List<string> suggestions);
+
+            Assert.That(built, Is.False);
+            Assert.That(hint, Is.Empty);
+            Assert.That(suggestions, Is.Null);
+        }
+
+        /// <summary>
+        /// Verifies a CS0234 does not match an introduced type of the same simple name that lives in
+        /// another namespace.
+        /// </summary>
+        [Test]
+        public void TryBuild_WhenNamespaceMemberMissingAndNamespacesDiffer_ProducesNothing()
+        {
+            bool built = IntroducedTypeDiagnosticHint.TryBuild(
+                "CS0234",
+                "The type or namespace name 'Widget' does not exist in the namespace 'Example'",
+                new List<string> { "Other.Widget" },
+                out string hint,
+                out List<string> suggestions);
+
+            Assert.That(built, Is.False);
+            Assert.That(hint, Is.Empty);
+            Assert.That(suggestions, Is.Null);
+        }
+
+        /// <summary>
+        /// Verifies a CS0246 matching several introduced types lists all of them and suggests
+        /// reflection for each.
+        /// </summary>
+        [Test]
+        public void TryBuild_WhenSeveralIntroducedTypesShareTheName_ListsEveryCandidate()
+        {
+            bool built = IntroducedTypeDiagnosticHint.TryBuild(
+                "CS0246",
+                "The type or namespace name 'Widget' could not be found",
+                new List<string> { "Example.Widget", "Other.Widget" },
+                out string hint,
+                out List<string> suggestions);
+
+            Assert.That(built, Is.True);
+            Assert.That(
+                hint,
+                Is.EqualTo(
+                    "'Widget' matches these hot-reload introduced types: Example.Widget, Other.Widget. execute-dynamic-code compiles against the compiled assemblies only, so none of them is visible here until it is compiled. Pick the one you mean and use reflection through the loaded assembly (AppDomain.CurrentDomain.GetAssemblies), or run 'uloop compile' to make it a compiled type."));
+            Assert.That(
+                suggestions,
+                Is.EqualTo(new[]
+                {
+                    SingleMatchReflectionSuggestion,
+                    "Locate the type with AppDomain.CurrentDomain.GetAssemblies().SelectMany(a => a.GetTypes()).First(t => t.FullName == \"Other.Widget\") and drive it through reflection",
+                    CompileSuggestion
+                }));
+        }
+    }
+}

--- a/Assets/Tests/Editor/DynamicCodeToolTests/IntroducedTypeDiagnosticHintTests.cs.meta
+++ b/Assets/Tests/Editor/DynamicCodeToolTests/IntroducedTypeDiagnosticHintTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 25c5c4eb7694242b79835710c6007a7b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/HotReload/HotReloadIntroducedTypeActivationTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadIntroducedTypeActivationTests.cs
@@ -10,6 +10,7 @@ using NUnit.Framework;
 using UnityEngine;
 
 using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+using io.github.hatayama.UnityCliLoop.ToolContracts;
 
 namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 {
@@ -57,6 +58,37 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 Assert.That(
                     HotReloadIntroducedTypeHolder.Resolver.ResolveExact(artifact.AssemblyFullName),
                     Is.SameAs(artifact.Assembly));
+            }
+        }
+
+        /// <summary>
+        /// Verifies that Initialize publishes the introduced type names through the tool contract
+        /// port, so a tool that cannot reference this assembly sees what the registry holds.
+        /// </summary>
+        [Test]
+        public void Holder_AfterInitialize_PublishesActiveTypeNamesThroughTheToolContractPort()
+        {
+            HotReloadIntroducedTypeArtifact artifact = CreateArtifact();
+
+            using (HotReloadIntroducedTypeHolder.BeginReplacement())
+            {
+                HotReloadIntroducedTypeHolder.Initialize();
+                HotReloadIntroducedTypeHolder.Registry.RegisterPrepared(artifact);
+                HotReloadIntroducedTypeHolder.Registry.Activate(artifact);
+
+                Func<IReadOnlyList<string>> describe =
+                    HotReloadIntroducedTypeCoordination.DescribeActiveTypeNames;
+                Assert.That(describe, Is.Not.Null);
+
+                List<string> expected = new List<string>();
+                foreach (HotReloadIntroducedTypeDescriptor descriptor
+                    in HotReloadIntroducedTypeHolder.Registry.DescribeActive())
+                {
+                    expected.Add(descriptor.MetadataName);
+                }
+
+                Assert.That(describe(), Is.EqualTo(expected));
+                Assert.That(expected, Is.Not.Empty);
             }
         }
 

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/CompilationDiagnosticMessageParser.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/CompilationDiagnosticMessageParser.cs
@@ -25,6 +25,32 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return NormalizeTypeName(match.Groups[1].Value);
         }
 
+        /// <summary>
+        /// Returns the namespace of a CS0234 message, whose second quoted phrase is the namespace
+        /// the missing type was looked for in. Null when the message has no second quoted phrase.
+        /// </summary>
+        public static string ExtractNamespaceNameFromMessage(string message)
+        {
+            if (message == null)
+            {
+                return null;
+            }
+
+            MatchCollection matches = TypeNamePattern.Matches(message);
+            if (matches.Count < 2)
+            {
+                return null;
+            }
+
+            string rawNamespace = matches[1].Groups[1].Value;
+            if (string.IsNullOrWhiteSpace(rawNamespace))
+            {
+                return null;
+            }
+
+            return rawNamespace.Trim();
+        }
+
         private static string NormalizeTypeName(string rawName)
         {
             if (string.IsNullOrWhiteSpace(rawName))

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCodeExecutionResponseFactory.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCodeExecutionResponseFactory.cs
@@ -362,6 +362,23 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             string hint = string.Empty;
             List<string> suggestions = new();
 
+            // A missing type that hot reload introduced is a design limit of this tool, not a
+            // spelling or using-directive problem, so it is explained before the generic hints.
+            IReadOnlyList<string> introducedTypeNames =
+                HotReloadIntroducedTypeCoordination.DescribeActiveTypeNames?.Invoke();
+            if (IntroducedTypeDiagnosticHint.TryBuild(
+                    error.ErrorCode,
+                    error.Message,
+                    introducedTypeNames,
+                    out string introducedTypeHint,
+                    out List<string> introducedTypeSuggestions))
+            {
+                // The ambiguous candidates stay available behind the introduced-type ones: the
+                // diagnostic cannot tell which of the two the caller meant.
+                AppendAmbiguousCandidateSuggestions(error, ambiguousCandidates, introducedTypeSuggestions);
+                return (introducedTypeHint, introducedTypeSuggestions);
+            }
+
             switch (error.ErrorCode)
             {
                 case "CS0246":
@@ -425,6 +442,29 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     }
 
                     return (hint, suggestions);
+            }
+        }
+
+        private static void AppendAmbiguousCandidateSuggestions(
+            CompilationError error,
+            Dictionary<string, List<string>> ambiguousCandidates,
+            List<string> suggestions)
+        {
+            if (ambiguousCandidates == null)
+            {
+                return;
+            }
+
+            string typeName = CompilationDiagnosticMessageParser.ExtractTypeNameFromMessage(error.Message);
+            if (typeName == null
+                || !ambiguousCandidates.TryGetValue(typeName, out List<string> candidates))
+            {
+                return;
+            }
+
+            foreach (string ns in candidates)
+            {
+                suggestions.Add($"Use {ns}.{typeName}");
             }
         }
 

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCodeExecutionResponseFactory.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCodeExecutionResponseFactory.cs
@@ -364,43 +364,19 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             // A missing type that hot reload introduced is a design limit of this tool, not a
             // spelling or using-directive problem, so it is explained before the generic hints.
-            IReadOnlyList<string> introducedTypeNames =
-                HotReloadIntroducedTypeCoordination.DescribeActiveTypeNames?.Invoke();
-            if (IntroducedTypeDiagnosticHint.TryBuild(
-                    error.ErrorCode,
-                    error.Message,
-                    introducedTypeNames,
+            if (TryBuildIntroducedTypeHint(
+                    error,
+                    ambiguousCandidates,
                     out string introducedTypeHint,
                     out List<string> introducedTypeSuggestions))
             {
-                // The ambiguous candidates stay available behind the introduced-type ones: the
-                // diagnostic cannot tell which of the two the caller meant.
-                AppendAmbiguousCandidateSuggestions(error, ambiguousCandidates, introducedTypeSuggestions);
                 return (introducedTypeHint, introducedTypeSuggestions);
             }
 
             switch (error.ErrorCode)
             {
                 case "CS0246":
-                    string typeName = CompilationDiagnosticMessageParser.ExtractTypeNameFromMessage(error.Message);
-                    if (typeName != null
-                        && ambiguousCandidates != null
-                        && ambiguousCandidates.TryGetValue(typeName, out List<string> candidates))
-                    {
-                        string candidateList = string.Join(", ", candidates);
-                        hint = $"Auto-using resolution found multiple candidates for '{typeName}': {candidateList}. Use a fully-qualified name or add the correct using directive.";
-                        foreach (string ns in candidates)
-                        {
-                            suggestions.Add($"Use {ns}.{typeName}");
-                        }
-
-                        return (hint, suggestions);
-                    }
-
-                    hint = "Auto-using resolution was attempted but could not resolve this identifier. Use a fully-qualified name (e.g., UnityEngine.Mathf) or add the correct using directive.";
-                    suggestions.Add("Use fully-qualified name (e.g., UnityEngine.Mathf, System.Linq.Enumerable)");
-                    suggestions.Add("Add the appropriate using directive at the top of the snippet");
-                    return (hint, suggestions);
+                    return BuildTypeNotFoundHint(error, ambiguousCandidates);
 
                 case "CS0103":
                     string identifierName = CompilationDiagnosticMessageParser.ExtractTypeNameFromMessage(error.Message);
@@ -443,6 +419,57 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
                     return (hint, suggestions);
             }
+        }
+
+        private static (string hint, List<string> suggestions) BuildTypeNotFoundHint(
+            CompilationError error,
+            Dictionary<string, List<string>> ambiguousCandidates)
+        {
+            List<string> suggestions = new();
+            string typeName = CompilationDiagnosticMessageParser.ExtractTypeNameFromMessage(error.Message);
+            if (typeName != null
+                && ambiguousCandidates != null
+                && ambiguousCandidates.TryGetValue(typeName, out List<string> candidates))
+            {
+                string candidateList = string.Join(", ", candidates);
+                string ambiguousHint = $"Auto-using resolution found multiple candidates for '{typeName}': {candidateList}. Use a fully-qualified name or add the correct using directive.";
+                foreach (string ns in candidates)
+                {
+                    suggestions.Add($"Use {ns}.{typeName}");
+                }
+
+                return (ambiguousHint, suggestions);
+            }
+
+            suggestions.Add("Use fully-qualified name (e.g., UnityEngine.Mathf, System.Linq.Enumerable)");
+            suggestions.Add("Add the appropriate using directive at the top of the snippet");
+            return (
+                "Auto-using resolution was attempted but could not resolve this identifier. Use a fully-qualified name (e.g., UnityEngine.Mathf) or add the correct using directive.",
+                suggestions);
+        }
+
+        private static bool TryBuildIntroducedTypeHint(
+            CompilationError error,
+            Dictionary<string, List<string>> ambiguousCandidates,
+            out string hint,
+            out List<string> suggestions)
+        {
+            IReadOnlyList<string> introducedTypeNames =
+                HotReloadIntroducedTypeCoordination.DescribeActiveTypeNames?.Invoke();
+            if (!IntroducedTypeDiagnosticHint.TryBuild(
+                    error.ErrorCode,
+                    error.Message,
+                    introducedTypeNames,
+                    out hint,
+                    out suggestions))
+            {
+                return false;
+            }
+
+            // The ambiguous candidates stay available behind the introduced-type ones: the
+            // diagnostic cannot tell which of the two the caller meant.
+            AppendAmbiguousCandidateSuggestions(error, ambiguousCandidates, suggestions);
+            return true;
         }
 
         private static void AppendAmbiguousCandidateSuggestions(

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/IntroducedTypeDiagnosticHint.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/IntroducedTypeDiagnosticHint.cs
@@ -1,0 +1,143 @@
+using System;
+using System.Collections.Generic;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Explains a missing-type diagnostic whose name is a hot-reload introduced type: dynamic
+    /// code compiles against on-disk assemblies only, so the type is invisible here by design.
+    /// </summary>
+    internal static class IntroducedTypeDiagnosticHint
+    {
+        private const string TypeOrNamespaceNotFoundErrorCode = "CS0246";
+        private const string NamespaceMemberNotFoundErrorCode = "CS0234";
+
+        private const string CompileSuggestion =
+            "Run 'uloop compile' when the type is final, then reference it directly";
+
+        /// <summary>
+        /// Builds the hint and suggestions for a diagnostic that names an active introduced type.
+        /// Returns false when the diagnostic is unrelated, which leaves the existing hints in place.
+        /// </summary>
+        internal static bool TryBuild(
+            string errorCode,
+            string message,
+            IReadOnlyList<string> activeIntroducedTypeNames,
+            out string hint,
+            out List<string> suggestions)
+        {
+            hint = string.Empty;
+            suggestions = null;
+
+            if (!IsMissingTypeErrorCode(errorCode))
+            {
+                return false;
+            }
+
+            if (activeIntroducedTypeNames == null || activeIntroducedTypeNames.Count == 0)
+            {
+                return false;
+            }
+
+            string name = CompilationDiagnosticMessageParser.ExtractTypeNameFromMessage(message);
+            if (string.IsNullOrEmpty(name))
+            {
+                return false;
+            }
+
+            // Why the namespace is only read for CS0234: CS0246 reports an unqualified name, so its
+            // message carries no namespace to narrow the match with.
+            string namespaceName = string.Equals(errorCode, NamespaceMemberNotFoundErrorCode, StringComparison.Ordinal)
+                ? CompilationDiagnosticMessageParser.ExtractNamespaceNameFromMessage(message)
+                : null;
+
+            List<string> matches = CollectMatches(activeIntroducedTypeNames, name, namespaceName);
+            if (matches.Count == 0)
+            {
+                return false;
+            }
+
+            hint = BuildHint(name, matches);
+            suggestions = BuildSuggestions(matches);
+            return true;
+        }
+
+        private static bool IsMissingTypeErrorCode(string errorCode)
+        {
+            return string.Equals(errorCode, TypeOrNamespaceNotFoundErrorCode, StringComparison.Ordinal)
+                || string.Equals(errorCode, NamespaceMemberNotFoundErrorCode, StringComparison.Ordinal);
+        }
+
+        private static List<string> CollectMatches(
+            IReadOnlyList<string> activeIntroducedTypeNames,
+            string name,
+            string namespaceName)
+        {
+            List<string> matches = new List<string>();
+            foreach (string metadataName in activeIntroducedTypeNames)
+            {
+                if (string.IsNullOrEmpty(metadataName))
+                {
+                    continue;
+                }
+
+                if (!string.Equals(ExtractSimpleName(metadataName), name, StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                if (!IsInNamespace(metadataName, namespaceName))
+                {
+                    continue;
+                }
+
+                matches.Add(metadataName);
+            }
+
+            return matches;
+        }
+
+        private static string ExtractSimpleName(string metadataName)
+        {
+            int separatorIndex = metadataName.LastIndexOfAny(new[] { '.', '+' });
+            return separatorIndex < 0
+                ? metadataName
+                : metadataName.Substring(separatorIndex + 1);
+        }
+
+        private static bool IsInNamespace(string metadataName, string namespaceName)
+        {
+            if (string.IsNullOrEmpty(namespaceName))
+            {
+                return true;
+            }
+
+            return metadataName.StartsWith(namespaceName + ".", StringComparison.Ordinal);
+        }
+
+        private static string BuildHint(string name, List<string> matches)
+        {
+            if (matches.Count == 1)
+            {
+                return $"'{name}' is a hot-reload introduced type ({matches[0]}). execute-dynamic-code compiles against the compiled assemblies only, so an introduced type is not visible here until it is compiled. Use reflection through the loaded assembly (AppDomain.CurrentDomain.GetAssemblies) while it is active, or run 'uloop compile' to make it a compiled type.";
+            }
+
+            string candidateList = string.Join(", ", matches);
+            return $"'{name}' matches these hot-reload introduced types: {candidateList}. execute-dynamic-code compiles against the compiled assemblies only, so none of them is visible here until it is compiled. Pick the one you mean and use reflection through the loaded assembly (AppDomain.CurrentDomain.GetAssemblies), or run 'uloop compile' to make it a compiled type.";
+        }
+
+        private static List<string> BuildSuggestions(List<string> matches)
+        {
+            List<string> suggestions = new List<string>();
+            foreach (string metadataName in matches)
+            {
+                suggestions.Add(
+                    "Locate the type with AppDomain.CurrentDomain.GetAssemblies().SelectMany(a => a.GetTypes())"
+                    + $".First(t => t.FullName == \"{metadataName}\") and drive it through reflection");
+            }
+
+            suggestions.Add(CompileSuggestion);
+            return suggestions;
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/IntroducedTypeDiagnosticHint.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/IntroducedTypeDiagnosticHint.cs
@@ -91,7 +91,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     continue;
                 }
 
-                matches.Add(metadataName);
+                // Hot reload publishes Cecil metadata names ('Outer/Inner'); the reported name has
+                // to be the reflection form, because that is what a suggested lookup compares.
+                matches.Add(metadataName.Replace('/', '+'));
             }
 
             return matches;
@@ -99,7 +101,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
         private static string ExtractSimpleName(string metadataName)
         {
-            int separatorIndex = metadataName.LastIndexOfAny(new[] { '.', '+' });
+            // Both nesting separators are accepted: hot reload publishes Cecil metadata names
+            // ('Outer/Inner'), while the same name reads as 'Outer+Inner' through reflection.
+            int separatorIndex = metadataName.LastIndexOfAny(new[] { '.', '+', '/' });
             return separatorIndex < 0
                 ? metadataName
                 : metadataName.Substring(separatorIndex + 1);

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/IntroducedTypeDiagnosticHint.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/IntroducedTypeDiagnosticHint.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1c002c53382e74fa4be0ea99f9aed575
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadIntroducedTypeHolder.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadIntroducedTypeHolder.cs
@@ -1,4 +1,7 @@
 using System;
+using System.Collections.Generic;
+
+using io.github.hatayama.UnityCliLoop.ToolContracts;
 
 namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 {
@@ -28,6 +31,33 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             resolver?.Dispose();
             registry = new HotReloadIntroducedTypeRegistry();
             resolver = new HotReloadIntroducedTypeAssemblyResolver(registry);
+            HotReloadIntroducedTypeCoordination.DescribeActiveTypeNames = DescribeActiveTypeNames;
+        }
+
+        /// <summary>
+        /// Reports the metadata names of the active introduced types for tools that cannot
+        /// reference this assembly.
+        /// </summary>
+        /// <remarks>
+        /// Why the field is read rather than the Registry property: a caller asking what this
+        /// domain holds must get an answer even while a replacement scope is open, and the
+        /// property throws when no registry is installed.
+        /// </remarks>
+        private static IReadOnlyList<string> DescribeActiveTypeNames()
+        {
+            HotReloadIntroducedTypeRegistry currentRegistry = registry;
+            if (currentRegistry == null)
+            {
+                return Array.Empty<string>();
+            }
+
+            List<string> names = new List<string>();
+            foreach (HotReloadIntroducedTypeDescriptor descriptor in currentRegistry.DescribeActive())
+            {
+                names.Add(descriptor.MetadataName);
+            }
+
+            return names;
         }
 
         /// <summary>

--- a/Packages/src/Editor/FirstPartyTools/HotReload/Skill/references/introduced-types.md
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/Skill/references/introduced-types.md
@@ -70,7 +70,9 @@ that reaches the type through Unity (serialization, `[SerializeField]`, Inspecto
 `AddComponent`, `CreateInstance`, message discovery); a call to a member an earlier or the same
 reload *added* to a compiled type (an `Added` row), because introduced types compile against the
 compiled assemblies and retained artifacts only, so the compile fails naming the missing member;
-and any new or changed `.asmdef` / `.asmref`.
+and any new or changed `.asmdef` / `.asmref`. When `execute-dynamic-code` fails on an introduced
+type, the diagnostic's `Hint` names it and points to reflection through the loaded assembly or to
+`uloop compile`.
 
 ## File selection and new files
 

--- a/Packages/src/Editor/ToolContracts/HotReloadIntroducedTypeCoordination.cs
+++ b/Packages/src/Editor/ToolContracts/HotReloadIntroducedTypeCoordination.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Collections.Generic;
+
+namespace io.github.hatayama.UnityCliLoop.ToolContracts
+{
+    /// <summary>
+    /// Lets other tools ask hot reload which introduced types are active without referencing
+    /// the hot reload assembly. Null until hot reload initializes.
+    /// </summary>
+    public static class HotReloadIntroducedTypeCoordination
+    {
+        /// <summary>
+        /// Set by HotReloadIntroducedTypeHolder. Returns the metadata names
+        /// (Namespace.Outer+Nested form) of every active introduced type, empty when none.
+        /// </summary>
+        public static Func<IReadOnlyList<string>> DescribeActiveTypeNames { get; set; }
+    }
+}

--- a/Packages/src/Editor/ToolContracts/HotReloadIntroducedTypeCoordination.cs
+++ b/Packages/src/Editor/ToolContracts/HotReloadIntroducedTypeCoordination.cs
@@ -10,8 +10,10 @@ namespace io.github.hatayama.UnityCliLoop.ToolContracts
     public static class HotReloadIntroducedTypeCoordination
     {
         /// <summary>
-        /// Set by HotReloadIntroducedTypeHolder. Returns the metadata names
-        /// (Namespace.Outer+Nested form) of every active introduced type, empty when none.
+        /// Set by HotReloadIntroducedTypeHolder. Returns the metadata name of every active
+        /// introduced type, empty when none. These are metadata names as defined in
+        /// docs/glossary.md: nested types are joined with '/'. Convert one to the reflection
+        /// form before comparing it against Type.FullName or passing it to Assembly.GetType.
         /// </summary>
         public static Func<IReadOnlyList<string>> DescribeActiveTypeNames { get; set; }
     }

--- a/Packages/src/Editor/ToolContracts/HotReloadIntroducedTypeCoordination.cs.meta
+++ b/Packages/src/Editor/ToolContracts/HotReloadIntroducedTypeCoordination.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9b3ecd1396fa844e4aa116f30434c1e5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -184,6 +184,19 @@ reload. Hot reload adopts a snapshot as the edited-method baseline only when its
 match the corresponding portable-PDB document checksum for that source file; otherwise
 the file falls back to patching every editable method.
 
+### Metadata name
+
+The ECMA-335 spelling of a type as Cecil and the transform worker emit it: namespace and
+type joined with `.`, nested types joined with `/` (`Example.Outer/Inner`). Introduced-type
+descriptors, worker method keys, and added-field keys carry this form.
+
+### Reflection name
+
+The CLR spelling that `Type.FullName` returns and `Assembly.GetType` accepts: nested types
+joined with `+` (`Example.Outer+Inner`). Anything compared against a live `Type`, or shown
+to an agent as a `FullName` to look up, must be converted to this form at the boundary
+where the metadata name leaves the worker.
+
 ### Shim
 
 A generated static method that mirrors an edited user method body for hot reload. For an

--- a/docs/hot-reload-introduced-types.md
+++ b/docs/hot-reload-introduced-types.md
@@ -88,7 +88,9 @@ recovery: the types stay loaded whatever the methods did, so a re-apply is not a
 - Anything that reads the type through Unity: serialization, `[SerializeField]`, Inspector
   display, `AddComponent`, `ScriptableObject.CreateInstance`, Unity message discovery.
 - Use from `uloop execute-dynamic-code`. Dynamic code compiles against the compiled assemblies,
-  not against the reload's artifact.
+  not against the reload's artifact. The compile error's `Hint` names the introduced type and
+  points to reflection through the loaded assembly or to `uloop compile`, so the failure does not
+  read as a missing type.
 - A new or changed `.asmdef` / `.asmref`. Assembly layout is decided at compile time.
 - A call to a member an earlier or the same reload *added* to a compiled type (an `Added` row).
   Introduced types compile against the compiled assemblies and the retained artifacts only, so


### PR DESCRIPTION
## Summary
- A `execute-dynamic-code` compile error that names a hot-reload introduced type now says so, instead of reading as if the type does not exist.

## User Impact
- Before: referencing a type introduced by hot reload from `uloop execute-dynamic-code` failed with `CS0246: The type or namespace name 'X' could not be found` (or `CS0234 ... does not exist in the namespace 'N'` when the namespace itself is compiled) and an empty `Hint`. The response gave no sign that this is a known limit of the dynamic-code path, so the natural reaction was to suspect the introduced type and investigate it.
- After: when the missing name matches an active introduced type, the diagnostic names it and points at the two routes that actually work — reflection through the loaded assembly while it is active, or `uloop compile` to make it a compiled type. Several introduced types of the same simple name are all listed so the caller can pick.
- Making an introduced type directly referenceable from dynamic code is out of scope here and tracked in #2699.

## Changes
- New `IntroducedTypeDiagnosticHint` (ExecuteDynamicCode) matches a `CS0246` / `CS0234` diagnostic against the active introduced type names — simple-name match, plus a namespace-prefix match for `CS0234` — and builds the hint and suggestions.
- New `HotReloadIntroducedTypeCoordination` port in `ToolContracts`, set by `HotReloadIntroducedTypeHolder.Initialize`. Neither tool assembly references the other; a null delegate (hot reload not initialized in this domain) leaves the existing hints untouched.
- `CompilationDiagnosticMessageParser.ExtractNamespaceNameFromMessage` reads the second quoted phrase of a `CS0234` message (a separate method, not an overload).
- `GetHintAndSuggestions` consults the new hint before its switch. When the same name is also an ambiguous auto-using candidate, the existing `Use {ns}.{type}` suggestions stay behind the introduced-type ones — the diagnostic alone cannot tell which route was meant, so both stay available.
- Documented the new `Hint` in the hot reload skill reference and `docs/hot-reload-introduced-types.md` (skill copies regenerated with `uloop skills install`).

## Verification
- `uloop run-tests --filter-type class --filter-value IntroducedTypeDiagnosticHintTests` — 8 passed (red before the implementation: the class did not compile).
- `uloop run-tests --filter-type class --filter-value DynamicCodeExecutionResponseFactoryTests` — 16 passed (red before wiring).
- `uloop run-tests --filter-type class --filter-value CompilationDiagnosticMessageParserTests` — 3 passed.
- `uloop run-tests --filter-type class --filter-value HotReloadIntroducedTypeActivationTests` — 25 passed; the new wiring test was confirmed red (`Expected: not null / But was: null`) with the `Initialize` delegate assignment temporarily removed, then restored.
- `uloop run-tests --filter-type class --filter-value HotReloadIntroducedTypeRegistryTests` — 21 passed.
- `uloop compile` clean; `check-skill-size` reports no skill over the limit.

https://claude.ai/code/session_01Kx1PySdK82LC6AG96v2vus


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2701?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

