### PR TITLE
fix: Returning focus to the Editor during Play Mode no longer throws

### DIFF
--- a/Assets/Tests/Editor/ExternalSceneFocusReturnDeferralTests.cs
+++ b/Assets/Tests/Editor/ExternalSceneFocusReturnDeferralTests.cs
@@ -1,0 +1,98 @@
+using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor
+{
+    /// <summary>
+    /// Tests the Play Mode deferral of the focus-return Scene preflight without Unity's Play Mode APIs.
+    /// </summary>
+    public sealed class ExternalSceneFocusReturnDeferralTests
+    {
+        [Test]
+        public void ShouldResolveOnFocusReturn_WhenEditMode_ReturnsTrueWithoutDeferring()
+        {
+            // Verifies the Edit Mode focus return still resolves immediately and leaves nothing deferred.
+            ExternalSceneFocusReturnDeferral deferral = new ExternalSceneFocusReturnDeferral(isDeferred: false);
+
+            bool shouldResolve = deferral.ShouldResolveOnFocusReturn(isPlayingOrWillChangePlaymode: false);
+
+            Assert.That(shouldResolve, Is.True);
+            Assert.That(deferral.IsDeferred, Is.False);
+        }
+
+        [Test]
+        public void ShouldResolveOnFocusReturn_WhenPlaying_ReturnsFalseAndDefers()
+        {
+            // Verifies the focus return is skipped during Play Mode and remembered for Edit Mode.
+            ExternalSceneFocusReturnDeferral deferral = new ExternalSceneFocusReturnDeferral(isDeferred: false);
+
+            bool shouldResolve = deferral.ShouldResolveOnFocusReturn(isPlayingOrWillChangePlaymode: true);
+
+            Assert.That(shouldResolve, Is.False);
+            Assert.That(deferral.IsDeferred, Is.True);
+        }
+
+        [Test]
+        public void ConsumeOnEnteredEditMode_WhenDeferred_ReturnsTrueOnceAndClears()
+        {
+            // Verifies a deferred focus return runs exactly once after Play Mode ends.
+            ExternalSceneFocusReturnDeferral deferral = new ExternalSceneFocusReturnDeferral(isDeferred: true);
+
+            bool firstConsume = deferral.ConsumeOnEnteredEditMode();
+            bool secondConsume = deferral.ConsumeOnEnteredEditMode();
+
+            Assert.That(firstConsume, Is.True);
+            Assert.That(secondConsume, Is.False);
+            Assert.That(deferral.IsDeferred, Is.False);
+        }
+
+        [Test]
+        public void ConsumeOnEnteredEditMode_WhenNothingDeferred_ReturnsFalse()
+        {
+            // Verifies leaving Play Mode without a skipped focus return does not trigger a resolve.
+            ExternalSceneFocusReturnDeferral deferral = new ExternalSceneFocusReturnDeferral(isDeferred: false);
+
+            Assert.That(deferral.ConsumeOnEnteredEditMode(), Is.False);
+        }
+
+        [Test]
+        public void RemoveSnapshotsForScenesNotOpen_RemovesRuntimeLoadedScenesAndKeepsOpenOnes()
+        {
+            // Verifies fingerprints recorded for Scenes loaded only at runtime do not survive into Edit Mode.
+            Dictionary<string, (bool Exists, DateTime LastWriteTimeUtc, long Length)> snapshots =
+                new Dictionary<string, (bool Exists, DateTime LastWriteTimeUtc, long Length)>(StringComparer.Ordinal)
+                {
+                    ["Assets/Scenes/Bootstrap.unity"] = (true, DateTime.MinValue, 10),
+                    ["Assets/Scenes/SubScene.unity"] = (true, DateTime.MinValue, 20)
+                };
+
+            string[] removed = ExternalSceneSnapshotPruner.RemoveSnapshotsForScenesNotOpen(
+                snapshots,
+                new[] { "Assets/Scenes/Bootstrap.unity" });
+
+            Assert.That(removed, Is.EqualTo(new[] { "Assets/Scenes/SubScene.unity" }));
+            Assert.That(snapshots.Keys, Is.EqualTo(new[] { "Assets/Scenes/Bootstrap.unity" }));
+        }
+
+        [Test]
+        public void RemoveSnapshotsForScenesNotOpen_WhenAllOpen_RemovesNothing()
+        {
+            // Verifies the baseline for Scenes still open in the Editor is kept so external changes remain detectable.
+            Dictionary<string, (bool Exists, DateTime LastWriteTimeUtc, long Length)> snapshots =
+                new Dictionary<string, (bool Exists, DateTime LastWriteTimeUtc, long Length)>(StringComparer.Ordinal)
+                {
+                    ["Assets/Scenes/Bootstrap.unity"] = (true, DateTime.MinValue, 10)
+                };
+
+            string[] removed = ExternalSceneSnapshotPruner.RemoveSnapshotsForScenesNotOpen(
+                snapshots,
+                new[] { "Assets/Scenes/Bootstrap.unity" });
+
+            Assert.That(removed, Is.Empty);
+            Assert.That(snapshots.Count, Is.EqualTo(1));
+        }
+    }
+}

