### PR TITLE
chore: Replace the hot-reload entry preflight Either tuple with a named outcome

### DIFF
--- a/Assets/Tests/Editor/HotReload/HotReloadEntryResolutionTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadEntryResolutionTests.cs
@@ -1,0 +1,151 @@
+using System.Collections.Generic;
+using System.Reflection;
+
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
+{
+    /// <summary>
+    /// EditMode coverage for <see cref="HotReloadEntryResolution.ResolveEntries"/> preflight:
+    /// which entries resolve, and what a file reports when one of them does not. The test
+    /// assembly stands in for the compiled shim assembly, so no worker is started.
+    /// </summary>
+    public class HotReloadEntryResolutionTests
+    {
+        private const string TestAssemblyName = "UnityCLILoop.Tests.Editor.HotReload";
+        private const string ShimTypeName = "HotReloadHandwrittenShims";
+        private const string FixtureTypeMetadataName =
+            "io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload.HotReloadCoreFixture";
+        private const string FilePath = "Assets/Tests/Editor/HotReload/HotReloadCoreFixtures.cs";
+
+        private static Assembly ShimAssembly => typeof(HotReloadHandwrittenShims).Assembly;
+
+        /// <summary>
+        /// What: every entry of a file resolving leaves the result all-resolved, with one resolved
+        /// entry per input row and no failure outcomes.
+        /// </summary>
+        [Test]
+        public void ResolveEntries_WhenEveryEntryResolves_ReportsAllResolved()
+        {
+            TransformWorkerEntryDto[] entries =
+            {
+                BuildExistingMethodEntry(
+                    nameof(HotReloadCoreFixture.StaticPing),
+                    new string[0],
+                    "StaticPing__shim0"),
+                BuildExistingMethodEntry(
+                    nameof(HotReloadCoreFixture.ReplaceableCompute),
+                    new[] { "System.Int32" },
+                    "ReplaceableCompute__shim0")
+            };
+
+            HotReloadEntryResolution.Result result = HotReloadEntryResolution.ResolveEntries(
+                TestAssemblyName,
+                FilePath,
+                ShimAssembly,
+                entries,
+                new Dictionary<string, string>());
+
+            Assert.That(result.AllResolved, Is.True);
+            Assert.That(result.ResolvedEntries, Has.Count.EqualTo(2));
+            Assert.That(result.FailureOutcomes, Is.Empty);
+        }
+
+        /// <summary>
+        /// What: an entry naming a shim method the shim assembly does not declare fails the whole
+        /// file — the result is not all-resolved, the failing row is reported Failed, and every
+        /// other row of the file is reported Skipped with the atomic-file reason.
+        /// </summary>
+        [Test]
+        public void ResolveEntries_WhenShimMethodIsMissing_FailsTheFileAtomically()
+        {
+            TransformWorkerEntryDto[] entries =
+            {
+                BuildExistingMethodEntry(
+                    nameof(HotReloadCoreFixture.StaticPing),
+                    new string[0],
+                    "StaticPing__shim0"),
+                BuildExistingMethodEntry(
+                    nameof(HotReloadCoreFixture.ReplaceableCompute),
+                    new[] { "System.Int32" },
+                    "ReplaceableCompute__shimAbsent")
+            };
+
+            HotReloadEntryResolution.Result result = HotReloadEntryResolution.ResolveEntries(
+                TestAssemblyName,
+                FilePath,
+                ShimAssembly,
+                entries,
+                new Dictionary<string, string>());
+
+            Assert.That(result.AllResolved, Is.False);
+            Assert.That(result.ResolvedEntries, Is.Empty);
+            Assert.That(result.FailureOutcomes, Has.Count.EqualTo(2));
+            Assert.That(
+                result.FailureOutcomes[0].Kind,
+                Is.EqualTo(HotReloadMethodOutcomeKind.Skipped));
+            Assert.That(
+                result.FailureOutcomes[0].Reason,
+                Is.EqualTo(HotReloadConstants.AtomicFileSkipReason));
+            Assert.That(
+                result.FailureOutcomes[1].Kind,
+                Is.EqualTo(HotReloadMethodOutcomeKind.Failed));
+            Assert.That(
+                result.FailureOutcomes[1].Reason,
+                Does.Contain("ReplaceableCompute__shimAbsent"));
+        }
+
+        /// <summary>
+        /// What: an added-method entry resolves through the shim lookup alone — it needs no
+        /// compiled original method, and the resolved entry is marked as an added method.
+        /// </summary>
+        [Test]
+        public void ResolveEntries_WhenEntryIsAnAddedMethod_ResolvesWithoutAnOriginalMethod()
+        {
+            TransformWorkerEntryDto[] entries =
+            {
+                new TransformWorkerEntryDto
+                {
+                    sourceProjectRelativePath = FilePath,
+                    typeMetadataName = FixtureTypeMetadataName,
+                    methodName = "AddedByThisReload",
+                    parameterTypeFullNames = new string[0],
+                    shimTypeName = ShimTypeName,
+                    shimMethodName = "StaticPing__shim0",
+                    patchKind = HotReloadConstants.PatchKindAddedMethod
+                }
+            };
+
+            HotReloadEntryResolution.Result result = HotReloadEntryResolution.ResolveEntries(
+                TestAssemblyName,
+                FilePath,
+                ShimAssembly,
+                entries,
+                new Dictionary<string, string>());
+
+            Assert.That(result.AllResolved, Is.True);
+            Assert.That(result.ResolvedEntries, Has.Count.EqualTo(1));
+            Assert.That(result.ResolvedEntries[0].IsAddedMethod, Is.True);
+            Assert.That(result.ResolvedEntries[0].OriginalMethod, Is.Null);
+            Assert.That(result.ResolvedEntries[0].ShimMethod, Is.Not.Null);
+        }
+
+        private static TransformWorkerEntryDto BuildExistingMethodEntry(
+            string methodName,
+            string[] parameterTypeFullNames,
+            string shimMethodName)
+        {
+            return new TransformWorkerEntryDto
+            {
+                sourceProjectRelativePath = FilePath,
+                typeMetadataName = FixtureTypeMetadataName,
+                methodName = methodName,
+                parameterTypeFullNames = parameterTypeFullNames,
+                shimTypeName = ShimTypeName,
+                shimMethodName = shimMethodName
+            };
+        }
+    }
+}

