### PR TITLE
chore: Replace the hot-reload patch-target 8-tuple with a named resolution type

### DIFF
--- a/Assets/Tests/Editor/HotReload/HotReloadAssemblyResolutionDiagnosticsTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadAssemblyResolutionDiagnosticsTests.cs
@@ -178,14 +178,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             List<HotReloadMethodOutcome> outcomes = new List<HotReloadMethodOutcome>();
             List<string> warnings = new List<string>();
 
-            (HotReloadFileProcessResult earlyResult,
-                string projectRelativePath,
-                string assemblyName,
-                UnityCompilationAssembly compilationAssembly,
-                string targetDllPath,
-                string projectRoot,
-                HotReloadUnchangedSourceDecision unchangedDecision,
-                HotReloadNewSourceMembershipEvidence newSourceMembershipEvidence) = HotReloadPatchTargetSupport.ResolvePatchTarget(
+            HotReloadPatchTargetResolution resolution = HotReloadPatchTargetSupport.ResolvePatchTarget(
                 MissingHotReloadScriptPath,
                 MissingHotReloadScriptPath,
                 outcomes,
@@ -193,14 +186,14 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 "assembly-resolution-wiring",
                 new List<HotReloadMethodOutcome>());
 
-            Assert.That(earlyResult, Is.Null);
-            Assert.That(projectRelativePath, Is.EqualTo(MissingHotReloadScriptPath));
-            Assert.That(assemblyName, Is.EqualTo(HotReloadTestAssemblyName));
-            Assert.That(compilationAssembly, Is.Not.Null);
-            Assert.That(targetDllPath, Is.Not.Null.And.Not.Empty);
-            Assert.That(projectRoot, Is.Not.Null.And.Not.Empty);
-            Assert.That(unchangedDecision, Is.EqualTo(HotReloadUnchangedSourceDecision.NotUnchanged));
-            Assert.That(newSourceMembershipEvidence, Is.Not.Null);
+            Assert.That(resolution.EarlyResult, Is.Null);
+            Assert.That(resolution.ProjectRelativePath, Is.EqualTo(MissingHotReloadScriptPath));
+            Assert.That(resolution.AssemblyName, Is.EqualTo(HotReloadTestAssemblyName));
+            Assert.That(resolution.CompilationAssembly, Is.Not.Null);
+            Assert.That(resolution.TargetDllPath, Is.Not.Null.And.Not.Empty);
+            Assert.That(resolution.ProjectRoot, Is.Not.Null.And.Not.Empty);
+            Assert.That(resolution.UnchangedDecision, Is.EqualTo(HotReloadUnchangedSourceDecision.NotUnchanged));
+            Assert.That(resolution.NewSourceMembershipEvidence, Is.Not.Null);
         }
 
         private static UnityCompilationAssembly FindCompilationAssembly(string assemblyName)

--- a/Assets/Tests/Editor/HotReload/HotReloadNewSourceMembershipTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadNewSourceMembershipTests.cs
@@ -50,14 +50,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             List<HotReloadMethodOutcome> outcomes = new List<HotReloadMethodOutcome>();
             List<string> warnings = new List<string>();
 
