### PR TITLE
chore: share one catalog base across added fields, methods, and properties

### DIFF
--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AddedFieldCatalog.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AddedFieldCatalog.cs
@@ -19,11 +19,8 @@ using Microsoft.CodeAnalysis.Text;
 /// What: file-wide catalog of added fields, syntax keys for drift strip, store-rewrite
 /// presence, and display names of fields rewritten in emitted shim bodies.
 /// </summary>
-internal sealed class AddedFieldCatalog
+internal sealed class AddedFieldCatalog : AddedMemberCatalog<AddedFieldBinding>
 {
-    private readonly Dictionary<string, AddedFieldBinding> _byKey =
-        new Dictionary<string, AddedFieldBinding>(StringComparer.Ordinal);
-    private readonly HashSet<string> _classifiedAddedKeys = new HashSet<string>(StringComparer.Ordinal);
     private readonly HashSet<string> _rewrittenAddedFieldKeys = new HashSet<string>(StringComparer.Ordinal);
     private readonly HashSet<string> _foldedConstKeys = new HashSet<string>(StringComparer.Ordinal);
     private readonly HashSet<string> _addedSyntaxKeys = new HashSet<string>(StringComparer.Ordinal);
@@ -33,16 +30,11 @@ internal sealed class AddedFieldCatalog
 
     public IReadOnlyCollection<string> RemovedSyntaxKeys => _removedSyntaxKeys;
 
-    public bool HasClassifiedAdded => _classifiedAddedKeys.Count > 0;
-
     public bool HasStoreRewrites { get; private set; }
 
-    public void MarkClassifiedAdded(string fieldKey)
+    protected override string KeyOf(AddedFieldBinding binding)
     {
-        if (fieldKey != null)
-        {
-            _classifiedAddedKeys.Add(fieldKey);
-        }
+        return binding.FieldKey;
     }
 
     public void AddAddedSyntaxKey(string syntaxKey)
@@ -55,19 +47,7 @@ internal sealed class AddedFieldCatalog
         _removedSyntaxKeys.Add(syntaxKey);
     }
 
-    public void RegisterStore(AddedFieldBinding binding)
-    {
-        _byKey[binding.FieldKey] = binding;
-        MarkClassifiedAdded(binding.FieldKey);
-    }
-
-    public void RegisterConst(AddedFieldBinding binding)
-    {
-        _byKey[binding.FieldKey] = binding;
-        MarkClassifiedAdded(binding.FieldKey);
-    }
-
-    // Why rewritten keys, not RegisterStore/RegisterConst: those fire at declaration
+    // Why rewritten keys, not Register: registration fires at declaration
     // classification, so unused fields and isolation-excluded bodies would still list.
     // Excluded methods are dropped in TypeEmitPlanner.QueueTypeMethods before rewrite, so a file-wide
     // rewrite set matches emitted entries without per-entry tracking.
@@ -88,7 +68,7 @@ internal sealed class AddedFieldCatalog
         List<string> names = new List<string>(fieldKeys.Count);
         foreach (string fieldKey in fieldKeys)
         {
-            AddedFieldBinding binding = _byKey[fieldKey];
+            AddedFieldBinding binding = GetRegistered(fieldKey);
             if (!string.Equals(binding.SourceProjectRelativePath, projectRelativePath, StringComparison.Ordinal))
             {
                 continue;
@@ -116,22 +96,6 @@ internal sealed class AddedFieldCatalog
         string fieldName = fieldKey.Substring(
             separatorIndex + TransformWorkerProgramMarker.AddedFieldKeySeparator.Length);
         return typeMetadataName + "." + fieldName;
-    }
-
-    public void RegisterUnavailable(AddedFieldBinding binding)
-    {
-        _byKey[binding.FieldKey] = binding;
-        MarkClassifiedAdded(binding.FieldKey);
-    }
-
-    public AddedFieldBinding FindOrNull(string fieldKey)
-    {
-        if (fieldKey == null)
-        {
-            return null;
-        }
-
-        return _byKey.TryGetValue(fieldKey, out AddedFieldBinding binding) ? binding : null;
     }
 
     public void MarkStoreRewrite(string fieldKey)

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AddedFieldClassifier.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AddedFieldClassifier.cs
@@ -106,10 +106,11 @@ internal static class AddedFieldClassifier
             fieldSymbol.Name);
         if (declarationChangeReason != null)
         {
-            // Why not RegisterStore: rewriting to the side table would hide the
-            // declaration change and leave compiled callers on the old field.
+            // Why register as unavailable: the reason set here is what stops the field from
+            // being rewritten to the side table, which would hide the declaration change and
+            // leave compiled callers on the old field.
             binding.UnavailableReason = declarationChangeReason;
-            addedFieldCatalog.RegisterUnavailable(binding);
+            addedFieldCatalog.Register(binding);
             return;
         }
 
