### PR TITLE
chore: stop calling skipped hot-reload members "v1" limitations

### DIFF
--- a/.agents/skills/uloop-hot-reload/references/scope-and-limits.md
+++ b/.agents/skills/uloop-hot-reload/references/scope-and-limits.md
@@ -246,7 +246,7 @@ stay `Skipped`.
 | An async/iterator/closure body references a private/internal type | Accessor delegates rescue member access, not type references; the body still cannot JIT-compile from the shim assembly |
 | A declared return or parameter type cannot be resolved (a new type this reload could not introduce, a missing using, or a typo) | Skipped; a supported new type declared in an edited file of the same assembly is introduced by this reload, so check `Warnings` for the refusal reason (`introduced-types.md`); otherwise add the type or the `using`, or fix the typo, then run `uloop compile` |
 | Edited setter, init, or indexer accessor of a *compiled* property | Accessor patching covers getters only; `uloop compile` applies these edits. Accessors of a property added in this edit are emitted instead |
-| Constructor (instance or static), operator, conversion operator, or explicit event accessor (add/remove) | Out of scope for v1; `uloop compile` applies these edits |
+| Constructor (instance or static), operator, conversion operator, or explicit event accessor (add/remove) | Skipped; `uloop compile` applies these edits |
 | Method raises or reads a field-like event that has no reachable backing field | Custom `add`/`remove` accessors, an `abstract`/`extern`/interface event, a delegate type that is not visible outside the assembly, or an event added in this edit leave nothing for the shim's Harmony accessor to bind |
 | Method raises or reads a field-like event through a conditional receiver (`other?.E`) | The shim has no name for the conditional receiver to pass to the accessor call |
 | Method names a field-like event inside `nameof` | The shim is a different type and cannot keep the bare event name |

--- a/.claude/skills/uloop-hot-reload/references/scope-and-limits.md
+++ b/.claude/skills/uloop-hot-reload/references/scope-and-limits.md
@@ -246,7 +246,7 @@ stay `Skipped`.
 | An async/iterator/closure body references a private/internal type | Accessor delegates rescue member access, not type references; the body still cannot JIT-compile from the shim assembly |
 | A declared return or parameter type cannot be resolved (a new type this reload could not introduce, a missing using, or a typo) | Skipped; a supported new type declared in an edited file of the same assembly is introduced by this reload, so check `Warnings` for the refusal reason (`introduced-types.md`); otherwise add the type or the `using`, or fix the typo, then run `uloop compile` |
 | Edited setter, init, or indexer accessor of a *compiled* property | Accessor patching covers getters only; `uloop compile` applies these edits. Accessors of a property added in this edit are emitted instead |
-| Constructor (instance or static), operator, conversion operator, or explicit event accessor (add/remove) | Out of scope for v1; `uloop compile` applies these edits |
+| Constructor (instance or static), operator, conversion operator, or explicit event accessor (add/remove) | Skipped; `uloop compile` applies these edits |
 | Method raises or reads a field-like event that has no reachable backing field | Custom `add`/`remove` accessors, an `abstract`/`extern`/interface event, a delegate type that is not visible outside the assembly, or an event added in this edit leave nothing for the shim's Harmony accessor to bind |
 | Method raises or reads a field-like event through a conditional receiver (`other?.E`) | The shim has no name for the conditional receiver to pass to the accessor call |
 | Method names a field-like event inside `nameof` | The shim is a different type and cannot keep the bare event name |

--- a/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
@@ -548,7 +548,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             AssertNoFileLevelFailure(result);
 
             const string expectedReason =
-                "Property setter, init, or indexer accessors are out of scope for v1; "
+                "Property setter, init, or indexer accessors are skipped; "
                 + "run 'uloop compile' to apply accessor edits.";
             bool foundPropertyGetterPatched = false;
             bool foundIndexerGetter = false;
@@ -622,7 +622,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             AssertNoFileLevelFailure(result);
 
             const string expectedReason =