-            (HotReloadFileProcessResult earlyResult,
-                string projectRelativePath,
-                string assemblyName,
-                UnityEditor.Compilation.Assembly compilationAssembly,
-                string targetDllPath,
-                string projectRoot,
-                HotReloadUnchangedSourceDecision unchangedDecision,
-                HotReloadNewSourceMembershipEvidence newSourceMembershipEvidence) = HotReloadPatchTargetSupport.ResolvePatchTarget(
+            HotReloadPatchTargetResolution resolution = HotReloadPatchTargetSupport.ResolvePatchTarget(
                 MissingHotReloadScriptPath,
                 MissingHotReloadScriptPath,
                 outcomes,
@@ -65,17 +58,17 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 "new-source-editor-state",
                 new List<HotReloadMethodOutcome>());
 
-            Assert.That(earlyResult, Is.Not.Null);
-            Assert.That(earlyResult.Outcomes, Has.Count.EqualTo(1));
-            Assert.That(earlyResult.Outcomes[0].Kind, Is.EqualTo(HotReloadMethodOutcomeKind.Failed));
-            Assert.That(earlyResult.Outcomes[0].Reason, Does.Contain("retry hot reload"));
-            Assert.That(projectRelativePath, Is.Null);
-            Assert.That(assemblyName, Is.Null);
-            Assert.That(compilationAssembly, Is.Null);
-            Assert.That(targetDllPath, Is.Null);
-            Assert.That(projectRoot, Is.Null);
-            Assert.That(unchangedDecision, Is.EqualTo(HotReloadUnchangedSourceDecision.NotUnchanged));
-            Assert.That(newSourceMembershipEvidence, Is.Null);
+            Assert.That(resolution.EarlyResult, Is.Not.Null);
+            Assert.That(resolution.EarlyResult.Outcomes, Has.Count.EqualTo(1));
+            Assert.That(resolution.EarlyResult.Outcomes[0].Kind, Is.EqualTo(HotReloadMethodOutcomeKind.Failed));
+            Assert.That(resolution.EarlyResult.Outcomes[0].Reason, Does.Contain("retry hot reload"));
+            Assert.That(resolution.ProjectRelativePath, Is.Null);
+            Assert.That(resolution.AssemblyName, Is.Null);
+            Assert.That(resolution.CompilationAssembly, Is.Null);
+            Assert.That(resolution.TargetDllPath, Is.Null);
+            Assert.That(resolution.ProjectRoot, Is.Null);
+            Assert.That(resolution.UnchangedDecision, Is.EqualTo(HotReloadUnchangedSourceDecision.NotUnchanged));
+            Assert.That(resolution.NewSourceMembershipEvidence, Is.Null);
         }
 
         /// <summary>
@@ -89,14 +82,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             List<HotReloadMethodOutcome> outcomes = new List<HotReloadMethodOutcome>();
             List<string> warnings = new List<string>();
 
-            (HotReloadFileProcessResult earlyResult,
-                string projectRelativePath,
-                string assemblyName,
-                UnityEditor.Compilation.Assembly compilationAssembly,
-                string targetDllPath,
-                string projectRoot,
-                HotReloadUnchangedSourceDecision unchangedDecision,
-                HotReloadNewSourceMembershipEvidence newSourceMembershipEvidence) = HotReloadPatchTargetSupport.ResolvePatchTarget(
+            HotReloadPatchTargetResolution resolution = HotReloadPatchTargetSupport.ResolvePatchTarget(
                 MissingHotReloadScriptPath,
                 MissingHotReloadScriptPath,
                 outcomes,
@@ -104,14 +90,14 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 "new-source-editor-ready",
                 new List<HotReloadMethodOutcome>());
 
-            Assert.That(earlyResult, Is.Null);
-            Assert.That(projectRelativePath, Is.EqualTo(MissingHotReloadScriptPath));
-            Assert.That(assemblyName, Is.Not.Null.And.Not.Empty);
-            Assert.That(compilationAssembly, Is.Not.Null);
-            Assert.That(targetDllPath, Is.Not.Null.And.Not.Empty);
-            Assert.That(projectRoot, Is.Not.Null.And.Not.Empty);
-            Assert.That(unchangedDecision, Is.EqualTo(HotReloadUnchangedSourceDecision.NotUnchanged));
-            Assert.That(newSourceMembershipEvidence, Is.Not.Null);
+            Assert.That(resolution.EarlyResult, Is.Null);
+            Assert.That(resolution.ProjectRelativePath, Is.EqualTo(MissingHotReloadScriptPath));
+            Assert.That(resolution.AssemblyName, Is.Not.Null.And.Not.Empty);
+            Assert.That(resolution.CompilationAssembly, Is.Not.Null);
+            Assert.That(resolution.TargetDllPath, Is.Not.Null.And.Not.Empty);
+            Assert.That(resolution.ProjectRoot, Is.Not.Null.And.Not.Empty);
+            Assert.That(resolution.UnchangedDecision, Is.EqualTo(HotReloadUnchangedSourceDecision.NotUnchanged));
+            Assert.That(resolution.NewSourceMembershipEvidence, Is.Not.Null);
         }
 
         /// <summary>