--- a/Assets/Tests/Editor/ExternalSceneFocusReturnDeferralTests.cs
+++ b/Assets/Tests/Editor/ExternalSceneFocusReturnDeferralTests.cs
@@ -94,5 +94,57 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(removed, Is.Empty);
             Assert.That(snapshots.Count, Is.EqualTo(1));
         }
+
+        [Test]
+        public void ShouldRecordBaselineOnInitialize_WhenDeferredAndFocused_KeepsTheRestoredFingerprints()
+        {
+            // Verifies a deferred focus return keeps the pre-reload fingerprints it still has to compare against.
+            ExternalSceneFocusReturnDeferral deferral = new ExternalSceneFocusReturnDeferral(isDeferred: true);
+
+            bool shouldRecord = deferral.ShouldRecordBaselineOnInitialize(
+                isFocused: true,
+                restoredSceneSnapshots: true);
+
+            Assert.That(shouldRecord, Is.False);
+        }
+
+        [Test]
+        public void ShouldRecordBaselineOnInitialize_WhenNotDeferredAndFocused_RecordsTheCurrentState()
+        {
+            // Verifies a focused reload with nothing deferred still refreshes the baseline as before.
+            ExternalSceneFocusReturnDeferral deferral = new ExternalSceneFocusReturnDeferral(isDeferred: false);
+
+            bool shouldRecord = deferral.ShouldRecordBaselineOnInitialize(
+                isFocused: true,
+                restoredSceneSnapshots: true);
+
+            Assert.That(shouldRecord, Is.True);
+        }
+
+        [Test]
+        public void ShouldRecordBaselineOnInitialize_WhenNothingWasRestored_RecordsEvenWhileDeferred()
+        {
+            // Verifies first launch always records a baseline, because there is nothing to preserve.
+            ExternalSceneFocusReturnDeferral deferral = new ExternalSceneFocusReturnDeferral(isDeferred: true);
+
+            bool shouldRecord = deferral.ShouldRecordBaselineOnInitialize(
+                isFocused: true,
+                restoredSceneSnapshots: false);
+
+            Assert.That(shouldRecord, Is.True);
+        }
+
+        [Test]
+        public void ShouldRecordBaselineOnInitialize_WhenUnfocused_KeepsTheRestoredFingerprints()
+        {
+            // Verifies the existing unfocused-reload behavior is unchanged when nothing is deferred.
+            ExternalSceneFocusReturnDeferral deferral = new ExternalSceneFocusReturnDeferral(isDeferred: false);
+
+            bool shouldRecord = deferral.ShouldRecordBaselineOnInitialize(
+                isFocused: false,
+                restoredSceneSnapshots: true);
+
+            Assert.That(shouldRecord, Is.False);
+        }
     }
 }

