### PR TITLE
chore: Pin the hot-reload group file conventions the apply stage relies on

### DIFF
--- a/Assets/Tests/Editor/HotReload/HotReloadGroupProcessorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadGroupProcessorTests.cs
@@ -10,6 +10,7 @@ using UnityEditor.Compilation;
 using UnityEngine;
 
 using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+using io.github.hatayama.UnityCliLoop.ToolContracts;
 
 namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 {
@@ -25,6 +26,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         private const string PersistedAddedMemberKey = "Coverage.Host::Persisted()";
         private const string BrokenSourcePath = "Assets/Tests/Editor/HotReload/BrokenNoticeSource.cs";
         private const string HealthySourcePath = "Assets/Tests/Editor/HotReload/HealthyNoticeSource.cs";
+        private const string CoverageCallerPath = "Assets/CoverageCaller.cs";
         private const string ParseErrorText =
             "BrokenNoticeSource.cs(3,1): error CS1022: Type or namespace definition, or end-of-file expected";
 
@@ -41,6 +43,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         {
             HotReloadEditorStateSnapshotProvider.CaptureForTesting = _previousSnapshotProvider;
             HotReloadAddedMemberRegistry.Clear();
+            // The added-field ledger is global, so a committed name would outlive this class.
+            HotReloadAddedFieldRegistry.ReplaceForFile(CoverageCallerPath, Array.Empty<string>());
         }
 
         /// <summary>
@@ -431,6 +435,180 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             Assert.That(CountFileFailedRows(brokenFile), Is.EqualTo(1));
             Assert.That(healthyFile.SkipApply, Is.False);
             Assert.That(CountFileFailedRows(healthyFile), Is.EqualTo(0));
+        }
+
+        /// <summary>
+        /// What: a file already skipped for parse errors stays skipped when the isolation plan
+        /// does not name it, and a file the plan names becomes skipped. The stage accumulates,
+        /// it never clears an earlier decision.
+        /// </summary>
+        [Test]
+        public void AccumulateAtomicSkipApply_WhenPlanDoesNotNameAnAlreadySkippedFile_KeepsItSkipped()
+        {
+            string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
+            Assembly compilationAssembly = FindCompilationAssembly();
+            HotReloadGroupFile parseErrorFile = CreateFile(BrokenSourcePath, projectRoot, compilationAssembly);
+            HotReloadGroupFile isolationFailedFile = CreateFile(HealthySourcePath, projectRoot, compilationAssembly);
+            parseErrorFile.SkipApply = true;
+            TransformWorkerEntryDto brokenEntry = CreateAtomicEntry(HealthySourcePath);
+            HotReloadFileAtomicIsolationPlan plan = HotReloadFileAtomicIsolationPlan.Build(
+                new[] { CreateAtomicEntry(BrokenSourcePath), brokenEntry },
+                CreateAtomicAttribution(brokenEntry),
+                Array.Empty<TransformWorkerSkippedDto>(),
+                CreateAtomicGroupFilePaths(BrokenSourcePath, HealthySourcePath),
+                new[] { BrokenSourcePath, HealthySourcePath });
+
+            HotReloadShimFirstCompile.AccumulateAtomicSkipApply(
+                new[] { parseErrorFile, isolationFailedFile },
+                plan);
+
+            Assert.That(plan.IsFailedFile(BrokenSourcePath), Is.False);
+            Assert.That(parseErrorFile.SkipApply, Is.True);
+            Assert.That(isolationFailedFile.SkipApply, Is.True);
+        }
+
+        /// <summary>
+        /// What: the isolation retry's per-file rows replace the first pass's added field and
+        /// const names, so the apply commits what the retry re-classified.
+        /// </summary>
+        [Test]
+        public void AdoptRetryAddedMemberNames_WhenRetryReturnsOtherNames_ReplacesTheFirstPassNames()
+        {
+            string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
+            Assembly compilationAssembly = FindCompilationAssembly();
+            HotReloadGroupFile file = CreateFile(BrokenSourcePath, projectRoot, compilationAssembly);
+            file.AddedFieldNames = new[] { "Sample.Host.firstPassField" };
+            file.AddedConstNames = new[] { "Sample.Host.FirstPassConst" };
+            TransformWorkerFileOutputDto retryFile = new TransformWorkerFileOutputDto
+            {
+                projectRelativePath = BrokenSourcePath,
+                addedFieldNames = new[] { "Sample.Host.retryField" },
+                addedConstNames = new[] { "Sample.Host.RetryConst" }
+            };
+
+            HotReloadShimFirstCompile.AdoptRetryAddedMemberNames(new[] { file }, new[] { retryFile });
+
+            Assert.That(file.AddedFieldNames, Is.EqualTo(new[] { "Sample.Host.retryField" }));
+            Assert.That(file.AddedConstNames, Is.EqualTo(new[] { "Sample.Host.RetryConst" }));
+        }
+
+        /// <summary>
+        /// What: a file the run left with no entry commits the worker row's added field names
+        /// when no retry replaced them.
+        /// </summary>
+        [Test]
+        public async Task ResolveEntriesToPatchAsync_WhenNoRetryReplacedTheNames_ClearsWithTheWorkerRowNames()
+        {
+            HotReloadNewSourceMembershipEvidence evidence = CaptureCurrentMembershipEvidence();
+            HotReloadApplyContext context = CreateEmptyEntriesContext(evidence);
+            HotReloadGroupFile file = context.Files[0];
+            file.FileOutput.addedFieldNames = new[] { "Sample.Host.workerField" };
+            file.AddedFieldNames = null;
+
+            HotReloadGroupCompileResult result = await HotReloadShimFirstCompile.ResolveEntriesToPatchAsync(
+                context,
+                CreateEmptyGateResult(),
+                CancellationToken.None);
+
+            Assert.That(result.Outcome, Is.EqualTo(HotReloadGroupCompileOutcome.ReadyWithoutMethods));
+            Assert.That(file.ClearedAddedFieldNames, Is.EqualTo(new[] { "Sample.Host.workerField" }));
+        }
+
+        /// <summary>
+        /// What: a retry's added field names win over the worker row when the run leaves the file
+        /// with no entry, so a field the retry no longer emits is not resurrected.
+        /// </summary>
+        [Test]
+        public async Task ResolveEntriesToPatchAsync_WhenARetryReplacedTheNames_ClearsWithTheRetryNames()
+        {
+            HotReloadNewSourceMembershipEvidence evidence = CaptureCurrentMembershipEvidence();
+            HotReloadApplyContext context = CreateEmptyEntriesContext(evidence);
+            HotReloadGroupFile file = context.Files[0];
+            file.FileOutput.addedFieldNames = new[] { "Sample.Host.workerField" };
+            file.AddedFieldNames = new[] { "Sample.Host.retryField" };
+
+            HotReloadGroupCompileResult result = await HotReloadShimFirstCompile.ResolveEntriesToPatchAsync(
+                context,
+                CreateEmptyGateResult(),
+                CancellationToken.None);
+
+            Assert.That(result.Outcome, Is.EqualTo(HotReloadGroupCompileOutcome.ReadyWithoutMethods));
+            Assert.That(file.ClearedAddedFieldNames, Is.EqualTo(new[] { "Sample.Host.retryField" }));
+        }
+
+        /// <summary>
+        /// What: a group whose transform worker fails returns unapplied results built from files
+        /// that never received a worker output row, so the result's SourceContentSha256 is null.
+        /// This is the worker-failure path (HotReloadGroupProcessor returns before the stage that
+        /// assigns FileOutput), which is why the unapplied result still has to guard that read.
+        /// </summary>
+        [Test]
+        public async Task ProcessGroupAsync_WhenTheWorkerFails_BuildsUnappliedResultsWithoutAWorkerRow()
+        {
+            string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
+            Assembly compilationAssembly = FindCompilationAssembly();
+            HotReloadGroupFile file = CreateFile(BrokenSourcePath, projectRoot, compilationAssembly);
+            // The stage that assigns it is the one this run never reaches.
+            file.FileOutput = null;
+
+            IReadOnlyList<HotReloadFileProcessResult> results;
+            using (HotReloadGroupProcessorDependencies.BeginReplacement(
+                HotReloadGroupProcessorDependencies.Create(
+                    files => true,
+                    (files, input, ct) => Task.FromResult(
+                        HotReloadIntroducedTypePreparationResult.NoIntroducedTypes()),
+                    (input, ct) => Task.FromResult(
+                        TransformWorkerClientResult.Failure("transform worker failed")),
+                    HotReloadGroupProcessor.GateAndCompileAsync,
+                    HotReloadGroupEntryPreparation.PrepareGroup,
+                    HotReloadEntryApplier.ApplyPreparedEntries)))
+            {
+                results = await HotReloadGroupProcessor.ProcessGroupAsync(
+                    new[] { file },
+                    "worker-failure-test",
+                    CancellationToken.None);
+            }
+
+            Assert.That(results, Has.Count.EqualTo(1));
+            Assert.That(results[0].SourceContentSha256, Is.Null);
+            Assert.That(results[0].PatchedCount, Is.EqualTo(0));
+            Assert.That(CountFileFailedRows(file), Is.EqualTo(1));
+        }
+
+        private static TransformWorkerEntryDto CreateAtomicEntry(string projectRelativePath)
+        {
+            return new TransformWorkerEntryDto
+            {
+                sourceProjectRelativePath = projectRelativePath,
+                typeMetadataName = "Sample.Host",
+                methodName = "Body",
+                parameterTypeFullNames = Array.Empty<string>(),
+                genericArity = 0,
+                patchKind = HotReloadConstants.PatchKindDelegation
+            };
+        }
+
+        private static HotReloadShimErrorAttribution.ShimCompileErrorAttribution CreateAtomicAttribution(
+            TransformWorkerEntryDto failedEntry)
+        {
+            Dictionary<TransformWorkerEntryDto, List<string>> errorMessagesByEntry =
+                new Dictionary<TransformWorkerEntryDto, List<string>>
+                {
+                    { failedEntry, new List<string> { "CS0103: name not found (line 12)" } }
+                };
+            return new HotReloadShimErrorAttribution.ShimCompileErrorAttribution(errorMessagesByEntry);
+        }
+
+        private static HotReloadGroupFilePaths CreateAtomicGroupFilePaths(params string[] projectRelativePaths)
+        {
+            List<(string ProjectRelativePath, string AssemblyResolvePath)> files =
+                new List<(string ProjectRelativePath, string AssemblyResolvePath)>();
+            foreach (string projectRelativePath in projectRelativePaths)
+            {
+                files.Add((projectRelativePath, projectRelativePath));
+            }
+
+            return new HotReloadGroupFilePaths(files);
         }
 
         /// <summary>

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadShimFirstCompile.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadShimFirstCompile.cs
@@ -196,15 +196,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 HotReloadFileAtomicIsolationPlan.CollectOutcomes(
                     isolation.Plan.AtomicSkipOutcomesByFile,
                     context.ProjectRelativePaths));
