### PR TITLE
chore: give the method transform decision its own skip-reason constants

### DIFF
--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AddedPropertyBinding.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AddedPropertyBinding.cs
@@ -44,7 +44,6 @@ internal sealed class AddedPropertyBinding
 
     public MethodTransformDecision SetterDecision { get; set; }
 
-
     public ExpressionSyntax Initializer { get; set; }
 
     public string UnavailableReason { get; set; }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/MethodTransformDecider.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/MethodTransformDecider.cs
@@ -39,13 +39,12 @@ internal static class MethodTransformDecider
 
         if (bodyNode == null)
         {
-            return MethodTransformDecision.Skip("Methods without a body (abstract/extern) are skipped.");
+            return MethodTransformDecision.Skip(MethodTransformSkipReasons.NoBody);
         }
 
         if (ContainsBaseExpression(bodyNode))
         {
-            return MethodTransformDecision.Skip(
-                "Methods that call base. members are skipped; C# cannot express base calls outside the type.");
+            return MethodTransformDecision.Skip(MethodTransformSkipReasons.BaseMemberCall);
         }
 
         string eventUseReason = EventAccessorRules.EvaluateEventUseSkipReason(
@@ -85,7 +84,7 @@ internal static class MethodTransformDecider
             return MethodTransformDecision.Skip(
                 v1Reason == null
                     ? EventAccessorRules.AccessorRewriteUnavailableReasonPrefix + accessorRejectReason
-                    : v1Reason + " Accessor rewrite unavailable: " + accessorRejectReason);
+                    : v1Reason + MethodTransformSkipReasons.AccessorRewriteUnavailableInfix + accessorRejectReason);
         }
 
         // Safety net: detection said "needs accessors" but eligibility found nothing to rewrite
@@ -103,14 +102,12 @@ internal static class MethodTransformDecider
     {
         if (closureInaccessible)
         {
-            return "Lambda, local-function, or query-expression bodies that access private/internal members "
-                + "are skipped in v1 (closure methods JIT-compile normally and fail accessibility checks).";
+            return MethodTransformSkipReasons.ClosureInaccessibleAccess;
         }
 
         if (asyncIteratorInaccessible)
         {
-            return "Async or iterator methods whose bodies access private/internal members are skipped in v1 "
-                + "(state-machine MoveNext JIT-compiles normally and fails accessibility checks).";
+            return MethodTransformSkipReasons.AsyncIteratorInaccessibleAccess;
         }
 
         return null;
@@ -129,19 +126,19 @@ internal static class MethodTransformDecider
         {
             if (declaration.Modifiers.Any(static modifier => modifier.IsKind(SyntaxKind.PartialKeyword)))
             {
-                return "Partial types are skipped because a single file cannot provide a complete semantic model.";
+                return MethodTransformSkipReasons.PartialType;
             }
         }
 
         if (typeSymbol.TypeKind == TypeKind.Struct || typeSymbol.IsValueType)
         {
-            return "Struct (value type) methods are out of scope for v1; byref instance transplant is unverified.";
+            return MethodTransformSkipReasons.StructHost;
         }
 
         bool hasTypeParameters = methodDeclaration != null && methodDeclaration.TypeParameterList != null;
         if (typeSymbol.IsGenericType || methodSymbol.IsGenericMethod || hasTypeParameters)
         {
-            return "Generic methods and methods inside generic types cannot be safely patched with Harmony. Run 'uloop compile'.";
+            return MethodTransformSkipReasons.GenericMethodOrType;
         }
 
         // Explicit interface implementations have dotted metadata names (e.g. IFoo.Bar) that are
@@ -149,7 +146,7 @@ internal static class MethodTransformDecider
         // matcher (Cecil MethodDefinition.Name). v1 skips them with an explicit reason.
         if (methodDeclaration != null && methodDeclaration.ExplicitInterfaceSpecifier != null)
         {
-            return "Explicit interface implementations are skipped in v1.";
+            return MethodTransformSkipReasons.ExplicitInterfaceImplementation;
         }
 
         return null;
@@ -260,7 +257,7 @@ internal static class MethodTransformDecider
         {
             return MethodTransformDecision.Skip(
                 AddedMethodSkipReasons.InaccessibleAccessNoRewrite
-                + " Accessor rewrite unavailable: "
+                + MethodTransformSkipReasons.AccessorRewriteUnavailableInfix
                 + accessorRejectReason
                 + " Run 'uloop compile'.");
         }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/MethodTransformSkipReasons.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/MethodTransformSkipReasons.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Collections.Immutable;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Runtime.Loader;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Text;
+
+/// <summary>
+/// What: skip strings for the compiled-method transform decision. Keep in the existing
+/// "reason + run uloop compile" style; the worker cannot reference HotReloadConstants.
+/// </summary>
+internal static class MethodTransformSkipReasons
+{
+    public const string NoBody = "Methods without a body (abstract/extern) are skipped.";
+
+    public const string BaseMemberCall =
+        "Methods that call base. members are skipped; C# cannot express base calls outside the type.";
+
+    public const string ClosureInaccessibleAccess =
+        "Lambda, local-function, or query-expression bodies that access private/internal members "
+        + "are skipped in v1 (closure methods JIT-compile normally and fail accessibility checks).";
+
+    public const string AsyncIteratorInaccessibleAccess =
+        "Async or iterator methods whose bodies access private/internal members are skipped in v1 "
+        + "(state-machine MoveNext JIT-compiles normally and fails accessibility checks).";
+
+    public const string PartialType =
+        "Partial types are skipped because a single file cannot provide a complete semantic model.";
+
+    public const string StructHost =
+        "Struct (value type) methods are out of scope for v1; byref instance transplant is unverified.";
+
+    public const string GenericMethodOrType =
+        "Generic methods and methods inside generic types cannot be safely patched with Harmony. Run 'uloop compile'.";
+
+    public const string ExplicitInterfaceImplementation = "Explicit interface implementations are skipped in v1.";
+
+    // Why an infix and not EventAccessorRules.AccessorRewriteUnavailableReasonPrefix: that one
+    // opens the sentence, while this one appends the rejection to a skip reason already written.
+    public const string AccessorRewriteUnavailableInfix = " Accessor rewrite unavailable: ";
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/PropertyGetterEmitter.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/PropertyGetterEmitter.cs
@@ -157,7 +157,7 @@ internal static class PropertyGetterEmitter
             {
                 SourceProjectRelativePath = sourceProjectRelativePath,
                 Method = WorkerMethodKeys.FormatMethodLabel(getterSymbol),
-                Reason = "Explicit interface implementations are skipped in v1."
+                Reason = MethodTransformSkipReasons.ExplicitInterfaceImplementation
             });
             return currentShimType;
         }