@@ -224,14 +210,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             List<HotReloadMethodOutcome> outcomes = new List<HotReloadMethodOutcome>();
             List<string> warnings = new List<string>();
 
-            (HotReloadFileProcessResult earlyResult,
-                string projectRelativePath,
-                string assemblyName,
-                UnityEditor.Compilation.Assembly compilationAssembly,
-                string targetDllPath,
-                string projectRoot,
-                HotReloadUnchangedSourceDecision unchangedDecision,
-                HotReloadNewSourceMembershipEvidence newSourceMembershipEvidence) = HotReloadPatchTargetSupport.ResolvePatchTarget(
+            HotReloadPatchTargetResolution resolution = HotReloadPatchTargetSupport.ResolvePatchTarget(
                 MissingPredefinedScriptPath,
                 MissingPredefinedScriptPath,
                 outcomes,
@@ -239,16 +218,16 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 "new-predefined-source",
                 new List<HotReloadMethodOutcome>());
 
-            Assert.That(earlyResult, Is.Null);
-            Assert.That(projectRelativePath, Is.EqualTo(MissingPredefinedScriptPath));
-            Assert.That(assemblyName, Is.EqualTo("Assembly-CSharp"));
-            Assert.That(compilationAssembly, Is.Not.Null);
-            Assert.That(targetDllPath, Is.Not.Null.And.Not.Empty);
-            Assert.That(projectRoot, Is.Not.Null.And.Not.Empty);
-            Assert.That(unchangedDecision, Is.EqualTo(HotReloadUnchangedSourceDecision.NotUnchanged));
-            Assert.That(newSourceMembershipEvidence, Is.Not.Null);
-            Assert.That(newSourceMembershipEvidence.Boundaries, Is.Empty);
-            Assert.That(newSourceMembershipEvidence.ResolvedAssemblyDefinitionPath, Is.Null);
+            Assert.That(resolution.EarlyResult, Is.Null);
+            Assert.That(resolution.ProjectRelativePath, Is.EqualTo(MissingPredefinedScriptPath));
+            Assert.That(resolution.AssemblyName, Is.EqualTo("Assembly-CSharp"));
+            Assert.That(resolution.CompilationAssembly, Is.Not.Null);
+            Assert.That(resolution.TargetDllPath, Is.Not.Null.And.Not.Empty);
+            Assert.That(resolution.ProjectRoot, Is.Not.Null.And.Not.Empty);
+            Assert.That(resolution.UnchangedDecision, Is.EqualTo(HotReloadUnchangedSourceDecision.NotUnchanged));
+            Assert.That(resolution.NewSourceMembershipEvidence, Is.Not.Null);
+            Assert.That(resolution.NewSourceMembershipEvidence.Boundaries, Is.Empty);
+            Assert.That(resolution.NewSourceMembershipEvidence.ResolvedAssemblyDefinitionPath, Is.Null);
         }
 
         /// <summary>

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
@@ -178,28 +178,21 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 run.OneShotCallerNoteCandidates);
             List<HotReloadMethodOutcome> alreadyActiveOutcomes = new List<HotReloadMethodOutcome>();
 
