### PR TITLE
chore: Give the hot-reload run summary counts a named tally type

### DIFF
--- a/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
@@ -6450,9 +6450,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             JObject workerResult = FindVibeLog(logs, HotReloadConstants.VibeLogWorkerResult);
             JObject applySummary = FindVibeLog(logs, HotReloadConstants.VibeLogApplySummary);
             AssertSameHotReloadCorrelation(fileStart, workerResult, applySummary);
-            Assert.That(
-                (int)applySummary["context"]["addedCount"],
-                Is.EqualTo(CountOutcomeKind(result, HotReloadMethodOutcomeKind.Added)));
+            AssertApplySummaryMatchesOutcomes(applySummary, result);
         }
 
         /// <summary>
@@ -6558,6 +6556,34 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                     (string)others[index]["correlation_id"],
                     Is.EqualTo(correlationId));
             }
+        }
+
+        private static void AssertApplySummaryMatchesOutcomes(
+            JObject applySummary,
+            HotReloadOrchestratorResult result)
+        {
+            JToken context = applySummary["context"];
+            Assert.That(
+                (int)context["patchedCount"],
+                Is.EqualTo(CountOutcomeKind(result, HotReloadMethodOutcomeKind.Patched)));
+            Assert.That(
+                (int)context["failedCount"],
+                Is.EqualTo(CountOutcomeKind(result, HotReloadMethodOutcomeKind.Failed)));
+            Assert.That(
+                (int)context["skippedCount"],
+                Is.EqualTo(CountOutcomeKind(result, HotReloadMethodOutcomeKind.Skipped)));
+            Assert.That(
+                (int)context["alreadyActiveCount"],
+                Is.EqualTo(CountOutcomeKind(result, HotReloadMethodOutcomeKind.AlreadyActive)));
+            Assert.That(
+                (int)context["addedCount"],
+                Is.EqualTo(CountOutcomeKind(result, HotReloadMethodOutcomeKind.Added)));
+            Assert.That(
+                (int)context["staleCount"],
+                Is.EqualTo(CountOutcomeKind(result, HotReloadMethodOutcomeKind.Stale)));
+            Assert.That(
+                (bool)context["success"],
+                Is.EqualTo(CountOutcomeKind(result, HotReloadMethodOutcomeKind.Failed) == 0));
         }
 
         private static int CountOutcomeKind(

--- a/Assets/Tests/Editor/HotReload/HotReloadOutcomeAggregationTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadOutcomeAggregationTests.cs
@@ -12,31 +12,55 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
     public sealed class HotReloadOutcomeAggregationTests
     {
         /// <summary>
-        /// What: every HotReloadMethodOutcomeKind is counted into its own bucket, so a newly added
-        /// kind cannot be silently dropped from the run summary.
+        /// What: every HotReloadMethodOutcomeKind is counted into its own tally bucket. Each kind
+        /// appears a different number of times, so a swapped bucket cannot pass unnoticed.
         /// </summary>
         [Test]
-        public void CountMethodOutcomeKinds_WithEveryKind_CountsEachBucketOnce()
+        public void CountMethodOutcomeKinds_WithEveryKind_CountsEachKindIntoItsOwnBucket()
+        {
+            List<HotReloadMethodOutcome> outcomes = new List<HotReloadMethodOutcome>();
+            AddOutcomes(outcomes, 1, HotReloadMethodOutcome.Patched("Type.Patched()", "Assets/A.cs"));
+            AddOutcomes(outcomes, 2, HotReloadMethodOutcome.Failed("Type.Failed()", "shim compile failed", "Assets/A.cs"));
+            AddOutcomes(outcomes, 3, HotReloadMethodOutcome.Skipped("Type.Skipped()", "unsupported", "Assets/A.cs"));
+            AddOutcomes(outcomes, 4, HotReloadMethodOutcome.AlreadyActive("Type.AlreadyActive()", "Assets/A.cs"));
+            AddOutcomes(outcomes, 5, HotReloadMethodOutcome.Added("Type.Added()", "Assets/A.cs"));
+            AddOutcomes(outcomes, 6, HotReloadMethodOutcome.Stale("Type.Stale()", "Assets/A.cs"));
+
+            HotReloadOutcomeTally tally = HotReloadOutcomeAggregation.CountMethodOutcomeKinds(outcomes);
+
+            Assert.That(tally.PatchedCount, Is.EqualTo(1));
+            Assert.That(tally.FailedCount, Is.EqualTo(2));
+            Assert.That(tally.SkippedCount, Is.EqualTo(3));
+            Assert.That(tally.AlreadyActiveCount, Is.EqualTo(4));
+            Assert.That(tally.AddedCount, Is.EqualTo(5));
+            Assert.That(tally.StaleCount, Is.EqualTo(6));
+            Assert.That(tally.HasFailure, Is.True);
+        }
+
+        /// <summary>
+        /// What: a run without a failed outcome reports no failure, so the summary success flag
+        /// derived from the tally stays true.
+        /// </summary>
+        [Test]
+        public void CountMethodOutcomeKinds_WithoutFailedOutcome_ReportsNoFailure()
         {
             List<HotReloadMethodOutcome> outcomes = new List<HotReloadMethodOutcome>
             {
-                HotReloadMethodOutcome.Patched("Type.Patched()", "Assets/A.cs"),
-                HotReloadMethodOutcome.Skipped("Type.Skipped()", "unsupported", "Assets/A.cs"),
-                HotReloadMethodOutcome.Failed("Type.Failed()", "shim compile failed", "Assets/A.cs"),
-                HotReloadMethodOutcome.Added("Type.Added()", "Assets/A.cs"),
-                HotReloadMethodOutcome.AlreadyActive("Type.AlreadyActive()", "Assets/A.cs"),
-                HotReloadMethodOutcome.Stale("Type.Stale()", "Assets/A.cs")
+                HotReloadMethodOutcome.Patched("Type.Patched()", "Assets/A.cs")
             };
 
-            (int patchedCount, int failedCount, int skippedCount, int alreadyActiveCount, int addedCount, int staleCount) =
-                HotReloadOutcomeAggregation.CountMethodOutcomeKinds(outcomes);
+            HotReloadOutcomeTally tally = HotReloadOutcomeAggregation.CountMethodOutcomeKinds(outcomes);
 
-            Assert.That(patchedCount, Is.EqualTo(1));
-            Assert.That(failedCount, Is.EqualTo(1));
-            Assert.That(skippedCount, Is.EqualTo(1));
-            Assert.That(alreadyActiveCount, Is.EqualTo(1));
-            Assert.That(addedCount, Is.EqualTo(1));
-            Assert.That(staleCount, Is.EqualTo(1));
+            Assert.That(tally.FailedCount, Is.EqualTo(0));
+            Assert.That(tally.HasFailure, Is.False);
+        }
+
+        private static void AddOutcomes(List<HotReloadMethodOutcome> outcomes, int count, HotReloadMethodOutcome outcome)
+        {
+            for (int index = 0; index < count; index++)
+            {
+                outcomes.Add(outcome);
+            }
         }
     }
 }