--- a/Assets/Tests/Editor/HotReload/HotReloadEntryResolutionTests.cs.meta
+++ b/Assets/Tests/Editor/HotReload/HotReloadEntryResolutionTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 24389120bbab54f7782e7f996c203ddc
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadEntryResolution.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadEntryResolution.cs
@@ -32,19 +32,19 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             List<ResolvedEntry> resolvedEntries = new List<ResolvedEntry>();
             for (int index = 0; index < entriesToPatch.Length; index++)
             {
-                (ResolvedEntry resolved, HotReloadMethodOutcome failure) = TryResolveEntry(
+                ResolvedEntryOutcome entryOutcome = TryResolveEntry(
                     entriesToPatch[index],
                     assemblyName,
                     shimAssembly,
                     bindFailures,
                     filePath);
-                if (failure != null)
+                if (entryOutcome.IsFailure)
                 {
                     return Result.Failed(
-                        BuildAtomicFailureOutcomes(entriesToPatch, index, failure, filePath));
+                        BuildAtomicFailureOutcomes(entriesToPatch, index, entryOutcome.Failure, filePath));
                 }
 
-                resolvedEntries.Add(resolved);
+                resolvedEntries.Add(entryOutcome.Resolved);
             }
 
             return Result.Succeeded(resolvedEntries);
@@ -102,7 +102,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 filePath);
         }
 
-        private static (ResolvedEntry Resolved, HotReloadMethodOutcome Failure) TryResolveEntry(
+        private static ResolvedEntryOutcome TryResolveEntry(
             TransformWorkerEntryDto entry,
             string assemblyName,
             Assembly shimAssembly,
@@ -124,7 +124,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 filePath);
         }
 
