### PR TITLE
chore: drop a redundant property binding field and a copied syntax-kind test

### DIFF
--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AddedPropertyBinding.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AddedPropertyBinding.cs
@@ -44,7 +44,6 @@ internal sealed class AddedPropertyBinding
 
     public MethodTransformDecision SetterDecision { get; set; }
 
-    public string StoreFieldKey { get; set; }
 
     public ExpressionSyntax Initializer { get; set; }
 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AddedPropertyBodyScan.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AddedPropertyBodyScan.cs
@@ -149,13 +149,13 @@ internal static class AddedPropertyBodyScan
         }
 
         if (expression.Parent is PrefixUnaryExpressionSyntax prefix
-            && IsIncrementOrDecrement(prefix.Kind()))
+            && AddedFieldBodyScan.IsIncrementOrDecrement(prefix.Kind()))
         {
             return AddedPropertySkipReasons.CompoundAssignment;
         }
 
         if (expression.Parent is PostfixUnaryExpressionSyntax postfix
-            && IsIncrementOrDecrement(postfix.Kind()))
+            && AddedFieldBodyScan.IsIncrementOrDecrement(postfix.Kind()))
         {
             return AddedPropertySkipReasons.CompoundAssignment;
         }
@@ -179,14 +179,6 @@ internal static class AddedPropertyBodyScan
         }
 
         return false;
-    }
-
-    private static bool IsIncrementOrDecrement(SyntaxKind kind)
-    {
-        return kind == SyntaxKind.PreIncrementExpression
-            || kind == SyntaxKind.PreDecrementExpression
-            || kind == SyntaxKind.PostIncrementExpression
-            || kind == SyntaxKind.PostDecrementExpression;
     }
 
     private static bool HasRefKind(ArgumentSyntax argument)

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AddedPropertyClassifier.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AddedPropertyClassifier.cs
@@ -392,7 +392,6 @@ internal static class AddedPropertyClassifier
         AddedPropertyBinding binding,
         AddedFieldCatalog addedFieldCatalog)
     {
-        binding.StoreFieldKey = binding.PropertyKey;
         binding.Initializer = binding.Declaration.Initializer?.Value;
 
         // Why not AddAddedSyntaxKey: the field syntax-key set drives field drift stripping,

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AddedPropertyEmitter.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AddedPropertyEmitter.cs
@@ -121,10 +121,12 @@ internal static class AddedPropertyEmitter
                 SyntaxFactory.IdentifierName(TransformWorkerProgramMarker.InstanceParameterName)));
         }
 
+        // Why PropertyKey: the auto-property store is keyed by the property itself, because
+        // RegisterAutoPropertyStore registers the backing field with FieldKey = PropertyKey.
         arguments.Add(SyntaxFactory.Argument(
             SyntaxFactory.LiteralExpression(
                 SyntaxKind.StringLiteralExpression,
-                SyntaxFactory.Literal(binding.StoreFieldKey))));
+                SyntaxFactory.Literal(binding.PropertyKey))));
         return arguments;
     }
 


### PR DESCRIPTION
## Summary
- Internal cleanup of the hot reload transform worker. No user-visible change.

## User Impact
- None. Skip reasons, shim names, and Skipped row ordering in hot reload output are byte-identical before and after this change.

## Changes
- Removed `AddedPropertyBinding.StoreFieldKey`. It had exactly one writer and one reader, and the writer always assigned the binding's own `PropertyKey`. The accessor shim emitter now reads `PropertyKey` directly, with a comment recording why that is the store key: the auto-property backing store is registered with `FieldKey = PropertyKey`.
- Removed the private `IsIncrementOrDecrement` copy in the added-property body scan and pointed its two call sites at the existing internal one in the added-field body scan, which the shim rewriters already call.

## Verification
- `uloop run-tests --filter-type class --filter-value <class>`, one class at a time: `TransformWorkerAddedFieldTests` (66 passed), `TransformWorkerAddedPropertyTests` (40), `TransformWorkerAddedMemberTests` (57), `TransformWorkerCrossFileTests` (11), `HotReloadWorkerRowsByFileTests` (3), `TransformWorkerIntroducedTypeTests` (24). 0 failed in every run.
- `uloop compile`: 0 errors, 0 warnings.
- `scripts/check-code-complexity.sh`: 0 issues (Go), no CA1502 findings above threshold 15 (C#).
- `scripts/check-file-length.sh`: no files above the 500 SLOC limit.

https://claude.ai/code/session_01H3pv1GH69HssoxHiHrYqWf


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2706?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