-            foreach (HotReloadGroupFile file in context.Files)
-            {
-                // Why not apply: the file's generations must keep the previous run's patches, so
-                // the apply loop skips it entirely instead of clearing it.
-                // Why OR: a file already skipped for parse errors must stay skipped, and the
-                // isolation plan only knows about the files its own retry failed on.
-                file.SkipApply = file.SkipApply || isolation.Plan.IsFailedFile(file.ProjectRelativePath);
-            }
-
+            AccumulateAtomicSkipApply(context.Files, isolation.Plan);
             AdoptRetryAddedMemberNames(context.Files, isolation.RetryFiles);
             if (isolation.RetryEntries.Length == 0)
             {
@@ -244,9 +236,25 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
         }
 
+        // Why not apply: a file the isolation retry failed on must keep the previous run's
+        // patches, so the apply loop skips it entirely instead of clearing it.
+        // Why OR: a file already skipped for parse errors must stay skipped, and the isolation
+        // plan only knows about the files its own retry failed on.
+        // internal so a test can pin that accumulation without running a shim compile.
+        internal static void AccumulateAtomicSkipApply(
+            IReadOnlyList<HotReloadGroupFile> files,
+            HotReloadFileAtomicIsolationPlan plan)
+        {
+            foreach (HotReloadGroupFile file in files)
+            {
+                file.SkipApply = file.SkipApply || plan.IsFailedFile(file.ProjectRelativePath);
+            }
+        }
+
         // Why the retry rows win: the retry re-classified every declaration with the exclusions
         // in place, so its per-file added fields and consts are the ones the apply commits.