@@ -123,17 +124,17 @@ internal static class AddedFieldClassifier
 
         if (binding.UnavailableReason != null)
         {
-            addedFieldCatalog.RegisterUnavailable(binding);
+            addedFieldCatalog.Register(binding);
             return;
         }
 
         if (fieldSymbol.IsConst)
         {
-            addedFieldCatalog.RegisterConst(binding);
+            addedFieldCatalog.Register(binding);
             return;
         }
 
-        addedFieldCatalog.RegisterStore(binding);
+        addedFieldCatalog.Register(binding);
     }
 
     internal static string EvaluateAddedFieldAvailability(

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AddedMemberCatalog.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AddedMemberCatalog.cs
@@ -1,0 +1,85 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Collections.Immutable;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Runtime.Loader;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Text;
+
+/// <summary>
+/// What: the "key to binding" ledger and the "classified as added" key set that the added
+/// field, method, and property families all keep. Derived catalogs supply the key of a
+/// binding and add whatever else their family needs.
+/// </summary>
+internal abstract class AddedMemberCatalog<TBinding> where TBinding : class
+{
+    private readonly Dictionary<string, TBinding> _byKey = new Dictionary<string, TBinding>(StringComparer.Ordinal);
+    private readonly HashSet<string> _classifiedAddedKeys = new HashSet<string>(StringComparer.Ordinal);
+
+    public bool HasClassifiedAdded => _classifiedAddedKeys.Count > 0;
+
+    protected IEnumerable<TBinding> RegisteredBindings => _byKey.Values;
+
+    /// <summary>Returns the ledger key of a binding (its field, method, or property key).</summary>
+    protected abstract string KeyOf(TBinding binding);
+
+    public void Register(TBinding binding)
+    {
+        Debug.Assert(binding != null, "binding must not be null.");
+        string key = KeyOf(binding);
+        Debug.Assert(!string.IsNullOrEmpty(key), "binding key must not be null or empty.");
+        _byKey[key] = binding;
+        MarkClassifiedAdded(key);
+    }
+
+    public void MarkClassifiedAdded(string key)
+    {
+        if (key != null)
+        {
+            _classifiedAddedKeys.Add(key);
+        }
+    }
+
+    public bool IsClassifiedAdded(string key)
+    {
+        return key != null && _classifiedAddedKeys.Contains(key);
+    }
+
+    public bool Contains(string key)
+    {
+        return key != null && _byKey.ContainsKey(key);
+    }
+
+    public TBinding FindOrNull(string key)
+    {
+        if (key == null)
+        {
+            return null;
+        }
+
+        return _byKey.TryGetValue(key, out TBinding binding) ? binding : null;
+    }
+
+    // Why the classified set survives: a key that was classified but is no longer registered is
+    // how a family reports "added but unavailable".
+    protected bool RemoveRegistered(string key)
+    {
+        return _byKey.Remove(key);
+    }
+
+    // Why indexing, not TryGetValue: callers that already hold a key from this catalog treat a
+    // miss as a broken invariant rather than an absent entry.
+    protected TBinding GetRegistered(string key)
+    {
+        return _byKey[key];
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AddedMethodCatalog.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AddedMethodCatalog.cs
@@ -15,11 +15,8 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Text;
 
-internal sealed class AddedMethodCatalog
+internal sealed class AddedMethodCatalog : AddedMemberCatalog<AddedMethodBinding>
 {
-    private readonly Dictionary<string, AddedMethodBinding> _byKey =
-        new Dictionary<string, AddedMethodBinding>(StringComparer.Ordinal);
-    private readonly HashSet<string> _classifiedAddedKeys = new HashSet<string>(StringComparer.Ordinal);
     private readonly HashSet<string> _addedSyntaxKeys = new HashSet<string>(StringComparer.Ordinal);
     private readonly HashSet<string> _addedTypeSyntaxKeys = new HashSet<string>(StringComparer.Ordinal);
     private readonly HashSet<string> _addedPropertySyntaxKeys = new HashSet<string>(StringComparer.Ordinal);
@@ -33,23 +30,9 @@ internal sealed class AddedMethodCatalog
 
     public IReadOnlyCollection<string> RemovedSyntaxKeys => _removedSyntaxKeys;
 
-    public void Register(AddedMethodBinding binding)
+    protected override string KeyOf(AddedMethodBinding binding)
     {
-        _byKey[binding.MethodKey] = binding;
-        MarkClassifiedAdded(binding.MethodKey);
-    }
-
-    public void MarkClassifiedAdded(string methodKey)
-    {
-        if (methodKey != null)
-        {
-            _classifiedAddedKeys.Add(methodKey);
-        }
-    }
-
-    public bool IsClassifiedAdded(string methodKey)
-    {
-        return methodKey != null && _classifiedAddedKeys.Contains(methodKey);
+        return binding.MethodKey;
     }
 
     public bool IsUnavailableAdded(string methodKey)
@@ -83,21 +66,6 @@ internal sealed class AddedMethodCatalog
         _removedSyntaxKeys.Add(syntaxKey);
     }
 
-    public bool Contains(string methodKey)
-    {
-        return methodKey != null && _byKey.ContainsKey(methodKey);
-    }
-
-    public AddedMethodBinding FindOrNull(string methodKey)
-    {
-        if (methodKey == null)
-        {
-            return null;
-        }
-
-        return _byKey.TryGetValue(methodKey, out AddedMethodBinding binding) ? binding : null;
-    }
-
     // A metadata receiver cannot bind to a source-only added method, so the rewriter
     // matches on type name, method name, and argument count when GetSymbolInfo is unbound.
     public AddedMethodBinding FindUniqueByReceiverOrNull(
@@ -111,7 +79,7 @@ internal sealed class AddedMethodCatalog
         string prefix = typeMetadataName + "::" + methodName + "(";
         AddedMethodBinding unique = null;
         int matches = 0;
-        foreach (AddedMethodBinding binding in _byKey.Values)
+        foreach (AddedMethodBinding binding in RegisteredBindings)
         {
             if (binding.MethodKey == null
                 || !binding.MethodKey.StartsWith(prefix, StringComparison.Ordinal)
@@ -131,11 +99,12 @@ internal sealed class AddedMethodCatalog
         return matches == 1 ? unique : null;
     }
 
+    // Why the classified key stays: IsUnavailableAdded reads "classified but not registered".
     public void Unregister(string methodKey)
     {
         if (methodKey != null)
         {
-            _byKey.Remove(methodKey);
+            RemoveRegistered(methodKey);
         }
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AddedPropertyCatalog.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AddedPropertyCatalog.cs
@@ -18,43 +18,13 @@ using Microsoft.CodeAnalysis.Text;
 /// <summary>
 /// Added-property bindings indexed by property and accessor identity for classification and rewrite.
 /// </summary>
-internal sealed class AddedPropertyCatalog
+internal sealed class AddedPropertyCatalog : AddedMemberCatalog<AddedPropertyBinding>
 {
-    private readonly Dictionary<string, AddedPropertyBinding> _byPropertyKey =
-        new Dictionary<string, AddedPropertyBinding>(StringComparer.Ordinal);
-    private readonly HashSet<string> _classifiedAddedKeys = new HashSet<string>(StringComparer.Ordinal);
+    public IEnumerable<AddedPropertyBinding> Bindings => RegisteredBindings;
 
-    public IEnumerable<AddedPropertyBinding> Bindings => _byPropertyKey.Values;
-
-    public void MarkClassifiedAdded(string propertyKey)
+    protected override string KeyOf(AddedPropertyBinding binding)
     {
-        if (propertyKey != null)
-        {
-            _classifiedAddedKeys.Add(propertyKey);
-        }
-    }
-
-    public bool IsClassifiedAdded(string propertyKey)
-    {
-        return propertyKey != null && _classifiedAddedKeys.Contains(propertyKey);
-    }
-
-    public void Register(AddedPropertyBinding binding)
-    {
-        Debug.Assert(binding != null, "binding must not be null.");
-        Debug.Assert(!string.IsNullOrEmpty(binding.PropertyKey), "binding.PropertyKey must not be null or empty.");
-        _byPropertyKey[binding.PropertyKey] = binding;
-        MarkClassifiedAdded(binding.PropertyKey);
-    }
-
-    public AddedPropertyBinding FindOrNull(string propertyKey)
-    {
-        if (propertyKey == null)
-        {
-            return null;
-        }
-
-        return _byPropertyKey.TryGetValue(propertyKey, out AddedPropertyBinding binding) ? binding : null;
+        return binding.PropertyKey;
     }
 
     public AddedPropertyBinding FindBySymbolOrNull(IPropertySymbol propertySymbol)

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AddedPropertyClassifier.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AddedPropertyClassifier.cs
@@ -397,7 +397,7 @@ internal static class AddedPropertyClassifier
 
         // Why not AddAddedSyntaxKey: the field syntax-key set drives field drift stripping,
         // while the property declaration is already registered as an added property key.
-        addedFieldCatalog.RegisterStore(new AddedFieldBinding
+        addedFieldCatalog.Register(new AddedFieldBinding
         {
             SourceProjectRelativePath = binding.SourceProjectRelativePath,
             FieldKey = binding.PropertyKey,


### PR DESCRIPTION
## Summary
- Internal cleanup of the hot reload transform worker. No user-visible change.

## User Impact
- None. Skip reasons, shim names, and Skipped row ordering in hot reload output are byte-identical before and after this change.

## Changes
- Added a shared `AddedMemberCatalog<TBinding>` base that owns the key-to-binding ledger and the "classified as added" key set, with derived catalogs supplying only their key through `KeyOf`.
- The added-field, added-method, and added-property catalogs each dropped their own copy of that dictionary, that set, and the `Register` / `FindOrNull` / `MarkClassifiedAdded` / `IsClassifiedAdded` bodies.
- Removed `RegisterStore` / `RegisterConst` / `RegisterUnavailable` from the field catalog. Their bodies were identical because the store/const/unavailable distinction already lives on the binding (`IsConst`, `UnavailableReason`); call sites now use the single `Register`.
- Preserved the contracts that the families rely on: `Unregister` still removes only the ledger entry and keeps the classified key (so "added but unavailable" still resolves), `MarkClassifiedAdded(null)` and `FindOrNull(null)` stay no-ops, and the display-name listing keeps the indexer contract that throws on a key the catalog does not hold.

## Verification
- `uloop run-tests --filter-type class --filter-value <class>`, one class at a time: `TransformWorkerAddedFieldTests` (66 passed), `TransformWorkerAddedPropertyTests` (40), `TransformWorkerAddedMemberTests` (57), `TransformWorkerCrossFileTests` (11), `HotReloadWorkerRowsByFileTests` (3), `TransformWorkerIntroducedTypeTests` (24). 0 failed in every run.
- `uloop compile`: 0 errors, 0 warnings.
- `scripts/check-code-complexity.sh`: 0 issues (Go), no CA1502 findings above threshold 15 (C#).
- `scripts/check-file-length.sh`: no files above the 500 SLOC limit.

https://claude.ai/code/session_01H3pv1GH69HssoxHiHrYqWf


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2705?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