-        private static (ResolvedEntry Resolved, HotReloadMethodOutcome Failure) TryResolveAddedMethod(
+        private static ResolvedEntryOutcome TryResolveAddedMethod(
             TransformWorkerEntryDto entry,
             string methodLabel,
             Assembly shimAssembly,
@@ -133,16 +133,18 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         {
             if (bindFailures.TryGetValue(entry.shimTypeName ?? string.Empty, out string bindFailureReason))
             {
-                return (null, HotReloadMethodOutcome.Failed(methodLabel, bindFailureReason, filePath));
+                return ResolvedEntryOutcome.Failed(
+                    HotReloadMethodOutcome.Failed(methodLabel, bindFailureReason, filePath));
             }
 
             (MethodInfo shimMethod, string shimError) = FindShimMethod(shimAssembly, entry);
             if (shimMethod == null)
             {
-                return (null, HotReloadMethodOutcome.Failed(methodLabel, shimError, filePath));
+                return ResolvedEntryOutcome.Failed(
+                    HotReloadMethodOutcome.Failed(methodLabel, shimError, filePath));
             }
 
-            return (
+            return ResolvedEntryOutcome.Succeeded(
                 new ResolvedEntry(
                     entry,
                     methodLabel,
@@ -150,11 +152,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     HotReloadPatchShape.Transplant,
                     originalMethod: null,
                     shimMethod,
-                    isAddedMethod: true),
-                null);
+                    isAddedMethod: true));
         }
 
-        private static (ResolvedEntry Resolved, HotReloadMethodOutcome Failure) TryResolveExistingMethod(
+        private static ResolvedEntryOutcome TryResolveExistingMethod(
             TransformWorkerEntryDto entry,
             string methodLabel,
             string assemblyName,
@@ -168,7 +169,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             if (patchShape == HotReloadPatchShape.Delegation
                 && bindFailures.TryGetValue(entry.shimTypeName ?? string.Empty, out string bindFailureReason))
             {
-                return (null, HotReloadMethodOutcome.Failed(methodLabel, bindFailureReason, filePath));
+                return ResolvedEntryOutcome.Failed(
+                    HotReloadMethodOutcome.Failed(methodLabel, bindFailureReason, filePath));
             }
 
             string[] parameterTypeFullNames = entry.parameterTypeFullNames ?? Array.Empty<string>();
@@ -180,23 +182,26 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 entry.genericArity);
             if (!matchResult.Success)
             {
-                return (null, HotReloadMethodOutcome.Failed(methodLabel, matchResult.ErrorMessage, filePath));
+                return ResolvedEntryOutcome.Failed(
+                    HotReloadMethodOutcome.Failed(methodLabel, matchResult.ErrorMessage, filePath));
             }
 
             methodLabel = HotReloadMethodKeys.FormatMethodLabel(matchResult.Method);
             (MethodInfo shimMethod, string shimError) = FindShimMethod(shimAssembly, entry);
             if (shimMethod == null)
             {
-                return (null, HotReloadMethodOutcome.Failed(methodLabel, shimError, filePath));
+                return ResolvedEntryOutcome.Failed(
+                    HotReloadMethodOutcome.Failed(methodLabel, shimError, filePath));
             }
 
             HotReloadPatchResult patchability = HotReloadPatcher.CheckPatchable(matchResult.Method);
             if (!patchability.Success)
             {
-                return (null, HotReloadMethodOutcome.Failed(methodLabel, patchability.ErrorMessage, filePath));
+                return ResolvedEntryOutcome.Failed(
+                    HotReloadMethodOutcome.Failed(methodLabel, patchability.ErrorMessage, filePath));
             }
 
-            return (
+            return ResolvedEntryOutcome.Succeeded(
                 new ResolvedEntry(
                     entry,
                     methodLabel,
@@ -204,8 +209,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     patchShape,
                     matchResult.Method,
                     shimMethod,
-                    isAddedMethod: false),
-                null);
+                    isAddedMethod: false));
         }
 
         private static (MethodInfo ShimMethod, string ErrorMessage) FindShimMethod(
@@ -298,6 +302,37 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 OriginalMethod = originalMethod;
                 ShimMethod = shimMethod;
                 IsAddedMethod = isAddedMethod;
+            }
+        }
+
+        /// <summary>
+        /// One entry's preflight result: the resolved entry, or the outcome that failed it.
+        /// </summary>
+        private sealed class ResolvedEntryOutcome
+        {
+            public ResolvedEntry Resolved { get; }
+            public HotReloadMethodOutcome Failure { get; }
+
+            public bool IsFailure => Failure != null;
+
+            private ResolvedEntryOutcome(ResolvedEntry resolved, HotReloadMethodOutcome failure)
+            {
+                Resolved = resolved;
+                Failure = failure;
+            }
+
+            public static ResolvedEntryOutcome Succeeded(ResolvedEntry resolved)
+            {
+                Debug.Assert(resolved != null, "resolved must not be null.");
+
+                return new ResolvedEntryOutcome(resolved, null);
+            }
+
+            public static ResolvedEntryOutcome Failed(HotReloadMethodOutcome failure)
+            {
+                Debug.Assert(failure != null, "failure must not be null.");
+
+                return new ResolvedEntryOutcome(null, failure);
             }
         }
 


### PR DESCRIPTION
## Summary
- Internal maintenance of the hot-reload entry preflight, plus the unit coverage it was missing. No behavior change.

## User Impact
- No user-visible change. Every CLI response field, warning and log line is byte-identical to `main`.

## Changes
- The three private resolve steps each returned `(ResolvedEntry, HotReloadMethodOutcome)` and encoded "this one failed" as a `null` in the first slot. Eight branch returns had to spell out which half to leave null, and the caller tested the second slot to learn which half was meant.
- `ResolvedEntryOutcome` names the two cases with the same `Succeeded` / `Failed` idiom the file already uses for `HotReloadEntryResolution.Result`, and asserts that the chosen half is non-null.
- `FindShimMethod` keeps its `(MethodInfo, string)` tuple. It is a lookup rather than a resolve step, and reports an error message rather than a method outcome.
- The reflection-form method label reassignment in the existing-method path is unchanged.

## Tests
`HotReloadEntryResolutionTests` is new — `ResolveEntries` had no direct unit coverage, so the replacement had nothing holding it. It covers three cases: every entry resolving, an entry whose shim method is absent failing the file atomically, and the added-method path resolving with no original method. The test assembly stands in for the compiled shim assembly, so no worker is started.

Red was confirmed before green: with `ResolvedEntryOutcome.IsFailure` forced to `false`, `ResolveEntries_WhenShimMethodIsMissing_FailsTheFileAtomically` fails (2/3 passed) while the other two still pass. Restoring `IsFailure` returns the class to 3/3.

## Verification
- `uloop run-tests --filter-type regex --filter-value "HotReloadEntryResolutionTests|HotReloadPatcherTests|HotReloadShimCompilerTests"` — 27/27 passed.
- `scripts/check-code-complexity.sh` — 0 findings (Go: 0 issues; C#: no CA1502 above threshold 15).
- `scripts/check-file-length.sh` — 0 findings (no file above 500 SLOC).
- `uloop compile` — succeeded with no errors; the `.meta` for the new test source is included.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2717?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

