### PR TITLE
chore: Hold the hot-reload signature-change gate's four end states in one enum

### DIFF
--- a/Assets/Tests/Editor/HotReload/HotReloadGroupProcessorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadGroupProcessorTests.cs
@@ -776,5 +776,73 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 replacesCompiledMethod = true
             };
         }
+
+        /// <summary>
+        /// A failed gate reports the file as failed and carries no worker retry. Its scan did run,
+        /// because the failure is only reachable after the compiled call sites were scanned.
+        /// </summary>
+        [Test]
+        public void SignatureChangeGateResult_Failed_ReportsTheFileFailedAfterScanning()
+        {
+            HotReloadSignatureChangeGate.SignatureChangeGateResult result =
+                HotReloadSignatureChangeGate.SignatureChangeGateResult.Failed(
+                    "gate failure",
+                    new List<string> { TargetKey });
+
+            Assert.That(result.FileFailed, Is.True);
+            Assert.That(result.UsedWorkerRetry, Is.False);
+            Assert.That(result.DidScan, Is.True);
+            Assert.That(result.FailureMessage, Is.EqualTo("gate failure"));
+            Assert.That(result.GatedReplacementMethodKeys, Is.EqualTo(new[] { TargetKey }));
+        }
+
+        /// <summary>
+        /// A failed gate never reaches the stage that reads DidScan: the group pipeline turns it
+        /// into a Failed gate-and-compile result, which carries no gate for that stage to read.
+        /// </summary>
+        [Test]
+        public void GroupGateAndCompileResult_Failed_CarriesNoGateForTheCoverageStageToRead()
+        {
+            HotReloadGroupGateAndCompileResult result = HotReloadGroupGateAndCompileResult.Failed();
+
+            Assert.That(result.Outcome, Is.EqualTo(HotReloadGroupGateAndCompileOutcome.Failed));
+            Assert.That(result.Gate, Is.Null);
+            Assert.That(result.Compile, Is.Null);
+        }
+
+        /// <summary>
+        /// A retried gate reports the worker retry it consumed and does not fail the file.
+        /// </summary>
+        [Test]
+        public void SignatureChangeGateResult_Retried_ReportsTheWorkerRetryWithoutFailingTheFile()
+        {
+            HotReloadSignatureChangeGate.SignatureChangeGateResult result =
+                HotReloadSignatureChangeGate.SignatureChangeGateResult.Retried(
+                    null,
+                    new List<HotReloadMethodOutcome>(),
+                    new List<string>(),
+                    new List<HotReloadCallSiteScanner.CallSiteHit>(),
+                    new HashSet<HotReloadQualifiedMethodIdentity>(),
+                    new List<string>());
+
+            Assert.That(result.UsedWorkerRetry, Is.True);
+            Assert.That(result.FileFailed, Is.False);
+            Assert.That(result.DidScan, Is.True);
+        }
+
+        /// <summary>
+        /// A gate with nothing to scan reports no scan, so the coverage stage that depends on one
+        /// is skipped.
+        /// </summary>
+        [Test]
+        public void SignatureChangeGateResult_NoWork_ReportsThatNoScanRan()
+        {
+            HotReloadSignatureChangeGate.SignatureChangeGateResult result =
+                HotReloadSignatureChangeGate.SignatureChangeGateResult.NoWork();
+
+            Assert.That(result.DidScan, Is.False);
+            Assert.That(result.FileFailed, Is.False);
+            Assert.That(result.UsedWorkerRetry, Is.False);
+        }
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadSignatureChangeGate.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadSignatureChangeGate.cs
@@ -316,11 +316,22 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return outcomes;
         }
 