-        private static void AdoptRetryAddedMemberNames(
+        // internal so a test can pin the overwrite without running a shim compile.
+        internal static void AdoptRetryAddedMemberNames(
             IReadOnlyList<HotReloadGroupFile> files,
             TransformWorkerFileOutputDto[] retryFiles)
         {


### PR DESCRIPTION
## Summary
- Pins four conventions of a hot-reload group file that the apply stage already depends on but that no test held in place. No behavior change.

## User Impact
- No user-visible change. Every CLI response field, warning and log line is byte-identical to `main`.

## Changes
- Two of the four conventions lived inside a private method of the shim-first compile, reachable only through a worker-backed end-to-end run. The isolation stage's skip decision is now an internal helper, and the retry's added-member adoption is internal, following the seam precedent already used by the group processor ("internal so a test can observe..."). Neither is public, neither is an overload, and both keep their original bodies and call order.
- No other production behavior changed.

## Tests
Four tests added to the group processor tests:
- The isolation stage accumulates the skip decision: a file already skipped for parse errors stays skipped when the plan does not name it, and a file the plan names becomes skipped.
- The isolation retry's per-file rows replace the first pass's added field and const names.
- A run left with no entry clears with the worker row's added field names when no retry replaced them, and with the retry's names when one did — so a field the retry no longer emits is not resurrected.
- A group whose transform worker fails returns unapplied results built from files that never received a worker output row.

That last test also settles a question this branch set out to answer: the `FileOutput != null` guard in the unapplied-result builder **is reachable**. The worker output row is assigned in one place, in a stage the group processor returns before on three paths — a failed membership validation, a failed introduced-type preparation, and a failed transform worker. The guard therefore stays as it is.

Red was confirmed before green for all four:
- Reassigning the skip decision instead of accumulating it fails the first test on `Expected: True / But was: False`.
- Dropping the retry adoption fails the second on `Expected: "Sample.Host.retryField" / But was: "Sample.Host.firstPassField"`.
- Reading the worker row unconditionally in the clear fails the fourth on `Expected: "Sample.Host.retryField" / But was: "Sample.Host.workerField"`.
- Removing the `FileOutput != null` guard fails the worker-failure test with a `NullReferenceException`, which is the runtime evidence that the path is reachable.

## Verification
- `uloop run-tests --filter-type regex --filter-value "HotReloadAssemblyResolutionDiagnosticsTests|HotReloadGroupProcessorTests|HotReloadFileAtomicIsolationPlanTests|HotReloadToolTests"` — 93/93 passed.
- `scripts/check-code-complexity.sh` — 0 findings (Go: 0 issues; C#: no CA1502 above threshold 15).
- `scripts/check-file-length.sh` — 0 findings (no file above 500 SLOC).
- `uloop compile` — succeeded with no errors. No new source file, so no new `.meta`.

Note on running the tests: the regex includes `HotReloadAssemblyResolutionDiagnosticsTests` because the other classes do not capture the hot-reload package roots in their own setup, which fails one unrelated test on `main` as well when they run alone.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2720?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