-                "Constructors, operators, and event accessors are out of scope for v1; "
+                "Constructors, operators, and event accessors are skipped; "
                 + "run 'uloop compile' to apply these edits.";
             AssertHasSkipped(result, ".ctor()", expectedReason);
 

--- a/Assets/Tests/Editor/HotReload/HotReloadPatcherTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadPatcherTests.cs
@@ -552,7 +552,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
     }
 
     /// <summary>
-    /// Struct fixture used only to assert the v1 value-type rejection path.
+    /// Struct fixture used only to assert the value-type rejection path.
     /// </summary>
     public struct HotReloadValueTypeFixture
     {

--- a/Assets/Tests/Editor/HotReload/TransformWorkerClientTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerClientTests.cs
@@ -1254,7 +1254,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         private const string ExpectedExplicitAccessorSkipReason =
-            "Property setter, init, or indexer accessors are out of scope for v1; "
+            "Property setter, init, or indexer accessors are skipped; "
             + "run 'uloop compile' to apply accessor edits.";
 
         private const string ExpectedSetOnlyPropertySkipReason =
@@ -1886,7 +1886,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         private const string ExpectedUnsupportedMemberKindSkipReason =
-            "Constructors, operators, and event accessors are out of scope for v1; "
+            "Constructors, operators, and event accessors are skipped; "
             + "run 'uloop compile' to apply these edits.";
 
         // Keep in sync with OutsideMethodBodyDriftWarningFormat in

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadPatcher.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadPatcher.cs
@@ -535,12 +535,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     $"'{method}' (or its declaring type) is marked [BurstCompile] and cannot be patched.");
             }
 
-            // Value-type instance transplant needs byref `this` semantics that v1 has not validated.
+            // Value-type instance transplant needs byref `this` semantics that transplant has not validated.
             if (method.DeclaringType != null && method.DeclaringType.IsValueType)
             {
                 return HotReloadPatchResult.Failure(
                     HotReloadPatchFailureReason.UnpatchableValueType,
-                    $"'{method}' is declared on a value type; struct method transplant is out of scope for v1.");
+                    $"'{method}' is declared on a value type; struct method transplant is not supported.");
             }
 
             return HotReloadPatchResult.SuccessResult();

--- a/Packages/src/Editor/FirstPartyTools/HotReload/Skill/references/scope-and-limits.md
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/Skill/references/scope-and-limits.md
@@ -246,7 +246,7 @@ stay `Skipped`.
 | An async/iterator/closure body references a private/internal type | Accessor delegates rescue member access, not type references; the body still cannot JIT-compile from the shim assembly |
 | A declared return or parameter type cannot be resolved (a new type this reload could not introduce, a missing using, or a typo) | Skipped; a supported new type declared in an edited file of the same assembly is introduced by this reload, so check `Warnings` for the refusal reason (`introduced-types.md`); otherwise add the type or the `using`, or fix the typo, then run `uloop compile` |
 | Edited setter, init, or indexer accessor of a *compiled* property | Accessor patching covers getters only; `uloop compile` applies these edits. Accessors of a property added in this edit are emitted instead |
-| Constructor (instance or static), operator, conversion operator, or explicit event accessor (add/remove) | Out of scope for v1; `uloop compile` applies these edits |
+| Constructor (instance or static), operator, conversion operator, or explicit event accessor (add/remove) | Skipped; `uloop compile` applies these edits |
 | Method raises or reads a field-like event that has no reachable backing field | Custom `add`/`remove` accessors, an `abstract`/`extern`/interface event, a delegate type that is not visible outside the assembly, or an event added in this edit leave nothing for the shim's Harmony accessor to bind |
 | Method raises or reads a field-like event through a conditional receiver (`other?.E`) | The shim has no name for the conditional receiver to pass to the accessor call |
 | Method names a field-like event inside `nameof` | The shim is a different type and cannot keep the bare event name |

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/MethodTransformDecider.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/MethodTransformDecider.cs
@@ -70,8 +70,8 @@ internal static class MethodTransformDecider
             return MethodTransformDecision.Transplant();
         }
 