+        /// <summary>
+        /// The four ways the signature-change gate can end. Held as one value rather than as
+        /// separate flags, because no two of them can be true at once.
+        /// </summary>
+        internal enum SignatureChangeGateOutcome
+        {
+            NoWork,
+            WarningsOnly,
+            Failed,
+            Retried
+        }
+
         internal sealed class SignatureChangeGateResult
         {
-            public bool FileFailed { get; }
+            public SignatureChangeGateOutcome Outcome { get; }
             public string FailureMessage { get; }
-            public bool UsedWorkerRetry { get; }
             public bool DidScan { get; }
             public HotReloadShimIsolation.HotReloadShimIsolationResult Isolation { get; }
             public List<HotReloadMethodOutcome> SkippedOutcomes { get; }
@@ -329,10 +340,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             public HashSet<HotReloadQualifiedMethodIdentity> DeletedCallerExemptions { get; }
             public List<string> GatedReplacementMethodKeys { get; }
 
+            public bool FileFailed => Outcome == SignatureChangeGateOutcome.Failed;
+            public bool UsedWorkerRetry => Outcome == SignatureChangeGateOutcome.Retried;
+
             private SignatureChangeGateResult(
-                bool fileFailed,
+                SignatureChangeGateOutcome outcome,
                 string failureMessage,
-                bool usedWorkerRetry,
                 bool didScan,
                 HotReloadShimIsolation.HotReloadShimIsolationResult isolation,
                 List<HotReloadMethodOutcome> skippedOutcomes,
@@ -341,9 +354,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 HashSet<HotReloadQualifiedMethodIdentity> deletedCallerExemptions,
                 List<string> gatedReplacementMethodKeys)
             {
-                FileFailed = fileFailed;
+                Outcome = outcome;
                 FailureMessage = failureMessage;
-                UsedWorkerRetry = usedWorkerRetry;
                 DidScan = didScan;
                 Isolation = isolation;
                 SkippedOutcomes = skippedOutcomes ?? new List<HotReloadMethodOutcome>();
@@ -357,7 +369,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             public static SignatureChangeGateResult NoWork()
             {
                 return new SignatureChangeGateResult(
-                    false, null, false, false, null, null, null, null, null, null);
+                    SignatureChangeGateOutcome.NoWork,
+                    null, false, null, null, null, null, null, null);
             }
 
             public static SignatureChangeGateResult WarningsOnly(
@@ -366,18 +379,21 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 HashSet<HotReloadQualifiedMethodIdentity> deletedCallerExemptions)
             {
                 return new SignatureChangeGateResult(
-                    false, null, false, true, null, null, warnings, hits, deletedCallerExemptions, null);
+                    SignatureChangeGateOutcome.WarningsOnly,
+                    null, true, null, null, warnings, hits, deletedCallerExemptions, null);
             }
 
+            // Why didScan is true: this result is only built after FindCallSites has already run,
+            // so the scan did happen. It used to be reported false, which no consumer could
+            // observe because every reader of DidScan sits behind an early return on FileFailed.
             public static SignatureChangeGateResult Failed(
                 string failureMessage,
                 List<string> gatedReplacementMethodKeys)
             {
                 return new SignatureChangeGateResult(
-                    true,
+                    SignatureChangeGateOutcome.Failed,
                     failureMessage,
-                    false,
-                    false,
+                    true,
                     null,
                     null,
                     null,
@@ -395,9 +411,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 List<string> gatedReplacementMethodKeys)
             {
                 return new SignatureChangeGateResult(
-                    false,
+                    SignatureChangeGateOutcome.Retried,
                     null,
-                    true,
                     true,
                     isolation,
                     skippedOutcomes,


### PR DESCRIPTION
## Summary
- Internal maintenance of the hot-reload signature-change gate result, plus the unit coverage that pins its states. No behavior change.

## User Impact
- No user-visible change. Every CLI response field, warning and log line is byte-identical to `main`.

## Changes
- The gate ends one of four ways — no work, warnings only, failed, retried — and its result carried three booleans that could spell combinations none of those four states can produce.
- `SignatureChangeGateOutcome` names the four. `FileFailed` and `UsedWorkerRetry` become get-only properties derived from it, and the private constructor no longer takes them, so every existing consumer keeps reading the same property names against a state that can no longer contradict itself.
- Every existing property name, factory name, and consumer is unchanged, and the result type stays nested where it is.
- `Failed` now reports `didScan: true`. It is only built after `FindCallSites` has already run, so `false` was untrue. No consumer could observe the wrong value, because every reader of `DidScan` sits behind an early return on `FileFailed` — this PR pins that guard rather than relying on it silently.

## Tests
Four tests added to `HotReloadGroupProcessorTests`: what each of the failed, retried and no-work states reports, and that a failed gate becomes a `HotReloadGroupGateAndCompileResult.Failed()` carrying no gate at all — so the coverage stage that reads `DidScan` structurally cannot reach it.

Red was confirmed before green: with `Failed` restored to `didScan: false`, `SignatureChangeGateResult_Failed_ReportsTheFileFailedAfterScanning` fails on `Expected: True / But was: False`. Restoring the fix returns it to green.

## Verification
- `uloop run-tests --filter-type regex --filter-value "HotReloadAssemblyResolutionDiagnosticsTests|HotReloadGroupProcessorTests|HotReloadOrchestratorTests"` — 182/182 passed.
- `scripts/check-code-complexity.sh` — 0 findings (Go: 0 issues; C#: no CA1502 above threshold 15).
- `scripts/check-file-length.sh` — 0 findings (no file above 500 SLOC).
- `uloop compile` — succeeded with no errors. No new source file, so no new `.meta`.

Note on running the tests: `HotReloadGroupProcessorTests` does not call `HotReloadPackageRootProvider.CaptureCurrent` in its own setup, so running it alone fails one unrelated test with "Hot-reload package roots were never captured" on `main` as well. The regex above includes `HotReloadAssemblyResolutionDiagnosticsTests`, which captures the roots in setup.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2718?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