-            (HotReloadFileProcessResult earlyResolve,
-                string projectRelativePath,
-                string assemblyName,
-                UnityCompilationAssembly compilationAssembly,
-                string targetDllPath,
-                string projectRoot,
-                HotReloadUnchangedSourceDecision unchangedDecision,
-                HotReloadNewSourceMembershipEvidence newSourceMembershipEvidence) = HotReloadPatchTargetSupport.ResolvePatchTarget(
+            HotReloadPatchTargetResolution resolution = HotReloadPatchTargetSupport.ResolvePatchTarget(
                 filePath,
                 workerSourcePath,
                 sinks.Outcomes,
                 sinks.Warnings,
                 correlationId,
                 alreadyActiveOutcomes);
-            if (earlyResolve != null)
+            if (resolution.IsEarlyExit)
             {
-                resultSlots[index] = earlyResolve;
+                resultSlots[index] = resolution.EarlyResult;
                 resultPaths[index] = HotReloadPatchTargetSupport.ToProjectRelativeScriptPath(filePath);
                 return;
             }
 
-            if (unchangedDecision == HotReloadUnchangedSourceDecision.ShortCircuited)
+            if (resolution.UnchangedDecision == HotReloadUnchangedSourceDecision.ShortCircuited)
             {
                 deferredAlreadyActive[index] = alreadyActiveOutcomes;
             }
@@ -207,15 +200,15 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             groupFiles[index] = new HotReloadGroupFile(
                 filePath,
                 workerSourcePath,
-                projectRelativePath,
-                assemblyName,
-                compilationAssembly,
-                targetDllPath,
-                projectRoot,
+                resolution.ProjectRelativePath,
+                resolution.AssemblyName,
+                resolution.CompilationAssembly,
+                resolution.TargetDllPath,
+                resolution.ProjectRoot,
                 sinks,
-                newSourceMembershipEvidence);
-            resultPaths[index] = projectRelativePath;
-            plannerInput.Add((index, assemblyName, projectRelativePath));
+                resolution.NewSourceMembershipEvidence);
+            resultPaths[index] = resolution.ProjectRelativePath;
+            plannerInput.Add((index, resolution.AssemblyName, resolution.ProjectRelativePath));
         }
 
         private static bool[] ClassifyAllDeferredPlans(

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadPatchTargetResolution.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadPatchTargetResolution.cs
@@ -1,0 +1,92 @@
+using UnityEngine;
+
+using UnityCompilationAssembly = UnityEditor.Compilation.Assembly;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// The outcome of resolving the compiled assembly target for one hot-reload file: either an
+    /// early result the caller must report as-is, or the resolved target the apply stage needs.
+    /// </summary>
+    internal sealed class HotReloadPatchTargetResolution
+    {
+        public HotReloadFileProcessResult EarlyResult { get; }
+        public string ProjectRelativePath { get; }
+        public string AssemblyName { get; }
+        public UnityCompilationAssembly CompilationAssembly { get; }
+        public string TargetDllPath { get; }
+        public string ProjectRoot { get; }
+        public HotReloadUnchangedSourceDecision UnchangedDecision { get; }
+        public HotReloadNewSourceMembershipEvidence NewSourceMembershipEvidence { get; }
+
+        public bool IsEarlyExit => EarlyResult != null;
+
+        private HotReloadPatchTargetResolution(
+            HotReloadFileProcessResult earlyResult,
+            string projectRelativePath,
+            string assemblyName,
+            UnityCompilationAssembly compilationAssembly,
+            string targetDllPath,
+            string projectRoot,
+            HotReloadUnchangedSourceDecision unchangedDecision,
+            HotReloadNewSourceMembershipEvidence newSourceMembershipEvidence)
+        {
+            EarlyResult = earlyResult;
+            ProjectRelativePath = projectRelativePath;
+            AssemblyName = assemblyName;
+            CompilationAssembly = compilationAssembly;
+            TargetDllPath = targetDllPath;
+            ProjectRoot = projectRoot;
+            UnchangedDecision = unchangedDecision;
+            NewSourceMembershipEvidence = newSourceMembershipEvidence;
+        }
+
+        /// <summary>
+        /// A file that never reached a patch target. The caller reports the early result and
+        /// reads none of the target fields.
+        /// </summary>
+        internal static HotReloadPatchTargetResolution EarlyExit(HotReloadFileProcessResult earlyResult)
+        {
+            Debug.Assert(earlyResult != null, "earlyResult must not be null.");
+
+            return new HotReloadPatchTargetResolution(
+                earlyResult,
+                null,
+                null,
+                null,
+                null,
+                null,
+                HotReloadUnchangedSourceDecision.NotUnchanged,
+                null);
+        }
+
+        /// <summary>
+        /// A file whose compiled assembly, DLL and project root were all resolved.
+        /// </summary>
+        internal static HotReloadPatchTargetResolution Resolved(
+            string projectRelativePath,
+            string assemblyName,
+            UnityCompilationAssembly compilationAssembly,
+            string targetDllPath,
+            string projectRoot,
+            HotReloadUnchangedSourceDecision unchangedDecision,
+            HotReloadNewSourceMembershipEvidence newSourceMembershipEvidence)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(projectRelativePath), "projectRelativePath must not be null or empty.");
+            Debug.Assert(!string.IsNullOrEmpty(assemblyName), "assemblyName must not be null or empty.");
+            Debug.Assert(compilationAssembly != null, "compilationAssembly must not be null.");
+            Debug.Assert(!string.IsNullOrEmpty(targetDllPath), "targetDllPath must not be null or empty.");
+            Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be null or empty.");
+
+            return new HotReloadPatchTargetResolution(
+                null,
+                projectRelativePath,
+                assemblyName,
+                compilationAssembly,
+                targetDllPath,
+                projectRoot,
+                unchangedDecision,
+                newSourceMembershipEvidence);
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadPatchTargetResolution.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadPatchTargetResolution.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b50e7a63eef5947ad809c7e0843e1ac6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadPatchTargetSupport.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadPatchTargetSupport.cs
@@ -23,15 +23,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         // is one resolve stage and kept the method over CA1502. Unchanged-source
         // short-circuit is decided here but applied by the orchestrator so a changed
         // sibling in the same assembly can still pull the file into the group.
-        internal static (
-            HotReloadFileProcessResult EarlyResult,
-            string ProjectRelativePath,
-            string AssemblyName,
-            UnityCompilationAssembly CompilationAssembly,
-            string TargetDllPath,
-            string ProjectRoot,
-            HotReloadUnchangedSourceDecision UnchangedDecision,
-            HotReloadNewSourceMembershipEvidence NewSourceMembershipEvidence) ResolvePatchTarget(
+        internal static HotReloadPatchTargetResolution ResolvePatchTarget(
             string assemblyResolvePath,
             string workerSourcePath,
             List<HotReloadMethodOutcome> outcomes,
@@ -53,15 +45,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                         "Script path is not part of any compiled assembly (Assets/Packages paths only): "
                         + assemblyResolvePath,
                         assemblyResolvePath));
-                return (
-                    new HotReloadFileProcessResult(outcomes, warnings, 0),
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    HotReloadUnchangedSourceDecision.NotUnchanged,
-                    null);
+                return HotReloadPatchTargetResolution.EarlyExit(
+                    new HotReloadFileProcessResult(outcomes, warnings, 0));
             }
 
             string assemblyName = Path.GetFileNameWithoutExtension(rawAssemblyName);