--- a/Assets/Tests/Editor/ExternalSceneFocusReturnDeferralTests.cs.meta
+++ b/Assets/Tests/Editor/ExternalSceneFocusReturnDeferralTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c8adea9023f454e5e83dc5d9351e96bb
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/Compile/ExternalSceneChangeTracker.cs
+++ b/Packages/src/Editor/FirstPartyTools/Compile/ExternalSceneChangeTracker.cs
@@ -54,11 +54,13 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             EditorApplication.focusChanged += HandleFocusChanged;
             EditorApplication.playModeStateChanged -= HandlePlayModeStateChanged;
             EditorApplication.playModeStateChanged += HandlePlayModeStateChanged;
-            // Keep restored fingerprints only across a domain reload that happened while unfocused.
-            // The next focus-return preflight compares against those fingerprints so it can detect
-            // external changes that occurred before the reload. First launch still records a baseline
-            // even when the Editor starts unfocused.
-            if (EditorApplication.isFocused || !restoredSceneSnapshots)
+            // Keep restored fingerprints only across a domain reload that happened while unfocused,
+            // or while a focus return is still deferred: the deferred preflight compares against those
+            // fingerprints so it can detect external changes that occurred before the reload. First
+            // launch still records a baseline even when the Editor starts unfocused.
+            if (_focusReturnDeferral.ShouldRecordBaselineOnInitialize(
+                EditorApplication.isFocused,
+                restoredSceneSnapshots))
             {
                 RecordOpenSceneSnapshots();
                 ExternalPrefabStageChangeTracker.RecordCurrent();

--- a/Packages/src/Editor/FirstPartyTools/Compile/ExternalSceneChangeTracker.cs
+++ b/Packages/src/Editor/FirstPartyTools/Compile/ExternalSceneChangeTracker.cs
@@ -17,9 +17,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     {
         private const string SceneSnapshotsSessionStateKey =
             "io.github.hatayama.UnityCliLoop.ExternalSceneChangeTracker.SceneSnapshots";
+        private const string FocusReturnDeferredSessionStateKey =
+            "io.github.hatayama.UnityCliLoop.ExternalSceneChangeTracker.FocusReturnDeferred";
         private static readonly Dictionary<string, (bool Exists, DateTime LastWriteTimeUtc, long Length)> SceneSnapshots =
             new Dictionary<string, (bool Exists, DateTime LastWriteTimeUtc, long Length)>(StringComparer.Ordinal);
         private static bool _initialized;
+        private static ExternalSceneFocusReturnDeferral _focusReturnDeferral;
 
         public static void Initialize()
         {
@@ -35,6 +38,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             bool restoredSceneSnapshots = !string.IsNullOrEmpty(SessionState.GetString(SceneSnapshotsSessionStateKey, ""));
             RestoreSnapshotsFromSessionState();
+            // The deferral must outlive the domain reload that leaving Play Mode can trigger.
+            _focusReturnDeferral = new ExternalSceneFocusReturnDeferral(
+                SessionState.GetBool(FocusReturnDeferredSessionStateKey, false));
 
             _initialized = true;
             EditorSceneManager.sceneOpened -= HandleSceneOpened;
@@ -46,6 +52,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             ExternalPrefabStageChangeTracker.RegisterEventHandlers();
             EditorApplication.focusChanged -= HandleFocusChanged;
             EditorApplication.focusChanged += HandleFocusChanged;
+            EditorApplication.playModeStateChanged -= HandlePlayModeStateChanged;
+            EditorApplication.playModeStateChanged += HandlePlayModeStateChanged;
             // Keep restored fingerprints only across a domain reload that happened while unfocused.
             // The next focus-return preflight compares against those fingerprints so it can detect
             // external changes that occurred before the reload. First launch still records a baseline
@@ -75,7 +83,48 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             {
                 return;
             }
+
+            if (!_focusReturnDeferral.ShouldResolveOnFocusReturn(EditorApplication.isPlayingOrWillChangePlaymode))
+            {
+                SessionState.SetBool(FocusReturnDeferredSessionStateKey, true);
+                VibeLogger.LogInfo(
+                    "external_scene_resolve_focus_return",
+                    "ResolveForFocusReturn deferred until Play Mode ends",
+                    new { phase = "deferred" },
+                    includeStackTrace: false);
+                return;
+            }
+
             ResolveForFocusReturn();
+        }
+
+        private static void HandlePlayModeStateChanged(PlayModeStateChange state)
+        {
+            if (state != PlayModeStateChange.EnteredEditMode)
+            {
+                return;
+            }
+
+            string[] prunedScenePaths = ExternalSceneSnapshotPruner.RemoveSnapshotsForScenesNotOpen(
+                SceneSnapshots,
+                GetOpenScenePaths());
+            if (prunedScenePaths.Length > 0)
+            {
+                SaveSceneSnapshotsToSessionState();
+            }
+
+            bool shouldResolve = _focusReturnDeferral.ConsumeOnEnteredEditMode();
+            SessionState.SetBool(FocusReturnDeferredSessionStateKey, false);
+            VibeLogger.LogInfo(
+                "external_scene_entered_edit_mode",
+                "Entered Edit Mode",
+                new { prunedScenePaths, shouldResolve },
+                includeStackTrace: false);
+            // An unfocused Editor gets the same preflight from its next focus return.
+            if (shouldResolve && EditorApplication.isFocused)
+            {
+                ResolveForFocusReturn();
+            }
         }
 
         private static void HandleSceneOpened(Scene scene, OpenSceneMode mode)
@@ -257,6 +306,18 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             return scenes.ToArray();
+        }
+
+        private static string[] GetOpenScenePaths()
+        {
+            (string AssetPath, bool IsDirty)[] scenes = GetOpenSceneStates();
+            string[] scenePaths = new string[scenes.Length];
+            for (int i = 0; i < scenes.Length; i++)
+            {
+                scenePaths[i] = scenes[i].AssetPath;
+            }
+
+            return scenePaths;
         }
 
         private static bool IsTrackableScene(Scene scene)

--- a/Packages/src/Editor/FirstPartyTools/Compile/ExternalSceneFocusReturnDeferral.cs
+++ b/Packages/src/Editor/FirstPartyTools/Compile/ExternalSceneFocusReturnDeferral.cs
@@ -29,6 +29,16 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         }
 
         /// <summary>