-        // Condition (a): only the v1 private-access skip reasons are eligible for accessor rewrite.
-        string v1Reason = BuildAccessorRescueReason(closureInaccessible, asyncIteratorInaccessible);
+        // Condition (a): only the private-access skip reasons are eligible for accessor rewrite.
+        string rescuableSkipReason = BuildAccessorRescueReason(closureInaccessible, asyncIteratorInaccessible);
 
         if (!AccessorEligibility.TryBuildPlan(
                 semanticModel,
@@ -82,9 +82,9 @@ internal static class MethodTransformDecider
                 out string accessorRejectReason))
         {
             return MethodTransformDecision.Skip(
-                v1Reason == null
+                rescuableSkipReason == null
                     ? EventAccessorRules.AccessorRewriteUnavailableReasonPrefix + accessorRejectReason
-                    : v1Reason + MethodTransformSkipReasons.AccessorRewriteUnavailableInfix + accessorRejectReason);
+                    : rescuableSkipReason + MethodTransformSkipReasons.AccessorRewriteUnavailableInfix + accessorRejectReason);
         }
 
         // Safety net: detection said "needs accessors" but eligibility found nothing to rewrite
@@ -97,7 +97,7 @@ internal static class MethodTransformDecider
         return MethodTransformDecision.Delegation();
     }
 