### PR DESCRIPTION
## Summary
- Internal cleanup of the hot reload transform worker. No user-visible change.

## User Impact
- None. Every skip reason is carried over byte for byte, so hot reload output (reason strings, shim names, Skipped row ordering) is unchanged.

## Changes
- Added `MethodTransformSkipReasons`, matching the constants classes the added-field, added-method, and added-property families already have. The compiled-method transform decision was the only one holding its reasons inline (eight of them).
- Moved the `" Accessor rewrite unavailable: "` infix into that class as well. It is deliberately separate from `EventAccessorRules.AccessorRewriteUnavailableReasonPrefix`, which opens a sentence rather than continuing one.
- The property getter emitter had a second copy of the explicit-interface-implementation reason written out by hand; it now shares the constant, so the two cannot drift apart.
- The trailing `Run 'uloop compile'.` on the added-method rejection path is left inline here; it belongs to the call-to-action strings a follow-up change collects.
- Collapsed a stray double blank line left in `AddedPropertyBinding` by the previous cleanup.

## Verification
- Byte-identity check (not provable from tests alone, since only the property family pins full strings): resolved every compile-time string expression in the touched files before and after the change and compared them. The sets of values are identical; the only difference is that two literals which previously appeared twice now resolve through a single constant.
- `uloop run-tests --filter-type class --filter-value <class>`, one class at a time: `TransformWorkerAddedFieldTests` (66 passed), `TransformWorkerAddedPropertyTests` (40), `TransformWorkerAddedMemberTests` (57), `TransformWorkerCrossFileTests` (11), `HotReloadWorkerRowsByFileTests` (3), `TransformWorkerIntroducedTypeTests` (24), `HotReloadOrchestratorTests` (155), `HotReloadSkippedMemberCompileNoteTests` (12). 0 failed in every run.
- `uloop compile`: 0 errors, 0 warnings.
- `scripts/check-code-complexity.sh`: 0 issues (Go), no CA1502 findings above threshold 15 (C#).
- `scripts/check-file-length.sh`: no files above the 500 SLOC limit.

https://claude.ai/code/session_01H3pv1GH69HssoxHiHrYqWf


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2707?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

