### PR TITLE
chore: collect the compile call to action into one place

### DIFF
--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AddedFieldSkipReasons.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AddedFieldSkipReasons.cs
@@ -23,7 +23,7 @@ internal static class AddedFieldSkipReasons
 {
     public const string StructHost =
         "Added fields on struct types are skipped; the store requires a reference-type instance. "
-        + "Run 'uloop compile' to add them.";
+        + CompileCallToAction.ToAddThem;
 
     public const string InitializerNotLiteralOrExternalStatic =
         "Added field initializer is not a literal or an externally visible static member "
@@ -35,41 +35,41 @@ internal static class AddedFieldSkipReasons
         + "Or run 'uloop compile'.";
 
     public const string FieldTypeNotExternallyVisible =
-        "Added field type is not visible to the shim assembly. Run 'uloop compile'.";
+        "Added field type is not visible to the shim assembly. " + CompileCallToAction.Plain;
 
     public const string FieldTypeUnresolvedFormat =
         "Added field type '{0}' could not be resolved; check for a missing using directive or a typo, fix the declaration, and rerun. Run 'uloop compile' if the type is new.";
 
     public const string IncrementNotNumeric =
         "Increment or decrement of an added field is skipped unless the type is a numeric "
-        + "primitive or enum. Run 'uloop compile'.";
+        + "primitive or enum. " + CompileCallToAction.Plain;
 
     public const string RefOutIn =
-        "Added fields cannot be passed by ref, out, or in. Run 'uloop compile'.";
+        "Added fields cannot be passed by ref, out, or in. " + CompileCallToAction.Plain;
 
     public const string ConsumedWrite =
         "The value of an assignment to an added field is consumed; the store write returns void. "
-        + "Run 'uloop compile'.";
+        + CompileCallToAction.Plain;
 
     public const string DoubleEvalReceiver =
         "Assignment to an added field would evaluate a receiver with possible side effects twice. "
-        + "Run 'uloop compile'.";
+        + CompileCallToAction.Plain;
 
     public const string ValueTypeMemberWrite =
         "Writes to members of an added value-type field, and instance method calls on that field, "
-        + "cannot be rewritten. Run 'uloop compile'.";
+        + "cannot be rewritten. " + CompileCallToAction.Plain;
 
     public const string UnavailableAddedField =
-        "Uses an added field that hot reload cannot emit. Run 'uloop compile'.";
+        "Uses an added field that hot reload cannot emit. " + CompileCallToAction.Plain;
 
     public const string FieldTypeChanged =
-        "Field '{0}' has a different type in the compiled assembly. Run 'uloop compile'.";
+        "Field '{0}' has a different type in the compiled assembly. " + CompileCallToAction.Plain;
 
     public const string FieldModifiersChanged =
-        "Field '{0}' changed its static or const modifier in the compiled assembly. Run 'uloop compile'.";
+        "Field '{0}' changed its static or const modifier in the compiled assembly. " + CompileCallToAction.Plain;
 
     public const string MemberKindChanged =
-        "Field '{0}' is declared as a property or an event in the compiled assembly. Run 'uloop compile'.";
+        "Field '{0}' is declared as a property or an event in the compiled assembly. " + CompileCallToAction.Plain;
 
     public const string SerializeWarningFormat =
         "Added field '{0}' has a serialization attribute, so it will not appear in the Inspector "

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AddedMethodSkipReasons.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AddedMethodSkipReasons.cs
@@ -19,22 +19,22 @@ internal static class AddedMethodSkipReasons
 {
     public const string VirtualOrAbstract =
         "Added virtual, override, or abstract methods are skipped; the compiled type has no vtable slot. "
-        + "Run 'uloop compile' to add them.";
+        + CompileCallToAction.ToAddThem;
 
     public const string Generic =
         "Added generic methods are skipped; hot reload cannot emit a typed shim for them. "
-        + "Run 'uloop compile'.";
+        + CompileCallToAction.Plain;
 
     public const string MethodGroupReference =
         "Methods that capture an added method as a method group or delegate are skipped; "
-        + "the shim signature does not match. Run 'uloop compile'.";
+        + "the shim signature does not match. " + CompileCallToAction.Plain;
 
     public const string ConditionalAccess =
         "Added-method calls through conditional access are skipped; there is no rewrite shape. "
-        + "Run 'uloop compile'.";
+        + CompileCallToAction.Plain;
 
     public const string UnavailableAddedCall =
-        "Calls an added method that hot reload cannot emit. Run 'uloop compile'.";
+        "Calls an added method that hot reload cannot emit. " + CompileCallToAction.Plain;
 
     public const string TypeNotIntroduced =
         "Declared on a type that is not in the compiled assembly and was not introduced by this "
@@ -42,7 +42,7 @@ internal static class AddedMethodSkipReasons
         + "that line gives the reason it was not introduced.";
 
     public const string InterfaceMember =
-        "Interface members are not patchable. Run 'uloop compile'.";
+        "Interface members are not patchable. " + CompileCallToAction.Plain;
 
     public const string InaccessibleAccessNoRewrite =
         "Added methods whose bodies access private/internal members are skipped when the access "

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AddedPropertySkipReasons.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AddedPropertySkipReasons.cs
@@ -22,71 +22,71 @@ internal static class AddedPropertySkipReasons
 {
     public const string SetOnly =
         "Added properties with only a setter are skipped; the shim requires a getter identity. "
-        + "Run 'uloop compile' to add them.";
+        + CompileCallToAction.ToAddThem;
 
     public const string VirtualOrAbstract =
         "Added virtual, override, abstract, or interface properties are skipped; the compiled type has no vtable slot. "
-        + "Run 'uloop compile' to add them.";
+        + CompileCallToAction.ToAddThem;
 
     public const string ExplicitInterface =
         "Added explicit interface properties are skipped; the compiled type has no interface member slot. "
-        + "Run 'uloop compile' to add them.";
+        + CompileCallToAction.ToAddThem;
 
     public const string InitAccessor =
         "Added properties with init accessors are skipped; the shim cannot preserve initialization-only assignment. "
-        + "Run 'uloop compile' to add them.";
+        + CompileCallToAction.ToAddThem;
 
     public const string PropertyPattern =
         "Property patterns that match an added property are skipped; a pattern member name cannot "
-        + "be replaced by an accessor shim call. Run 'uloop compile' to add it.";
+        + "be replaced by an accessor shim call. " + CompileCallToAction.ToAddIt;
 
     public const string GenericHostType =
         "Added properties on generic types are skipped; one accessor identity and one store entry "
-        + "cannot stand for every closed instantiation. Run 'uloop compile' to add them.";
+        + "cannot stand for every closed instantiation. " + CompileCallToAction.ToAddThem;
 
     public const string StructHost =
         "Added properties on struct types are skipped; the shim requires a reference-type instance. "
-        + "Run 'uloop compile' to add them.";
+        + CompileCallToAction.ToAddThem;
 
     public const string ValueTypeUnresolvedFormat =
         "Added property type '{0}' could not be resolved; check for a missing using directive or a typo, "
         + "fix the declaration, and rerun. Run 'uloop compile' if the type is new.";
 
     public const string ValueTypeNotExternallyVisible =
-        "Added property type is not visible to the shim assembly. Run 'uloop compile' to add it.";
+        "Added property type is not visible to the shim assembly. " + CompileCallToAction.ToAddIt;
 
     public const string CompoundAssignment =
         "Compound assignment, increment, and decrement of an added property are skipped; the accessor shim cannot preserve the operation. "
-        + "Run 'uloop compile' to add it.";
+        + CompileCallToAction.ToAddIt;
 
     public const string ConsumedWrite =
         "The value of an assignment to an added property is consumed; the setter shim returns void. "
-        + "Run 'uloop compile' to add it.";
+        + CompileCallToAction.ToAddIt;
 
     public const string NameofReference =
         "References to added properties inside nameof are skipped; the member does not exist in the compiled assembly. "
-        + "Run 'uloop compile' to add it.";
+        + CompileCallToAction.ToAddIt;
 
     public const string ObjectInitializer =
         "Object initializers that assign added properties are skipped; the setter shim cannot rewrite the initializer. "
-        + "Run 'uloop compile' to add it.";
+        + CompileCallToAction.ToAddIt;
 
     public const string DeconstructionTarget =
         "Deconstruction assignment to an added property is skipped; the setter shim cannot stand as a "
-        + "deconstruction target. Run 'uloop compile' to add it.";
+        + "deconstruction target. " + CompileCallToAction.ToAddIt;
 
     public const string ConditionalAccess =
-        "Conditional access to added properties is skipped; there is no rewrite shape. Run 'uloop compile' to add it.";
+        "Conditional access to added properties is skipped; there is no rewrite shape. " + CompileCallToAction.ToAddIt;
 
     public const string RefOutIn =
-        "Added properties cannot be passed by ref, out, or in. Run 'uloop compile' to add them.";
+        "Added properties cannot be passed by ref, out, or in. " + CompileCallToAction.ToAddThem;
 
     public const string UnavailableAddedProperty =
-        "Uses an added property that hot reload cannot emit. Run 'uloop compile'.";
+        "Uses an added property that hot reload cannot emit. " + CompileCallToAction.Plain;
 
     public const string CompiledMemberKindChanged =
-        "Property '{0}' is declared as a field or an event in the compiled assembly. Run 'uloop compile'.";
+        "Property '{0}' is declared as a field or an event in the compiled assembly. " + CompileCallToAction.Plain;
 
     public const string InitializerNotEmittable =
-        "Added property initializer cannot run in the shim lambda. Run 'uloop compile' to add it.";
+        "Added property initializer cannot run in the shim lambda. " + CompileCallToAction.ToAddIt;
 }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/CompileCallToAction.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/CompileCallToAction.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Collections.Immutable;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Runtime.Loader;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Text;
+
+/// <summary>
+/// What: the "compile it properly" call to action appended to a skip reason. The worker cannot
+/// reference HotReloadConstants, so the three wordings live here instead of being retyped.
+/// </summary>
+internal static class CompileCallToAction
+{
+    public const string Plain = "Run 'uloop compile'.";
+
+    public const string ToAddIt = "Run 'uloop compile' to add it.";
+
+    public const string ToAddThem = "Run 'uloop compile' to add them.";
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/MethodTransformDecider.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/MethodTransformDecider.cs
@@ -259,7 +259,7 @@ internal static class MethodTransformDecider
                 AddedMethodSkipReasons.InaccessibleAccessNoRewrite
                 + MethodTransformSkipReasons.AccessorRewriteUnavailableInfix
                 + accessorRejectReason
-                + " Run 'uloop compile'.");
+                + " " + CompileCallToAction.Plain);
         }
 
         bool usesDelegation = feasibilityPlan.Entries.Count > 0;

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/MethodTransformSkipReasons.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/MethodTransformSkipReasons.cs
@@ -41,7 +41,7 @@ internal static class MethodTransformSkipReasons
         "Struct (value type) methods are out of scope for v1; byref instance transplant is unverified.";
 
     public const string GenericMethodOrType =