-    // Null when the body needs accessors only for its event uses: there is no v1 skip to rescue.
+    // Null when the body needs accessors only for its event uses: there is no skip to rescue.
     private static string BuildAccessorRescueReason(bool closureInaccessible, bool asyncIteratorInaccessible)
     {
         if (closureInaccessible)
@@ -143,7 +143,7 @@ internal static class MethodTransformDecider
 
         // Explicit interface implementations have dotted metadata names (e.g. IFoo.Bar) that are
         // not valid C# identifiers for shim method names; sanitizing would also desync the
-        // matcher (Cecil MethodDefinition.Name). v1 skips them with an explicit reason.
+        // matcher (Cecil MethodDefinition.Name). They are skipped with an explicit reason.
         if (methodDeclaration != null && methodDeclaration.ExplicitInterfaceSpecifier != null)
         {
             return MethodTransformSkipReasons.ExplicitInterfaceImplementation;
@@ -218,7 +218,7 @@ internal static class MethodTransformDecider
             else if (node is QueryExpressionSyntax queryExpression)
             {
                 // Query clauses compile to display-class methods that JIT normally; treat the
-                // whole query (including the source expression) as a closure body for v1.
+                // whole query (including the source expression) as a closure body.
                 bodies.Add(queryExpression);
             }
         }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/MethodTransformSkipReasons.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/MethodTransformSkipReasons.cs
@@ -28,22 +28,22 @@ internal static class MethodTransformSkipReasons
 
     public const string ClosureInaccessibleAccess =
         "Lambda, local-function, or query-expression bodies that access private/internal members "
-        + "are skipped in v1 (closure methods JIT-compile normally and fail accessibility checks).";
+        + "are skipped (closure methods JIT-compile normally and fail accessibility checks).";
 
     public const string AsyncIteratorInaccessibleAccess =
-        "Async or iterator methods whose bodies access private/internal members are skipped in v1 "
+        "Async or iterator methods whose bodies access private/internal members are skipped "
         + "(state-machine MoveNext JIT-compiles normally and fails accessibility checks).";
 
     public const string PartialType =
         "Partial types are skipped because a single file cannot provide a complete semantic model.";
 
     public const string StructHost =
-        "Struct (value type) methods are out of scope for v1; byref instance transplant is unverified.";
+        "Struct (value type) methods are skipped; byref instance transplant is unverified.";
 
     public const string GenericMethodOrType =
         "Generic methods and methods inside generic types cannot be safely patched with Harmony. " + CompileCallToAction.Plain;
 
-    public const string ExplicitInterfaceImplementation = "Explicit interface implementations are skipped in v1.";
+    public const string ExplicitInterfaceImplementation = "Explicit interface implementations are skipped.";
 
     // Why an infix and not EventAccessorRules.AccessorRewriteUnavailableReasonPrefix: that one
     // opens the sentence, while this one appends the rejection to a skip reason already written.

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/UnsupportedMemberSkipCollector.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/UnsupportedMemberSkipCollector.cs
@@ -18,11 +18,11 @@ using Microsoft.CodeAnalysis.Text;
 internal static class UnsupportedMemberSkipCollector
 {
     internal const string ExplicitAccessorSkipReason =
-        "Property setter, init, or indexer accessors are out of scope for v1; "
+        "Property setter, init, or indexer accessors are skipped; "
         + "run 'uloop compile' to apply accessor edits.";
 
     internal const string UnsupportedMemberKindSkipReason =
-        "Constructors, operators, and event accessors are out of scope for v1; "
+        "Constructors, operators, and event accessors are skipped; "
         + "run 'uloop compile' to apply these edits.";
 
     // What: reports each property/indexer accessor that has an explicit body as Skipped.

--- a/docs/hot-reload.md
+++ b/docs/hot-reload.md
@@ -245,4 +245,4 @@ Wire details:
 - Transplant of methods with exception handlers (`try/finally`, `using`) rides on Harmony's
   standard `CodeInstruction` block round-trip; PR-3's end-to-end tests must include such a
   body.
-- Struct (value type) methods stay skipped in v1 (same restriction the prefix design had).
+- Struct (value type) methods stay skipped (same restriction the prefix design had).


### PR DESCRIPTION
## Summary
- Hot reload no longer tells you a member was skipped "in v1" or is "out of scope for v1".

## User Impact
- Before: skip reasons such as `Struct (value type) methods are out of scope for v1; byref instance transplant is unverified.` implied there is a later version that would accept the edit. There is no v2, so anyone reading the reason — usually an AI agent deciding what to do next — could reasonably wait for or look for one.
- After: the same reasons simply say the member is skipped, and the next step (`uloop compile`, where it applies) is unchanged. Runtime behavior is identical; only the wording changed.

## Changes
- Reworded the skip reasons for struct (value type) methods, explicit interface implementations, closure and async/iterator bodies that touch inaccessible members, property setter/init/indexer accessors, and constructors/operators/event accessors.
- Reworded one Editor-side patch failure message as well: the value-type rejection in the patcher said "out of scope for v1" and now says the transplant is not supported.
- Neither of the two reason strings the Editor matches exactly is affected.
- Dropped the same label from the surrounding comments and from one local name (`v1Reason` is now `rescuableSkipReason`, which says what it holds).
- Updated the matching line in the hot reload skill's scope reference and in the design docs, and regenerated the skill copies.
- The remaining "v1"/"v2" wording in the design notes is historical — it records which generation lifted which restriction — and is left alone.

## Verification
- `grep -rn "v1"` across the hot reload docs, package sources, and both generated skill copies now returns only the four historical design-note lines.
- `uloop run-tests --filter-type class --filter-value <class>`, one class at a time: `TransformWorkerClientTests` (77 passed), `HotReloadOrchestratorTests` (155), `HotReloadPatcherTests` (18), `TransformWorkerAddedFieldTests` (66), `TransformWorkerAddedPropertyTests` (40), `TransformWorkerAddedMemberTests` (57), `TransformWorkerCrossFileTests` (11), `HotReloadWorkerRowsByFileTests` (3), `TransformWorkerIntroducedTypeTests` (24), `HotReloadSkippedMemberCompileNoteTests` (12). 0 failed in every run.
- `uloop compile`: 0 errors, 0 warnings.
- `sync-tool-docs --check`: the embedded tool catalog matches the skill parameter tables.
- `check-skill-size`: no SKILL.md over the byte limit.

https://claude.ai/code/session_01H3pv1GH69HssoxHiHrYqWf


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2709?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

