### PR TITLE
fix: Hot reload now works for scripts inside packages

### DIFF
--- a/Assets/Tests/Editor/HotReload/HotReloadAssemblyResolutionDiagnosticsTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadAssemblyResolutionDiagnosticsTests.cs
@@ -27,6 +27,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         [SetUp]
         public void SetUp()
         {
+            // The production run captures these at its entry point; a direct call into the patch
+            // target resolver in a test has to do the same.
+            HotReloadPackageRootProvider.CaptureCurrent();
             _previousSnapshotProvider = HotReloadEditorStateSnapshotProvider.CaptureForTesting;
             HotReloadEditorStateSnapshotProvider.CaptureForTesting = () =>
                 new HotReloadEditorStateSnapshot(false, false, false);

--- a/Assets/Tests/Editor/HotReload/HotReloadCrossFileE2ETests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadCrossFileE2ETests.cs
@@ -59,6 +59,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         [SetUp]
         public void SetUp()
         {
+            // The production run captures these at its entry point; a direct call to the path
+            // normalizer in a test has to do the same.
+            HotReloadPackageRootProvider.CaptureCurrent();
             HotReloadPatcher.RevertAll();
             HotReloadAutoRefreshHold.SyncToActiveChanges();
         }

--- a/Assets/Tests/Editor/HotReload/HotReloadIntroducedTypeActivationTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadIntroducedTypeActivationTests.cs
@@ -24,6 +24,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         [SetUp]
         public void SetUp()
         {
+            // The production run captures these at its entry point; a direct call to the path
+            // normalizer in a test has to do the same.
+            HotReloadPackageRootProvider.CaptureCurrent();
             _previousSnapshotProvider = HotReloadEditorStateSnapshotProvider.CaptureForTesting;
             HotReloadPatcher.RevertAll();
             HotReloadAutoRefreshHold.SyncToActiveChanges();

--- a/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
@@ -32,6 +32,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         [SetUp]
         public void SetUp()
         {
+            // The production run captures these at its entry point; a direct call to the path
+            // normalizer in a test has to do the same.
+            HotReloadPackageRootProvider.CaptureCurrent();
             HotReloadPatcher.RevertAll();
             HotReloadAutoRefreshHold.SyncToActiveChanges();
         }

--- a/Assets/Tests/Editor/HotReload/HotReloadPatchTargetSupportPathTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadPatchTargetSupportPathTests.cs
@@ -1,0 +1,95 @@
+using System.IO;
+
+using NUnit.Framework;
+
+using UnityEditor.Compilation;
+
+using UnityEngine;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
+{
+    /// <summary>
+    /// Covers script-path normalization against the real Unity path APIs.
+    /// The expected values depend on this development project's own package layout
+    /// (the package embedded at Packages/src and the packages it depends on).
+    /// </summary>
+    public sealed class HotReloadPatchTargetSupportPathTests
+    {
+        private const string EmbeddedPhysicalPath =
+            "Packages/src/Editor/FirstPartyTools/HotReload/HotReloadPatchTargetSupport.cs";
+        private const string EmbeddedLogicalPath =
+            "Packages/io.github.hatayama.uloopmcp/Editor/FirstPartyTools/HotReload/HotReloadPatchTargetSupport.cs";
+        private const string GitPackageLogicalPath =
+            "Packages/com.boxqkrtm.ide.cursor/Editor/ProjectGeneration/ProjectGeneration.cs";
+        private const string AssetsScriptPath =
+            "Assets/Tests/Editor/HotReload/HotReloadToolTests.cs";
+        private const string EmbeddedAssemblyName =
+            "UnityCLILoop.FirstPartyTools.HotReload.Editor.dll";
+
+        [SetUp]
+        public void SetUp()
+        {
+            // The production run captures these at its entry point; a direct call to the path
+            // normalizer in a test has to do the same.
+            HotReloadPackageRootProvider.CaptureCurrent();
+        }
+
+        [Test]
+        public void ToProjectRelativeScriptPath_WhenEmbeddedPackagePhysicalPath_ReturnsLogicalPackagePath()
+        {
+            // Verifies the physical folder of an embedded package is mapped back to its virtual package path.
+            string relative = HotReloadPatchTargetSupport.ToProjectRelativeScriptPath(EmbeddedPhysicalPath);
+
+            Assert.That(relative, Is.EqualTo(EmbeddedLogicalPath));
+        }
+
+        [Test]
+        public void ToProjectRelativeScriptPath_WhenEmbeddedPackageLogicalPath_ReturnsItUnchanged()
+        {
+            // Verifies a logical package path survives normalization instead of collapsing to the physical folder.
+            string relative = HotReloadPatchTargetSupport.ToProjectRelativeScriptPath(EmbeddedLogicalPath);
+
+            Assert.That(relative, Is.EqualTo(EmbeddedLogicalPath));
+        }
+
+        [Test]
+        public void ToProjectRelativeScriptPath_WhenGitPackageLogicalPath_ReturnsItUnchanged()
+        {
+            // Verifies a git package path is not rewritten into its Library/PackageCache location.
+            string relative = HotReloadPatchTargetSupport.ToProjectRelativeScriptPath(GitPackageLogicalPath);
+
+            Assert.That(relative, Is.EqualTo(GitPackageLogicalPath));
+        }
+
+        [Test]
+        public void ToProjectRelativeScriptPath_WhenAssetsRelativePath_ReturnsItUnchanged()
+        {
+            // Verifies an already project-relative Assets path is left alone.
+            string relative = HotReloadPatchTargetSupport.ToProjectRelativeScriptPath(AssetsScriptPath);
+
+            Assert.That(relative, Is.EqualTo(AssetsScriptPath));
+        }
+
+        [Test]
+        public void ToProjectRelativeScriptPath_WhenAbsoluteAssetsPath_StripsTheProjectRoot()
+        {
+            // Verifies an absolute path under Assets becomes project-relative.
+            string absolutePath = Path.Combine(Application.dataPath, "Tests/Editor/HotReload/HotReloadToolTests.cs");
+
+            string relative = HotReloadPatchTargetSupport.ToProjectRelativeScriptPath(absolutePath);
+
+            Assert.That(relative, Is.EqualTo(AssetsScriptPath));
+        }
+
+        [Test]
+        public void ToProjectRelativeScriptPath_WhenEmbeddedPackagePhysicalPath_ResolvesTheOwningAssembly()
+        {
+            // Verifies the normalized path resolves to the package's own assembly instead of Assembly-CSharp-Editor.
+            string relative = HotReloadPatchTargetSupport.ToProjectRelativeScriptPath(EmbeddedPhysicalPath);
+
+            Assert.That(CompilationPipeline.GetAssemblyNameFromScriptPath(relative), Is.EqualTo(EmbeddedAssemblyName));
+        }
+    }
+}

--- a/Assets/Tests/Editor/HotReload/HotReloadPatchTargetSupportPathTests.cs.meta
+++ b/Assets/Tests/Editor/HotReload/HotReloadPatchTargetSupportPathTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7b08b0a7d7575438b9cc90a37ae9b85d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/HotReload/HotReloadScriptPathNormalizerTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadScriptPathNormalizerTests.cs
@@ -1,0 +1,117 @@
+using System;
+using System.Collections.Generic;
+
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
+{
+    /// <summary>
+    /// Covers the pure normalization of an absolute path into a project-relative script path.
+    /// </summary>
+    public sealed class HotReloadScriptPathNormalizerTests
+    {
+        private static IReadOnlyList<HotReloadPackageRoot> PackageRoots(params (string Resolved, string Asset)[] roots)
+        {
+            List<HotReloadPackageRoot> mapped = new List<HotReloadPackageRoot>(roots.Length);
+            foreach ((string Resolved, string Asset) root in roots)
+            {
+                mapped.Add(new HotReloadPackageRoot(root.Resolved, root.Asset));
+            }
+
+            return mapped;
+        }
+
+        [Test]
+        public void ToProjectRelative_WhenPathIsInsideACachedPackage_ReturnsTheVirtualPackagePath()
+        {
+            // Verifies a package's physical folder is mapped back to the Packages/<id> path Unity expects.
+            string relative = HotReloadScriptPathNormalizer.ToProjectRelative(
+                "/proj/Library/PackageCache/com.example.core@abc123/Runtime/Foo.cs",
+                "/proj",
+                PackageRoots(("/proj/Library/PackageCache/com.example.core@abc123", "Packages/com.example.core")),
+                StringComparison.Ordinal);
+
+            Assert.That(relative, Is.EqualTo("Packages/com.example.core/Runtime/Foo.cs"));
+        }
+
+        [Test]
+        public void ToProjectRelative_WhenPackageIsEmbeddedUnderTheProjectRoot_PrefersTheVirtualPackagePath()
+        {
+            // Verifies an embedded package is not reduced to its physical folder, which resolves to the wrong assembly.
+            string relative = HotReloadScriptPathNormalizer.ToProjectRelative(
+                "/proj/Packages/src/Editor/Foo.cs",
+                "/proj",
+                PackageRoots(("/proj/Packages/src", "Packages/com.example.core")),
+                StringComparison.Ordinal);
+
+            Assert.That(relative, Is.EqualTo("Packages/com.example.core/Editor/Foo.cs"));
+        }
+
+        [Test]
+        public void ToProjectRelative_WhenAbsoluteAssetsPath_StripsTheProjectRoot()
+        {
+            // Verifies an absolute Assets path under the project root becomes project-relative.
+            string relative = HotReloadScriptPathNormalizer.ToProjectRelative(
+                "/proj/Assets/Scripts/Foo.cs",
+                "/proj",
+                PackageRoots(),
+                StringComparison.Ordinal);
+
+            Assert.That(relative, Is.EqualTo("Assets/Scripts/Foo.cs"));
+        }
+
+        [Test]
+        public void ToProjectRelative_WhenProjectRootEndsWithSlash_StripsTheSameRoot()
+        {
+            // Verifies a trailing slash on the project root does not change the result.
+            string relative = HotReloadScriptPathNormalizer.ToProjectRelative(
+                "/proj/Assets/Scripts/Foo.cs",
+                "/proj/",
+                PackageRoots(),
+                StringComparison.Ordinal);
+
+            Assert.That(relative, Is.EqualTo("Assets/Scripts/Foo.cs"));
+        }
+
+        [Test]
+        public void ToProjectRelative_WhenPathUsesBackslashes_NormalizesSeparators()
+        {
+            // Verifies Windows separators in the path, the root, and a package root are all normalized.
+            string relative = HotReloadScriptPathNormalizer.ToProjectRelative(
+                "C:\\proj\\Assets\\Scripts\\Foo.cs",
+                "C:\\proj",
+                PackageRoots(("C:\\proj\\Packages\\src", "Packages/com.example.core")),
+                StringComparison.OrdinalIgnoreCase);
+
+            Assert.That(relative, Is.EqualTo("Assets/Scripts/Foo.cs"));
+        }
+
+        [Test]
+        public void ToProjectRelative_WhenWindowsCaseDiffers_StillMapsThePackageRoot()
+        {
+            // Verifies the Windows comparison ignores case differences against a package root.
+            string relative = HotReloadScriptPathNormalizer.ToProjectRelative(
+                "c:/PROJ/Packages/SRC/Editor/Foo.cs",
+                "C:/proj",
+                PackageRoots(("C:/proj/Packages/src", "Packages/com.example.core")),
+                StringComparison.OrdinalIgnoreCase);
+
+            Assert.That(relative, Is.EqualTo("Packages/com.example.core/Editor/Foo.cs"));
+        }
+
+        [Test]
+        public void ToProjectRelative_WhenPathIsOutsideTheProject_OnlyNormalizesSeparators()
+        {
+            // Verifies a path outside the project root is returned as is, so the caller hits the existing failure path.
+            string relative = HotReloadScriptPathNormalizer.ToProjectRelative(
+                "/other/Assets/Scripts/Foo.cs",
+                "/proj",
+                PackageRoots(),
+                StringComparison.Ordinal);
+
+            Assert.That(relative, Is.EqualTo("/other/Assets/Scripts/Foo.cs"));
+        }
+    }
+}

--- a/Assets/Tests/Editor/HotReload/HotReloadScriptPathNormalizerTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadScriptPathNormalizerTests.cs
@@ -50,6 +50,19 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         [Test]
+        public void ToProjectRelative_WhenPackageResolvesOutsideTheProject_ReturnsTheVirtualPackagePath()
+        {
+            // Verifies a file: package whose folder lives outside the project root still maps to its virtual path.
+            string relative = HotReloadScriptPathNormalizer.ToProjectRelative(
+                "/MyPackage/Runtime/Foo.cs",
+                "/proj",
+                PackageRoots(("/MyPackage", "Packages/com.example.core")),
+                StringComparison.Ordinal);
+
+            Assert.That(relative, Is.EqualTo("Packages/com.example.core/Runtime/Foo.cs"));
+        }
+
+        [Test]
         public void ToProjectRelative_WhenAbsoluteAssetsPath_StripsTheProjectRoot()
         {
             // Verifies an absolute Assets path under the project root becomes project-relative.

--- a/Assets/Tests/Editor/HotReload/HotReloadScriptPathNormalizerTests.cs.meta
+++ b/Assets/Tests/Editor/HotReload/HotReloadScriptPathNormalizerTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 340d7451fdd5a4382b5c233777f0c3c6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
@@ -40,6 +40,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             // CompilationPipeline / Application.dataPath require the Unity main thread, and the
             // groups cannot be planned before every file knows which assembly it compiles into.
             await MainThreadSwitcher.SwitchToMainThread(ct);
+            // Why after the switch: PackageInfo is main-thread only, and script paths are
+            // normalized against these roots later on the background threads this run switches to.
+            HotReloadPackageRootProvider.CaptureCurrent();
             // Why after the switch: the accumulator has to read the Auto Refresh hold flag out of
             // SessionState, which is a main-thread API.
             HotReloadRunAccumulator run =

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadPackageRoots.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadPackageRoots.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Collections.Generic;
+
+using UnityEngine;
+
+using UpmPackageInfo = UnityEditor.PackageManager.PackageInfo;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// One package's physical folder and the virtual path Unity exposes it under.
+    /// </summary>
+    internal sealed class HotReloadPackageRoot
+    {
+        internal HotReloadPackageRoot(string resolvedPath, string assetPath)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(resolvedPath), "resolvedPath must not be empty.");
+            Debug.Assert(!string.IsNullOrEmpty(assetPath), "assetPath must not be empty.");
+            ResolvedPath = resolvedPath;
+            AssetPath = assetPath;
+        }
+
+        /// <summary>Absolute folder the package's files actually live in.</summary>
+        internal string ResolvedPath { get; }
+
+        /// <summary>Virtual folder Unity's script APIs expect, in the form Packages/&lt;package-id&gt;.</summary>
+        internal string AssetPath { get; }
+    }
+
+    /// <summary>
+    /// Captures the package folder mapping on the Unity main thread so path normalization can run
+    /// on the background threads the hot-reload run switches to.
+    /// </summary>
+    internal static class HotReloadPackageRootProvider
+    {
+        // Why a replaceable seam: the real mapping is Editor process state, while tests must be able
+        // to prove the normalization against package roots that this project does not contain.
+        internal static Func<IReadOnlyList<HotReloadPackageRoot>> CaptureForTesting = Capture;
+
+        private static IReadOnlyList<HotReloadPackageRoot> _current;
+
+        /// <summary>Refreshes the mapping. Must be called from the Unity main thread.</summary>
+        internal static void CaptureCurrent()
+        {
+            _current = CaptureForTesting();
+        }
+
+        internal static IReadOnlyList<HotReloadPackageRoot> Current
+        {
+            get
+            {
+                // Fail fast rather than capturing lazily: PackageInfo is main-thread only, so a
+                // lazy capture would succeed or throw depending on which thread first asked, and a
+                // caller that never passed through the run entry point would be silently tolerated.
+                if (_current == null)
+                {
+                    throw new InvalidOperationException(
+                        "Hot-reload package roots were never captured. Call "
+                        + nameof(HotReloadPackageRootProvider) + "." + nameof(CaptureCurrent)
+                        + " on the Unity main thread before normalizing script paths.");
+                }
+
+                return _current;
+            }
+        }
+
+        private static IReadOnlyList<HotReloadPackageRoot> Capture()
+        {
+            UpmPackageInfo[] packages = UpmPackageInfo.GetAllRegisteredPackages();
+            List<HotReloadPackageRoot> roots = new List<HotReloadPackageRoot>(packages.Length);
+            foreach (UpmPackageInfo package in packages)
+            {
+                if (string.IsNullOrEmpty(package.resolvedPath) || string.IsNullOrEmpty(package.assetPath))
+                {
+                    continue;
+                }
+
+                roots.Add(new HotReloadPackageRoot(package.resolvedPath, package.assetPath));
+            }
+
+            return roots;
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadPackageRoots.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadPackageRoots.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8c3d4b4f4bef942e49f113bf89b6eb7c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadPatchTargetSupport.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadPatchTargetSupport.cs
@@ -279,24 +279,21 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         internal static string ToProjectRelativeScriptPath(string path)
         {
             Debug.Assert(!string.IsNullOrEmpty(path), "path must not be empty.");
-            string normalized = path.Replace('\\', '/');
-            string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, "..")).Replace('\\', '/');
-            if (!projectRoot.EndsWith("/", StringComparison.Ordinal))
-            {
-                projectRoot += "/";
-            }
+            string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
 
-            string fullPath = Path.GetFullPath(path).Replace('\\', '/');
+            // Path.GetFullPath resolves a relative path against the current directory (the project
+            // root in the Editor) and turns a virtual Packages/<pkg-id>/... path into the physical
+            // folder behind it, which resolves to the wrong assembly. The captured package roots
+            // map that physical folder back to the virtual path Unity's script APIs expect.
+            string fullPath = Path.GetFullPath(path.Replace('\\', '/'));
             StringComparison comparison = Application.platform == RuntimePlatform.WindowsEditor
                 ? StringComparison.OrdinalIgnoreCase
                 : StringComparison.Ordinal;
-            if (fullPath.StartsWith(projectRoot, comparison))
-            {
-                return fullPath.Substring(projectRoot.Length);
-            }
-
-            // Already project-relative (Assets/... or Packages/...).
-            return normalized;
+            return HotReloadScriptPathNormalizer.ToProjectRelative(
+                fullPath,
+                projectRoot,
+                HotReloadPackageRootProvider.Current,
+                comparison);
         }
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadScriptPathNormalizer.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadScriptPathNormalizer.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Collections.Generic;
+
+using UnityEngine;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Turns an absolute script path into the project-relative form that
+    /// CompilationPipeline.GetAssemblyNameFromScriptPath accepts.
+    /// </summary>
+    internal static class HotReloadScriptPathNormalizer
+    {
+        internal static string ToProjectRelative(
+            string fullPath,
+            string projectRoot,
+            IReadOnlyList<HotReloadPackageRoot> packageRoots,
+            StringComparison comparison)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(fullPath), "fullPath must not be empty.");
+            Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be empty.");
+            Debug.Assert(packageRoots != null, "packageRoots must not be null.");
+
+            string normalized = fullPath.Replace('\\', '/');
+            // Package folders are matched before the project root: an embedded package lives under
+            // the project root, and stripping the root would yield the physical Packages/<folder>
+            // path, which resolves to the wrong assembly.
+            string packageRelative = TryMapToPackagePath(normalized, packageRoots, comparison);
+            if (packageRelative != null)
+            {
+                return packageRelative;
+            }
+
+            string root = WithTrailingSlash(projectRoot.Replace('\\', '/'));
+            // Assets has no virtual mapping of its own, so it stays absolute and needs the root removed.
+            if (normalized.StartsWith(root, comparison))
+            {
+                return normalized.Substring(root.Length);
+            }
+
+            // Outside the project: returned as is so GetAssemblyNameFromScriptPath yields an empty
+            // name and the caller reports the existing "not part of any compiled assembly" failure.
+            return normalized;
+        }
+
+        private static string TryMapToPackagePath(
+            string normalized,
+            IReadOnlyList<HotReloadPackageRoot> packageRoots,
+            StringComparison comparison)
+        {
+            foreach (HotReloadPackageRoot packageRoot in packageRoots)
+            {
+                string resolvedRoot = WithTrailingSlash(packageRoot.ResolvedPath.Replace('\\', '/'));
+                if (!normalized.StartsWith(resolvedRoot, comparison))
+                {
+                    continue;
+                }
+
+                string assetRoot = WithTrailingSlash(packageRoot.AssetPath.Replace('\\', '/'));
+                return assetRoot + normalized.Substring(resolvedRoot.Length);
+            }
+
+            return null;
+        }
+
+        private static string WithTrailingSlash(string path)
+        {
+            return path.EndsWith("/", StringComparison.Ordinal) ? path : path + "/";
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadScriptPathNormalizer.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadScriptPathNormalizer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 21aa48f397624469e801803cca5e92a7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary
- `uloop hot-reload` now works for scripts that live in a package — git packages, `file:` packages, and embedded packages — not only for scripts under `Assets/`.

## User Impact

Before, passing a package path to hot reload failed:

```
uloop hot-reload --files Packages/<package-id>/Editor/Foo.cs
Failed (file): ... is not part of the last compiled assembly
```

The path was resolved with `Path.GetFullPath`, which turns Unity's virtual `Packages/<package-id>/...` path into the physical folder behind it: `Library/PackageCache/<package-id>@<hash>/...` for a git package, and the real folder for an embedded or `file:` package. `CompilationPipeline.GetAssemblyNameFromScriptPath` only answers correctly for the virtual path, so those physical paths resolved to `Assembly-CSharp-Editor` and the file looked like it belonged to a different assembly than the one it actually compiles into. In practice, no script in any package could be hot reloaded — including this repository's own package sources.

After, both spellings of the same file work and report the same assembly, so a package author can edit a method body and hot reload it the way an `Assets/` script has always worked.

## Changes
- Capture each package's `resolvedPath` / `assetPath` pair at the hot-reload run entry point (right after it switches to the Unity main thread) and map an absolute path back to `Packages/<package-id>/...` through those roots.
- Only strip the project root for `Assets/` paths, which have no virtual mapping of their own.
- Fail fast when the mapping was never captured, rather than capturing it lazily: `PackageInfo` is main-thread only, and the run drops Unity's synchronization context (`ConfigureAwait(false)`) before path normalization happens, so a lazy capture would succeed or throw depending on which thread asked first.
- Cover the normalization twice: as a pure function with injected package roots (including Windows separators and case-insensitive matching), and against the real Unity APIs for embedded, git, and `Assets/` paths.

### Why not the shorter fix
Returning early for any path that already starts with `Packages/` was considered and rejected: it does not help a caller that passes the *physical* path of an embedded package (`Packages/<folder>/...` where the folder name is not the package id), nor a `Library/PackageCache/...` path, both of which are ordinary inputs today. Normalizing through the package roots handles every spelling with one rule.

## Verification
- EditMode tests, `HotReloadScriptPathNormalizerTests` + `HotReloadPatchTargetSupportPathTests`: 13 passed, 0 failed. The integration tests were confirmed to fail before the fix (4 of 6, with the physical path and `Assembly-CSharp-Editor.dll` as the actual values).
- EditMode regression across the hot-reload suites that call the path helper (`HotReloadScriptPathNormalizerTests`, `HotReloadPatchTargetSupportPathTests`, `HotReloadAssemblyResolutionDiagnosticsTests`, `HotReloadOrchestratorTests`, `HotReloadNewSourceMembershipTests`, `HotReloadCrossFileE2ETests`, `HotReloadIntroducedTypeActivationTests`): 243 passed, 0 failed.
- File-length check: `No files exceeded the file-length limit.`
- Manual end-to-end in a running Editor, editing a method body in a script inside the embedded package and hot reloading it by both spellings of its path:
  - physical path (`Packages/<embedded-folder>/...`): `PatchedTotal=6`, no `Failed` outcome.
  - virtual package path (`Packages/<package-id>/...`): `PatchedTotal=6`, no `Failed` outcome.
  - The probe edit was reverted afterwards and is not part of this branch.

### Not verified
A `file:` package whose folder lives outside the project root was not tested — this project has none. Git packages (under `Library/PackageCache`) and embedded packages are both verified, and a `file:` package is registered through the same `PackageInfo` mapping, so it is expected to behave the same, but that is reasoning rather than a measurement.

Fixes #2666


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2713?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