-        "Generic methods and methods inside generic types cannot be safely patched with Harmony. Run 'uloop compile'.";
+        "Generic methods and methods inside generic types cannot be safely patched with Harmony. " + CompileCallToAction.Plain;
 
     public const string ExplicitInterfaceImplementation = "Explicit interface implementations are skipped in v1.";
 


### PR DESCRIPTION
## Summary
- Internal cleanup of the hot reload transform worker. No user-visible change.

## User Impact
- None. Every skip reason resolves to the same bytes, so hot reload output (reason strings, shim names, Skipped row ordering) is unchanged.

## Changes
- Added `CompileCallToAction` with the three wordings that close a hot reload skip reason: `Run 'uloop compile'.`, `Run 'uloop compile' to add it.`, and `Run 'uloop compile' to add them.`
- Replaced the 37 hand-typed copies of those three across the added-field, added-method, added-property, and method-transform skip reasons with concatenations of the constants. Constant-to-constant concatenation is done by the compiler, so there is no runtime cost, and the space that separated the sentence from the call to action stays on the preceding literal.
- Only these three wordings are touched. The other compile-related phrasings in the worker (`Use uloop compile.`, `until 'uloop compile'.`, `requires a compile`, and the rest) are left exactly as they are; unifying them would be a wording change, not a cleanup.

## Verification
- Byte-identity check (not provable from tests alone, since only the property family pins full strings): resolved every compile-time string expression in the touched files before and after the change and compared them. The only difference is the three new constant values themselves; every existing reason resolves to the same bytes.
- `uloop run-tests --filter-type class --filter-value <class>`, one class at a time: `TransformWorkerAddedFieldTests` (66 passed), `TransformWorkerAddedPropertyTests` (40), `TransformWorkerAddedMemberTests` (57), `TransformWorkerCrossFileTests` (11), `HotReloadWorkerRowsByFileTests` (3), `TransformWorkerIntroducedTypeTests` (24), `HotReloadOrchestratorTests` (155), `HotReloadSkippedMemberCompileNoteTests` (12), `TransformWorkerClientTests` (77). 0 failed in every run.
- `uloop compile`: 0 errors, 0 warnings.
- `scripts/check-code-complexity.sh`: 0 issues (Go), no CA1502 findings above threshold 15 (C#).
- `scripts/check-file-length.sh`: no files above the 500 SLOC limit.

https://claude.ai/code/session_01H3pv1GH69HssoxHiHrYqWf