@@ -85,15 +70,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                         "(file)",
                         resolutionFailureReason,
                         assemblyResolvePath));
-                return (
-                    new HotReloadFileProcessResult(outcomes, warnings, 0),
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    HotReloadUnchangedSourceDecision.NotUnchanged,
-                    null);
+                return HotReloadPatchTargetResolution.EarlyExit(
+                    new HotReloadFileProcessResult(outcomes, warnings, 0));
             }
 
             bool isNewSource = !HotReloadAssemblyResolutionDiagnostics.ContainsProjectRelativeSourceFile(
@@ -106,15 +84,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 if (notReadyReason != null)
                 {
                     outcomes.Add(HotReloadMethodOutcome.Failed("(file)", notReadyReason, assemblyResolvePath));
-                    return (
-                        new HotReloadFileProcessResult(outcomes, warnings, 0),
-                        null,
-                        null,
-                        null,
-                        null,
-                        null,
-                        HotReloadUnchangedSourceDecision.NotUnchanged,
-                        null);
+                    return HotReloadPatchTargetResolution.EarlyExit(
+                        new HotReloadFileProcessResult(outcomes, warnings, 0));
                 }
             }
 
@@ -131,30 +102,16 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                         "(file)",
                         "Compiled assembly not found at '" + targetDllPath + "'. Compile the project first.",
                         assemblyResolvePath));