+        /// Decides whether Initialize may replace the restored fingerprints with the current disk state.
+        /// A deferred focus return needs the pre-reload fingerprints to compare against, so re-recording
+        /// them after the Play Mode domain reload would hide exactly the change it was deferred to detect.
+        /// </summary>
+        public bool ShouldRecordBaselineOnInitialize(bool isFocused, bool restoredSceneSnapshots)
+        {
+            return !restoredSceneSnapshots || (isFocused && !IsDeferred);
+        }
+
+        /// <summary>
         /// Returns whether a deferred preflight must run now, and clears the deferral so it runs only once.
         /// </summary>
         public bool ConsumeOnEnteredEditMode()

--- a/Packages/src/Editor/FirstPartyTools/Compile/ExternalSceneFocusReturnDeferral.cs
+++ b/Packages/src/Editor/FirstPartyTools/Compile/ExternalSceneFocusReturnDeferral.cs
@@ -1,0 +1,41 @@
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Remembers that a focus-return Scene preflight was skipped during Play Mode so it can run once Edit Mode returns.
+    /// </summary>
+    internal sealed class ExternalSceneFocusReturnDeferral
+    {
+        public ExternalSceneFocusReturnDeferral(bool isDeferred)
+        {
+            IsDeferred = isDeferred;
+        }
+
+        public bool IsDeferred { get; private set; }
+
+        /// <summary>
+        /// Decides whether the focus-return preflight may run now. In Play Mode the open-Scene list also holds
+        /// Scenes loaded at runtime and EditorSceneManager.RestoreSceneManagerSetup throws, so the preflight
+        /// is deferred instead of being applied to that state.
+        /// </summary>
+        public bool ShouldResolveOnFocusReturn(bool isPlayingOrWillChangePlaymode)
+        {
+            if (!isPlayingOrWillChangePlaymode)
+            {
+                return true;
+            }
+
+            IsDeferred = true;
+            return false;
+        }
+
+        /// <summary>
+        /// Returns whether a deferred preflight must run now, and clears the deferral so it runs only once.
+        /// </summary>
+        public bool ConsumeOnEnteredEditMode()
+        {
+            bool wasDeferred = IsDeferred;
+            IsDeferred = false;
+            return wasDeferred;
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/Compile/ExternalSceneFocusReturnDeferral.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/Compile/ExternalSceneFocusReturnDeferral.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3e7a2a673ab5444a381a99dc2980de7b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/Compile/ExternalSceneSnapshotPruner.cs
+++ b/Packages/src/Editor/FirstPartyTools/Compile/ExternalSceneSnapshotPruner.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Drops Scene fingerprints that no longer belong to a Scene open in the Editor.
+    /// </summary>
+    internal static class ExternalSceneSnapshotPruner
+    {
+        /// <summary>
+        /// Removes every snapshot whose Scene is not in <paramref name="openScenePaths"/> and returns the removed paths.
+        /// Fingerprints recorded while a Scene was loaded only at runtime must not survive into Edit Mode,
+        /// where they would otherwise trigger a reload for a Scene the user never opened.
+        /// </summary>
+        public static string[] RemoveSnapshotsForScenesNotOpen(
+            Dictionary<string, (bool Exists, DateTime LastWriteTimeUtc, long Length)> snapshots,
+            string[] openScenePaths)
+        {
+            Debug.Assert(snapshots != null, "snapshots must not be null");
+            Debug.Assert(openScenePaths != null, "openScenePaths must not be null");
+
+            HashSet<string> openScenePathSet = new HashSet<string>(openScenePaths, StringComparer.Ordinal);
+            List<string> removedScenePaths = new List<string>();
+            foreach (string assetPath in snapshots.Keys)
+            {
+                if (!openScenePathSet.Contains(assetPath))
+                {
+                    removedScenePaths.Add(assetPath);
+                }
+            }
+
+            for (int i = 0; i < removedScenePaths.Count; i++)
+            {
+                snapshots.Remove(removedScenePaths[i]);
+            }
+
+            return removedScenePaths.ToArray();
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/Compile/ExternalSceneSnapshotPruner.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/Compile/ExternalSceneSnapshotPruner.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e45c61616c7f84a178af714efb889d73
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/docs/focus-return-asset-handling.md
+++ b/docs/focus-return-asset-handling.md
@@ -31,6 +31,25 @@ in-memory state is treated as authoritative there. The decision is isolated in
 `ExternalAssetFocusReturnSavePolicy` so it can be unit-tested without Unity Scene APIs
 (`Assets/Tests/Editor/ExternalAssetFocusReturnSavePolicyTests.cs`).
 
+## Why the preflight is deferred during Play Mode
+
+While Play Mode is running (or about to change), a focus return records that the preflight
+was skipped and does nothing else. Two things make the table above inapplicable there:
+the open-Scene list comes from `SceneManager` and also contains Scenes loaded at runtime
+(for example additive loads), which are not open in the Editor at all, and
+`EditorSceneManager.RestoreSceneManagerSetup` throws `InvalidOperationException` in Play Mode,
+so the `clean + changed` row cannot be applied. Before this deferral existed the throw
+happened before the fingerprints were persisted, so the stale fingerprint of a runtime-loaded
+Scene kept the exception firing on every later focus return.
+
+On `PlayModeStateChange.EnteredEditMode` the tracker first drops fingerprints for Scenes that
+are no longer open in the Editor (runtime-loaded Scenes never get a lasting baseline), then
+runs the preflight once if a focus return was deferred and the Editor is focused. An unfocused
+Editor leaves it to the next focus return instead. The deferral flag lives in `SessionState`
+because leaving Play Mode can trigger a domain reload. The decision is isolated in
+`ExternalSceneFocusReturnDeferral` and `ExternalSceneSnapshotPruner`
+(`Assets/Tests/Editor/ExternalSceneFocusReturnDeferralTests.cs`).
+
 ## Why dirty-but-unchanged assets are never saved
 
 Through package 3.0.0 the preflight saved every dirty Scene and the dirty Prefab Stage on every focus


### PR DESCRIPTION
## Summary
- Returning focus to the Editor while Play Mode is running no longer throws, and the error no longer repeats on every later focus return.
- Scene changes made outside the Editor are still picked up: the check is deferred and runs once after Play Mode ends.

## User Impact

Before: while Play Mode was running, giving the Editor focus back made the external-Scene preflight compare fingerprints for every Scene in `SceneManager`, including Scenes loaded additively at runtime. When one of them looked changed on disk, it called `EditorSceneManager.RestoreSceneManagerSetup`, which is not allowed in Play Mode:

```
InvalidOperationException: This cannot be used during play mode
```

Because the exception was thrown before the new fingerprints were persisted, the stale entry for the runtime-loaded Scene stayed in the snapshot, so the same exception fired on every later focus return until the session snapshot was cleared. In practice, a user who entered Play Mode, switched to another app and came back kept seeing the exception for the rest of the session.

After: nothing is reloaded during Play Mode. The preflight is skipped and remembered, stale fingerprints for Scenes that are no longer open in the Editor are dropped on returning to Edit Mode, and the deferred preflight then runs once — so an external Scene edit made during the Play Mode session is still detected, without the exception.

## Changes
- Skip the preflight while `isPlayingOrWillChangePlaymode`, and record the skip in `SessionState` so it survives the domain reload on exiting Play Mode.
- On `EnteredEditMode`, drop fingerprints for Scenes that are no longer open in the Editor, then run the deferred preflight once, when the Editor has focus.
- While a focus return is still deferred, keep the fingerprints restored from the session instead of
  re-recording them from disk. Exiting Play Mode normally triggers a domain reload, and a focused
  re-record would erase the very baseline the deferred preflight has to compare against.
- Isolate the three decisions in `ExternalSceneFocusReturnDeferral` and `ExternalSceneSnapshotPruner` so they are plain testable logic, and document the Play Mode case in `docs/focus-return-asset-handling.md`.

## Verification
- EditMode tests matching `ExternalScene` (regex filter, the surrounding Scene-tracking suite): 29 passed, 0 failed.
- EditMode tests, `ExternalSceneFocusReturnDeferralTests` (class filter): 10 passed, 0 failed.
- Manual, additive Scene case: with an additively loaded Scene in Play Mode, the focus-return handler was invoked directly (through reflection, since window focus cannot be scripted) and it deferred instead of throwing; repeating it stays clean.
- Manual, deferred-detection case: with `Assets/Scenes/SampleScene.unity` open and clean, entering Play Mode, touching the Scene file on disk during Play, invoking the focus-return handler (deferred, no exception), then leaving Play Mode with the Editor focused:
  - the Editor log shows `Entered Edit Mode` with `shouldResolve: true`, then the deferred preflight starting with `changed: true` for that Scene and finishing with `changed: false` — the external edit was detected and the Scene reloaded.
  - the stored fingerprint moved to the new on-disk timestamp, and no `InvalidOperationException` appears anywhere in the log.

Fixes #2682