--- a/Assets/Tests/Editor/HotReload/HotReloadToolTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadToolTests.cs
@@ -571,7 +571,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             HotReloadResponse response = HotReloadTool.BuildApplyResponse(result);
 
             Assert.That(response.Success, Is.False);
-            Assert.That(response.Message, Does.Contain("Stale=1"));
+            Assert.That(
+                response.Message,
+                Is.EqualTo("Hot reload finished with one or more Failed method outcomes. See Methods. Stale=1."));
         }
 
         /// <summary>

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOutcomeAggregation.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOutcomeAggregation.cs
@@ -61,8 +61,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
         }
 
-        internal static (int patchedCount, int failedCount, int skippedCount, int alreadyActiveCount, int addedCount, int staleCount)
-            CountMethodOutcomeKinds(IReadOnlyList<HotReloadMethodOutcome> outcomes)
+        internal static HotReloadOutcomeTally CountMethodOutcomeKinds(
+            IReadOnlyList<HotReloadMethodOutcome> outcomes)
         {
             int patchedCount = 0;
             int failedCount = 0;
@@ -99,7 +99,13 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 }
             }
 
-            return (patchedCount, failedCount, skippedCount, alreadyActiveCount, addedCount, staleCount);
+            return new HotReloadOutcomeTally(
+                patchedCount,
+                failedCount,
+                skippedCount,
+                alreadyActiveCount,
+                addedCount,
+                staleCount);
         }
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOutcomeTally.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOutcomeTally.cs
@@ -1,0 +1,33 @@
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// How many method outcomes of a run fell into each kind.
+    /// </summary>
+    internal readonly struct HotReloadOutcomeTally
+    {
+        public int PatchedCount { get; }
+        public int FailedCount { get; }
+        public int SkippedCount { get; }
+        public int AlreadyActiveCount { get; }
+        public int AddedCount { get; }
+        public int StaleCount { get; }
+
+        public bool HasFailure => FailedCount > 0;
+
+        public HotReloadOutcomeTally(
+            int patchedCount,
+            int failedCount,
+            int skippedCount,
+            int alreadyActiveCount,
+            int addedCount,
+            int staleCount)
+        {
+            PatchedCount = patchedCount;
+            FailedCount = failedCount;
+            SkippedCount = skippedCount;
+            AlreadyActiveCount = alreadyActiveCount;
+            AddedCount = addedCount;
+            StaleCount = staleCount;
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOutcomeTally.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOutcomeTally.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fcac4d31669cf4545b40132a60c18447
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadRunAccumulator.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadRunAccumulator.cs
@@ -184,16 +184,15 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
         private void LogSummary(string correlationId)
         {
-            (int patchedCount, int failedCount, int skippedCount, int alreadyActiveCount, int addedCount, int staleCount) =
-                HotReloadOutcomeAggregation.CountMethodOutcomeKinds(_outcomes);
+            HotReloadOutcomeTally tally = HotReloadOutcomeAggregation.CountMethodOutcomeKinds(_outcomes);
             HotReloadOrchestratorLog.LogHotReloadApplySummary(
-                patchedCount,
-                failedCount,
-                skippedCount,
-                alreadyActiveCount,
-                addedCount,
-                staleCount,
-                failedCount == 0,
+                tally.PatchedCount,
+                tally.FailedCount,
+                tally.SkippedCount,
+                tally.AlreadyActiveCount,
+                tally.AddedCount,
+                tally.StaleCount,
+                !tally.HasFailure,
                 correlationId);
         }
     }


### PR DESCRIPTION
## Summary
- Internal maintenance of the hot-reload run summary counting, plus tightened assertions on the summary log and message. No behavior change.

## User Impact
- No user-visible change. Every CLI response field, warning and log line is byte-identical to `main`.

## Changes
- The run-level outcome counter returned a six-element `int` tuple. Every caller had to restate the bucket order, and a swapped element would have been accepted silently.
- `HotReloadOutcomeTally` names the six buckets and derives `HasFailure`, so the summary logger reads properties instead of tuple positions. The log call keeps the same argument order, wording and correlation id.
- The response builder is untouched; it does not read the tally.

## Tests
- The aggregation test now gives each outcome kind a different count (1/2/3/4/5/6) instead of one apiece, so a swapped bucket cannot pass. A second test pins that a run with no failed outcome reports `HasFailure` false.
- The orchestrator apply-summary log check was asserting the added count and the correlation id only; it now asserts all six counts and the success flag against the run's own outcomes.
- The failure-plus-stale response test raised `Does.Contain("Stale=1")` to an `Is.EqualTo` on the whole `Message`, pinning the exact summary text.

Red was confirmed before green: with two buckets swapped in the tally constructor, `CountMethodOutcomeKinds_WithEveryKind_CountsEachKindIntoItsOwnBucket` fails on `Expected: 3 / But was: 4`. Restoring the constructor returns the class to 2/2 green.

## Verification
- `uloop run-tests --filter-type regex --filter-value "HotReloadAssemblyResolutionDiagnosticsTests|HotReloadOutcomeAggregationTests|HotReloadToolTests|HotReloadOrchestratorTests"` — 224/224 passed.
- `scripts/check-code-complexity.sh` — 0 findings (Go: 0 issues; C#: no CA1502 above threshold 15).
- `scripts/check-file-length.sh` — 0 findings (no file above 500 SLOC).
- `uloop compile` — succeeded with no errors; the new source file's `.meta` is included in the commit.

Note on running the tests: the regex includes `HotReloadAssemblyResolutionDiagnosticsTests` because the other classes do not capture the hot-reload package roots in their own setup, which fails one unrelated test on `main` as well when they run alone.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2719?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