-                return (
-                    new HotReloadFileProcessResult(outcomes, warnings, 0),
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    HotReloadUnchangedSourceDecision.NotUnchanged,
-                    null);
+                return HotReloadPatchTargetResolution.EarlyExit(
+                    new HotReloadFileProcessResult(outcomes, warnings, 0));
             }
 
             string mvidGuardError = CheckMvidGuard(assemblyName, targetDllPath);
             if (mvidGuardError != null)
             {
                 outcomes.Add(HotReloadMethodOutcome.Failed("(file)", mvidGuardError, assemblyResolvePath));
-                return (
-                    new HotReloadFileProcessResult(outcomes, warnings, 0),
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    HotReloadUnchangedSourceDecision.NotUnchanged,
-                    null);
+                return HotReloadPatchTargetResolution.EarlyExit(
+                    new HotReloadFileProcessResult(outcomes, warnings, 0));
             }
 
             HotReloadNewSourceMembershipEvidence newSourceMembershipEvidence = null;
@@ -170,15 +127,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 if (membershipFailure != null)
                 {
                     outcomes.Add(HotReloadMethodOutcome.Failed("(file)", membershipFailure, assemblyResolvePath));
-                    return (
-                        new HotReloadFileProcessResult(outcomes, warnings, 0),
-                        null,
-                        null,
-                        null,
-                        null,
-                        null,
-                        HotReloadUnchangedSourceDecision.NotUnchanged,
-                        null);
+                    return HotReloadPatchTargetResolution.EarlyExit(
+                        new HotReloadFileProcessResult(outcomes, warnings, 0));
                 }
             }
 
@@ -204,8 +154,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                         projectRelativePath));
             }
 
-            return (
-                null,
+            return HotReloadPatchTargetResolution.Resolved(
                 projectRelativePath,
                 assemblyName,
                 compilationAssembly,


### PR DESCRIPTION
## Summary
- Internal maintenance of the hot-reload patch-target resolver. No behavior change.

## User Impact
- No user-visible change. Every CLI response field, warning and log line is byte-identical to `main`.

## Changes
- `ResolvePatchTarget` returned an eight-element tuple. Its failure shape — an early result followed by five nulls, `NotUnchanged`, and one more null — was copied verbatim at six exit points, and every caller had to spell all eight elements out to read one of them.
- The new `HotReloadPatchTargetResolution` names the two ways the resolve can end: `EarlyExit(earlyResult)` for a file that never reached a patch target, and `Resolved(...)` for one that did. A failure exit is now one line, and the resolved factory asserts its five non-null fields instead of trusting the caller.
- Callers and the four affected tests read named properties instead of destructuring eight elements.
- The sink warnings the resolver appends and the file-start log call are unmoved. Both are ordered side effects, and folding either into the return value would reorder the warnings a run reports.

## Verification
- `uloop run-tests --filter-type regex --filter-value "HotReloadNewSourceMembershipTests|HotReloadAssemblyResolutionDiagnosticsTests|HotReloadGroupProcessorTests|HotReloadPatchTargetSupportPathTests"` — 52/52 passed.
- `scripts/check-code-complexity.sh` — 0 findings (Go: 0 issues; C#: no CA1502 above threshold 15). No branch was added or removed in `ResolvePatchTarget`; only the shape of its returns changed.
- `scripts/check-file-length.sh` — 0 findings (no file above 500 SLOC).
- `uloop compile` — succeeded with no errors; the `.meta` for the new source is included.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2716?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

