### PR TITLE
chore: Give the hot-reload nested type name forms their own types

### DIFF
--- a/Assets/Tests/Editor/HotReload/HotReloadOneShotCallerNoteBuilderTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadOneShotCallerNoteBuilderTests.cs
@@ -41,6 +41,22 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
+        /// What: a caller named in metadata form is still found by reflection, so a nested
+        /// MonoBehaviour whose name uses the metadata nesting separator is classified.
+        /// </summary>
+        [Test]
+        public void IsOneShotLifecycleCaller_NestedCallerInMetadataForm_ReturnsTrue()
+        {
+            string metadataTypeName = typeof(ValidLifecycleFixture).FullName.Replace('+', '/');
+
+            bool result = HotReloadOneShotCallerNoteEnricher.IsOneShotLifecycleCaller(
+                CreateHit(metadataTypeName, "Awake"));
+
+            Assert.That(metadataTypeName, Does.Contain("/"));
+            Assert.That(result, Is.True);
+        }
+
+        /// <summary>
         /// What: a parameterized caller does not match a separate parameterless lifecycle-named method.
         /// </summary>
         [Test]

--- a/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
@@ -2525,7 +2525,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             int expectedOriginalLine = FindLineNumberContaining(editedSource, "MissingHelperAddedByEdit");
             Assert.That(expectedOriginalLine, Is.GreaterThan(0));
             string expectedMethodLabel = HotReloadMethodKeys.FormatMethodLabelParts(
-                typeof(HotReloadE2EFixture).FullName,
+                new HotReloadMetadataTypeName(typeof(HotReloadE2EFixture).FullName),
                 nameof(HotReloadE2EFixture.CallsMissingHelper),
                 new[] { typeof(int).FullName },
                 genericArity: 0);
@@ -2719,7 +2719,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             const string missingMethodName = "DoesNotExistInCompiledAssembly";
             string typeName = typeof(HotReloadE2EFixture).FullName;
             string expectedFailedLabel = HotReloadMethodKeys.FormatMethodLabelParts(
-                typeName,
+                new HotReloadMetadataTypeName(typeName),
                 missingMethodName,
                 new[] { typeof(int).FullName },
                 genericArity: 0);
@@ -2809,17 +2809,17 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             const string missingMethodName = "DoesNotExistInCompiledAssembly";
             string typeName = typeof(HotReloadCoreFixture).FullName;
             string expectedPriorLabel = HotReloadMethodKeys.FormatMethodLabelParts(
-                typeName,
+                new HotReloadMetadataTypeName(typeName),
                 nameof(HotReloadCoreFixture.ReplaceableCompute),
                 new[] { typeof(int).FullName },
                 genericArity: 0);
             string expectedFailedLabel = HotReloadMethodKeys.FormatMethodLabelParts(
-                typeName,
+                new HotReloadMetadataTypeName(typeName),
                 missingMethodName,
                 new[] { typeof(int).FullName },
                 genericArity: 0);
             string expectedTrailingLabel = HotReloadMethodKeys.FormatMethodLabelParts(
-                typeName,
+                new HotReloadMetadataTypeName(typeName),
                 nameof(HotReloadCoreFixture.StaticPing),
                 Array.Empty<string>(),
                 genericArity: 0);
@@ -3022,7 +3022,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 }
             };
             string removedMethodLabel = HotReloadMethodKeys.FormatMethodLabelParts(
-                typeName,
+                new HotReloadMetadataTypeName(typeName),
                 nameof(HotReloadCoreFixture.ReplaceableCompute),
                 replacedParameterTypeFullNames,
                 genericArity: 0);
@@ -4642,7 +4642,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 CancellationToken.None);
             AssertNoFileLevelFailure(second);
             string expectedLabel = HotReloadMethodKeys.FormatMethodLabelParts(
-                typeof(HotReloadSignatureChangeAlreadyActiveFixture).FullName,
+                new HotReloadMetadataTypeName(typeof(HotReloadSignatureChangeAlreadyActiveFixture).FullName),
                 nameof(HotReloadSignatureChangeAlreadyActiveFixture.Target),
                 new[] { "System.Int32" },
                 0);
@@ -4694,7 +4694,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 CancellationToken.None);
 
             string expectedLabel = HotReloadMethodKeys.FormatMethodLabelParts(
-                typeof(HotReloadSignatureChangeAlreadyActiveFixture).FullName,
+                new HotReloadMetadataTypeName(typeof(HotReloadSignatureChangeAlreadyActiveFixture).FullName),
                 nameof(HotReloadSignatureChangeAlreadyActiveFixture.Target),
                 new[] { "System.Int32" },
                 0);
@@ -5284,7 +5284,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 "io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload"
                 + ".HotReloadSignatureChangeUnchangedCallerFixture::Target(System.Int32)";
             string expectedCallerLabel = HotReloadMethodKeys.FormatMethodLabelParts(
-                typeof(HotReloadSignatureChangeUnchangedCallerFixture).FullName,
+                new HotReloadMetadataTypeName(typeof(HotReloadSignatureChangeUnchangedCallerFixture).FullName),
                 nameof(HotReloadSignatureChangeUnchangedCallerFixture.StoreTarget),
                 new[] { "System.Int32" },
                 0);
@@ -5413,12 +5413,12 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 new[]
                 {
                     HotReloadMethodKeys.FormatMethodLabelParts(
-                        typeof(HotReloadSignatureChangeTwoCallerFixture).FullName,
+                        new HotReloadMetadataTypeName(typeof(HotReloadSignatureChangeTwoCallerFixture).FullName),
                         nameof(HotReloadSignatureChangeTwoCallerFixture.CallerAlpha),
                         new[] { "System.Int32" },
                         0),
                     HotReloadMethodKeys.FormatMethodLabelParts(
-                        typeof(HotReloadSignatureChangeTwoCallerFixture).FullName,
+                        new HotReloadMetadataTypeName(typeof(HotReloadSignatureChangeTwoCallerFixture).FullName),
                         nameof(HotReloadSignatureChangeTwoCallerFixture.CallerBeta),
                         new[] { "System.Int32" },
                         0)
@@ -5555,8 +5555,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 nameof(HotReloadSignatureChangeGenericCallerFixture.Target),
                 "The return type of");
             string expectedCallerLabel = HotReloadMethodKeys.FormatMethodLabelParts(
-                "io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload"
-                + ".HotReloadSignatureChangeGenericCallerFixture",
+                new HotReloadMetadataTypeName(
+                    "io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload"
+                    + ".HotReloadSignatureChangeGenericCallerFixture"),
                 "Caller",
                 new[] { "System.Int32" },
                 genericArity: 0);
@@ -5598,8 +5599,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
             AssertNoFileLevelFailure(patched);
             string expectedCallerLabel = HotReloadMethodKeys.FormatMethodLabelParts(
-                "io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload"
-                + ".HotReloadSignatureChangeGenericCallerFixture",
+                new HotReloadMetadataTypeName(
+                    "io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload"
+                    + ".HotReloadSignatureChangeGenericCallerFixture"),
                 "Caller",
                 new[] { "System.Int32" },
                 genericArity: 0);
@@ -5811,8 +5813,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 result,
                 nameof(HotReloadSignatureChangeMultiReplacementHost.TargetCovered));
             string expectedCallerLabel = HotReloadMethodKeys.FormatMethodLabelParts(
-                "io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload"
-                + ".HotReloadSignatureChangeMultiReplacementHost",
+                new HotReloadMetadataTypeName(
+                    "io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload"
+                    + ".HotReloadSignatureChangeMultiReplacementHost"),
                 "CoveredCaller",
                 new[] { "System.Int32" },
                 genericArity: 0);
@@ -5847,8 +5850,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
             AssertNoFileLevelFailure(result);
             string expectedAddedLabel = HotReloadMethodKeys.FormatMethodLabelParts(
-                "io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload"
-                + ".HotReloadSignatureChangeExternalHost",
+                new HotReloadMetadataTypeName(
+                    "io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload"
+                    + ".HotReloadSignatureChangeExternalHost"),
                 "ToDelete",
                 new[] { "System.Int32", "System.Int32" },
                 genericArity: 0);
@@ -7137,7 +7141,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         private static string AddedPingMethodLabel()
         {
             return HotReloadMethodKeys.FormatMethodLabelParts(
-                typeof(HotReloadAddedMethodApplyFixture).FullName,
+                new HotReloadMetadataTypeName(typeof(HotReloadAddedMethodApplyFixture).FullName),
                 "AddedPing",
                 new[] { "System.Int32" },
                 0);
@@ -7146,7 +7150,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         private static string AddedPongMethodLabel()
         {
             return HotReloadMethodKeys.FormatMethodLabelParts(
-                typeof(HotReloadAddedMethodApplyFixture).FullName,
+                new HotReloadMetadataTypeName(typeof(HotReloadAddedMethodApplyFixture).FullName),
                 "AddedPong",
                 new[] { "System.Int32" },
                 0);

--- a/Assets/Tests/Editor/HotReload/HotReloadPatcherTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadPatcherTests.cs
@@ -400,7 +400,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 typeof(HotReloadCoreFixture), nameof(HotReloadCoreFixture.ReplaceableCompute));
             string fromMethod = HotReloadMethodKeys.FormatMethodLabel(original);
             string fromParts = HotReloadMethodKeys.FormatMethodLabelParts(
-                typeof(HotReloadCoreFixture).FullName,
+                new HotReloadMetadataTypeName(typeof(HotReloadCoreFixture).FullName),
                 nameof(HotReloadCoreFixture.ReplaceableCompute),
                 new[] { typeof(int).ToString() },
                 genericArity: 0);
@@ -414,7 +414,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             string nestedFromMethod = HotReloadMethodKeys.FormatMethodLabel(nested);
             string cecilStyleTypeName = typeof(HotReloadNestedKeyFixture.Inner).FullName.Replace('+', '/');
             string nestedFromParts = HotReloadMethodKeys.FormatMethodLabelParts(
-                cecilStyleTypeName,
+                new HotReloadMetadataTypeName(cecilStyleTypeName),
                 nameof(HotReloadNestedKeyFixture.Inner.Ping),
                 System.Array.Empty<string>(),
                 genericArity: 0);

--- a/Assets/Tests/Editor/HotReload/HotReloadSignatureChangeCoverageTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadSignatureChangeCoverageTests.cs
@@ -346,7 +346,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             HashSet<string> snapshotLabels = new HashSet<string>(StringComparer.Ordinal)
             {
                 HotReloadMethodKeys.FormatMethodLabelParts(
-                    "Example.Caller",
+                    new HotReloadMetadataTypeName("Example.Caller"),
                     "Call",
                     Array.Empty<string>(),
                     0)
@@ -494,6 +494,35 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 CallerGenericArity = 0,
                 TargetMethodKey = ReplacementKey
             };
+        }
+
+        /// <summary>
+        /// What: a worker-shaped label spells a nested caller type the way reflection does, so a
+        /// row built before Resolve matches the label a resolved MethodBase would produce.
+        /// </summary>
+        [Test]
+        public void FormatMethodLabelParts_WithNestedMetadataTypeName_UsesTheReflectionSeparator()
+        {
+            string label = HotReloadMethodKeys.FormatMethodLabelParts(
+                new HotReloadMetadataTypeName("Example.Outer/Inner"),
+                "Call",
+                new[] { "Example.Outer/Argument" },
+                0);
+
+            Assert.That(label, Is.EqualTo("Example.Outer+Inner.Call(Example.Outer+Argument)"));
+        }
+
+        /// <summary>
+        /// What: the short caller name of a nested type keeps only the innermost type, because the
+        /// display form makes a nesting step indistinguishable from a namespace segment.
+        /// </summary>
+        [Test]
+        public void FormatCallerShortName_WithNestedMetadataTypeName_KeepsTheInnermostType()
+        {
+            string shortName = HotReloadSignatureChangeCoverage.FormatCallerShortName(
+                "Example.Outer/Inner::Call()");
+
+            Assert.That(shortName, Is.EqualTo("Inner.Call"));
         }
 
     }

--- a/Assets/Tests/Editor/HotReload/HotReloadTypeNamesTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadTypeNamesTests.cs
@@ -1,0 +1,71 @@
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
+{
+    /// <summary>
+    /// Tests the conversions between the three spellings of a nested type name.
+    /// </summary>
+    public sealed class HotReloadTypeNamesTests
+    {
+        /// <summary>
+        /// What: a metadata name converts every nesting step to the reflection separator, so the
+        /// result can be handed to Assembly.GetType or compared with Type.FullName.
+        /// </summary>
+        [Test]
+        public void ToReflectionName_WithNestedType_ReplacesEveryNestingSeparator()
+        {
+            HotReloadMetadataTypeName metadataName = new HotReloadMetadataTypeName("Ns.Outer/Middle/Inner");
+
+            HotReloadReflectionTypeName reflectionName = metadataName.ToReflectionName();
+
+            Assert.That(reflectionName.Value, Is.EqualTo("Ns.Outer+Middle+Inner"));
+        }
+
+        /// <summary>
+        /// What: a metadata name converts every nesting step to a dot for display, leaving the
+        /// namespace separators it already has untouched.
+        /// </summary>
+        [Test]
+        public void ToDisplayShortName_WithNestedType_ReadsAsCSharpSourceWould()
+        {
+            HotReloadMetadataTypeName metadataName = new HotReloadMetadataTypeName("Ns.Outer/Inner");
+
+            string displayName = metadataName.ToDisplayShortName();
+
+            Assert.That(displayName, Is.EqualTo("Ns.Outer.Inner"));
+        }
+
+        /// <summary>
+        /// What: a top-level type spells the same in all three worlds, so both conversions leave
+        /// it unchanged.
+        /// </summary>
+        [Test]
+        public void Conversions_WithTopLevelType_ChangeNothing()
+        {
+            HotReloadMetadataTypeName metadataName = new HotReloadMetadataTypeName("Ns.TopLevel");
+
+            Assert.That(metadataName.ToReflectionName().Value, Is.EqualTo("Ns.TopLevel"));
+            Assert.That(metadataName.ToDisplayShortName(), Is.EqualTo("Ns.TopLevel"));
+        }
+
+        /// <summary>
+        /// What: two names are equal only when their values match exactly, because type names are
+        /// compared ordinally everywhere they are used as keys.
+        /// </summary>
+        [Test]
+        public void Equals_ComparesTheValueOrdinally()
+        {
+            HotReloadMetadataTypeName name = new HotReloadMetadataTypeName("Ns.Outer/Inner");
+            HotReloadMetadataTypeName same = new HotReloadMetadataTypeName("Ns.Outer/Inner");
+            HotReloadMetadataTypeName differentCase = new HotReloadMetadataTypeName("ns.outer/inner");
+            HotReloadMetadataTypeName differentSeparator = new HotReloadMetadataTypeName("Ns.Outer+Inner");
+
+            Assert.That(name.Equals(same), Is.True);
+            Assert.That(name.GetHashCode(), Is.EqualTo(same.GetHashCode()));
+            Assert.That(name.Equals(differentCase), Is.False);
+            Assert.That(name.Equals(differentSeparator), Is.False);
+        }
+    }
+}

--- a/Assets/Tests/Editor/HotReload/HotReloadTypeNamesTests.cs.meta
+++ b/Assets/Tests/Editor/HotReload/HotReloadTypeNamesTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: da18b4021d2d24c21a0b18c833b45a7e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/HotReload/TransformWorkerAddedMemberTests.cs
+++ b/Assets/Tests/Editor/HotReload/TransformWorkerAddedMemberTests.cs
@@ -1266,7 +1266,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             AssertHasSkip(result, "ExistingDefault", "Interface members are not patchable");
             Assert.That(FindEntry(result, "ExistingDefault"), Is.Null);
             string expectedLabel = HotReloadMethodKeys.FormatMethodLabelParts(
-                typeof(IHotReloadAddedMemberDefault).FullName,
+                new HotReloadMetadataTypeName(typeof(IHotReloadAddedMemberDefault).FullName),
                 "ExistingDefault",
                 Array.Empty<string>(),
                 genericArity: 0);
@@ -1297,7 +1297,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 snapshotSource: onDisk);
             Assert.That(result.Success, Is.True, result.ErrorMessage);
             string expectedLabel = HotReloadMethodKeys.FormatMethodLabelParts(
-                typeof(HotReloadMethodLabelNestedHost.INestedGeneric).FullName,
+                new HotReloadMetadataTypeName(typeof(HotReloadMethodLabelNestedHost.INestedGeneric).FullName),
                 "GenericPing",
                 new[] { "System.Int32", "System.String" },
                 genericArity: 1);

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadAppliedSourceLifecycle.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadAppliedSourceLifecycle.cs
@@ -183,7 +183,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
                 labels.Add(
                     HotReloadMethodKeys.FormatMethodLabelParts(
-                        entry.typeMetadataName,
+                        new HotReloadMetadataTypeName(entry.typeMetadataName),
                         entry.methodName,
                         entry.parameterTypeFullNames ?? Array.Empty<string>(),
                         entry.genericArity));

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadEntryResolution.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadEntryResolution.cs
@@ -267,7 +267,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         private static string FormatEntryLabel(TransformWorkerEntryDto entry)
         {
             return HotReloadMethodKeys.FormatMethodLabelParts(
-                entry.typeMetadataName,
+                new HotReloadMetadataTypeName(entry.typeMetadataName),
                 entry.methodName,
                 entry.parameterTypeFullNames ?? Array.Empty<string>(),
                 entry.genericArity);

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadFileAtomicIsolationPlan.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadFileAtomicIsolationPlan.cs
@@ -133,7 +133,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     sourceFile,
                     HotReloadMethodOutcome.Skipped(
                         HotReloadMethodKeys.FormatMethodLabelParts(
-                            entry.typeMetadataName,
+                            new HotReloadMetadataTypeName(entry.typeMetadataName),
                             entry.methodName,
                             entry.parameterTypeFullNames ?? Array.Empty<string>(),
                             entry.genericArity),
@@ -187,7 +187,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     failedEntry.sourceProjectRelativePath,
                     HotReloadMethodOutcome.Failed(
                         HotReloadMethodKeys.FormatMethodLabelParts(
-                            failedEntry.typeMetadataName,
+                            new HotReloadMetadataTypeName(failedEntry.typeMetadataName),
                             failedEntry.methodName,
                             failedEntry.parameterTypeFullNames ?? Array.Empty<string>(),
                             failedEntry.genericArity),

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadMethodKeys.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadMethodKeys.cs
@@ -69,8 +69,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 genericArity = method.GetGenericArguments().Length;
             }
 
-            return FormatMethodLabelParts(
-                method.DeclaringType.FullName,
+            return FormatMethodLabelFromReflection(
+                new HotReloadReflectionTypeName(method.DeclaringType.FullName),
                 method.Name,
                 parameterTypeFullNames,
                 genericArity);
@@ -80,18 +80,34 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         // as FormatMethodLabel. Cecil nested separators ('/') are normalized to reflection ('+').
         // Keep in sync with WorkerMethodKeys.FormatMethodLabelParts.
         internal static string FormatMethodLabelParts(
-            string typeMetadataName,
+            HotReloadMetadataTypeName typeMetadataName,
             string methodName,
             string[] parameterTypeFullNames,
             int genericArity)
         {
-            Debug.Assert(!string.IsNullOrEmpty(typeMetadataName), "typeMetadataName must not be null or empty.");
+            return FormatMethodLabelFromReflection(
+                typeMetadataName.ToReflectionName(),
+                methodName,
+                parameterTypeFullNames,
+                genericArity);
+        }
+
+        // What: the shared assembly of a label once every name it holds is in reflection form.
+        // Why a parameter type is converted here too: a worker row spells a nested parameter type
+        // in metadata form, while a resolved MethodBase already spells it as reflection does, so
+        // the conversion is a no-op on the reflection path and both paths produce one string.
+        private static string FormatMethodLabelFromReflection(
+            HotReloadReflectionTypeName typeReflectionName,
+            string methodName,
+            string[] parameterTypeFullNames,
+            int genericArity)
+        {
             Debug.Assert(!string.IsNullOrEmpty(methodName), "methodName must not be null or empty.");
             Debug.Assert(parameterTypeFullNames != null, "parameterTypeFullNames must not be null.");
             Debug.Assert(genericArity >= 0, "genericArity must not be negative.");
 
             StringBuilder builder = new StringBuilder();
-            builder.Append(NormalizeNestedTypeSeparators(typeMetadataName));
+            builder.Append(typeReflectionName.Value);
             builder.Append('.');
             builder.Append(methodName);
             if (genericArity > 0)
@@ -112,17 +128,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 Debug.Assert(
                     !string.IsNullOrEmpty(parameterTypeFullName),
                     "parameterTypeFullNames entries must not be null or empty.");
-                builder.Append(NormalizeNestedTypeSeparators(parameterTypeFullName));
+                builder.Append(new HotReloadMetadataTypeName(parameterTypeFullName).ToReflectionName().Value);
             }
 
             builder.Append(')');
             return builder.ToString();
-        }
-
-        // Why: Cecil metadata names use '/' for nested types; Type.FullName uses '+'.
-        private static string NormalizeNestedTypeSeparators(string metadataName)
-        {
-            return metadataName.Replace('/', '+');
         }
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOneShotCallerNoteEnricher.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOneShotCallerNoteEnricher.cs
@@ -60,7 +60,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 return false;
             }
 
-            Type callerType = assembly.GetType(hit.CallerTypeMetadataName.Replace('/', '+'));
+            Type callerType = assembly.GetType(
+                new HotReloadMetadataTypeName(hit.CallerTypeMetadataName).ToReflectionName().Value);
             if (callerType == null || !typeof(MonoBehaviour).IsAssignableFrom(callerType))
             {
                 return false;

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadShimFirstCompile.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadShimFirstCompile.cs
@@ -153,7 +153,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             {
                 TransformWorkerEntryDto soleEntry = entries[0];
                 failureMethodLabel = HotReloadMethodKeys.FormatMethodLabelParts(
-                    soleEntry.typeMetadataName,
+                    new HotReloadMetadataTypeName(soleEntry.typeMetadataName),
                     soleEntry.methodName,
                     soleEntry.parameterTypeFullNames ?? Array.Empty<string>(),
                     soleEntry.genericArity);
@@ -216,7 +216,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 outcomes.Add(
                     HotReloadMethodOutcome.Skipped(
                         HotReloadMethodKeys.FormatMethodLabelParts(
-                            entry.typeMetadataName,
+                            new HotReloadMetadataTypeName(entry.typeMetadataName),
                             entry.methodName,
                             entry.parameterTypeFullNames ?? Array.Empty<string>(),
                             entry.genericArity),

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadShimIsolation.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadShimIsolation.cs
@@ -469,7 +469,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             foreach (TransformWorkerEntryDto caller in callerEntries)
             {
                 string methodLabel = HotReloadMethodKeys.FormatMethodLabelParts(
-                    caller.typeMetadataName,
+                    new HotReloadMetadataTypeName(caller.typeMetadataName),
                     caller.methodName,
                     caller.parameterTypeFullNames ?? Array.Empty<string>(),
                     caller.genericArity);

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadSignatureChangeCoverage.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadSignatureChangeCoverage.cs
@@ -165,7 +165,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         {
             Debug.Assert(hit != null, "hit must not be null.");
             return HotReloadMethodKeys.FormatMethodLabelParts(
-                hit.CallerTypeMetadataName,
+                new HotReloadMetadataTypeName(hit.CallerTypeMetadataName),
                 hit.CallerMethodName,
                 hit.CallerParameterTypeFullNames ?? Array.Empty<string>(),
                 ReadGenericArityFromWireMethodKey(hit.CallerMethodKey, hit.CallerMethodName));
@@ -432,7 +432,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             Debug.Assert(!string.IsNullOrEmpty(wireKey), "wireKey must not be empty.");
             int separatorIndex = wireKey.IndexOf("::", StringComparison.Ordinal);
             Debug.Assert(separatorIndex >= 0, "wireKey must contain '::'.");
-            string typePart = wireKey.Substring(0, separatorIndex).Replace('/', '.');
+            string typePart = new HotReloadMetadataTypeName(wireKey.Substring(0, separatorIndex)).ToDisplayShortName();
             int lastDot = typePart.LastIndexOf('.');
             string typeName = lastDot >= 0 ? typePart.Substring(lastDot + 1) : typePart;
             string methodAndParams = wireKey.Substring(separatorIndex + 2);

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadSignatureChangeGate.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadSignatureChangeGate.cs
@@ -253,7 +253,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         {
             Debug.Assert(entry != null, "entry must not be null.");
             return HotReloadMethodKeys.FormatMethodLabelParts(
-                entry.typeMetadataName,
+                new HotReloadMetadataTypeName(entry.typeMetadataName),
                 entry.methodName,
                 entry.parameterTypeFullNames ?? Array.Empty<string>(),
                 entry.genericArity);

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadStalePatchOutcomes.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadStalePatchOutcomes.cs
@@ -64,7 +64,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 }
 
                 string displayKey = HotReloadMethodKeys.FormatMethodLabelParts(
-                    signature.typeMetadataName,
+                    new HotReloadMetadataTypeName(signature.typeMetadataName),
                     signature.methodName,
                     parameterTypeFullNames,
                     signature.genericArity);

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadSupersededSignatureRecorder.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadSupersededSignatureRecorder.cs
@@ -55,12 +55,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 }
 
                 string oldKey = HotReloadMethodKeys.FormatMethodLabelParts(
-                    signature.typeMetadataName,
+                    new HotReloadMetadataTypeName(signature.typeMetadataName),
                     signature.methodName,
                     parameterTypeFullNames,
                     signature.genericArity);
                 string newDisplayName = HotReloadMethodKeys.FormatMethodLabelParts(
-                    replacement.typeMetadataName,
+                    new HotReloadMetadataTypeName(replacement.typeMetadataName),
                     replacement.methodName,
                     replacement.parameterTypeFullNames ?? Array.Empty<string>(),
                     replacement.genericArity);

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadTypeNames.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadTypeNames.cs
@@ -1,0 +1,101 @@
+using System;
+
+using UnityEngine;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// A type name in metadata form, the spelling Cecil and the transform worker produce, where a
+    /// nested type reads Outer/Inner.
+    /// </summary>
+    /// <remarks>
+    /// Why a type and not a string: metadata, reflection and display names differ only in the
+    /// separator of a nested type, so a value that crosses from one world to the other silently
+    /// stops matching. Holding the world in the type makes the crossing a call, not a habit.
+    /// </remarks>
+    internal readonly struct HotReloadMetadataTypeName : IEquatable<HotReloadMetadataTypeName>
+    {
+        public string Value { get; }
+
+        public HotReloadMetadataTypeName(string value)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(value), "A metadata type name must not be null or empty.");
+
+            Value = value;
+        }
+
+        /// <summary>
+        /// The same type as reflection spells it, so it can be compared with Type.FullName or
+        /// handed to Assembly.GetType.
+        /// </summary>
+        public HotReloadReflectionTypeName ToReflectionName()
+        {
+            return new HotReloadReflectionTypeName(Value.Replace('/', '+'));
+        }
+
+        /// <summary>
+        /// The same type as C# source spells it. Display only: this form is ambiguous, because a
+        /// namespace segment and a nesting step become the same character.
+        /// </summary>
+        public string ToDisplayShortName()
+        {
+            return Value.Replace('/', '.');
+        }
+
+        public bool Equals(HotReloadMetadataTypeName other)
+        {
+            return string.Equals(Value, other.Value, StringComparison.Ordinal);
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is HotReloadMetadataTypeName other && Equals(other);
+        }
+
+        public override int GetHashCode()
+        {
+            return Value == null ? 0 : StringComparer.Ordinal.GetHashCode(Value);
+        }
+
+        public override string ToString()
+        {
+            return Value;
+        }
+    }
+
+    /// <summary>
+    /// A type name in reflection form, the spelling Type.FullName produces, where a nested type
+    /// reads Outer+Inner.
+    /// </summary>
+    internal readonly struct HotReloadReflectionTypeName : IEquatable<HotReloadReflectionTypeName>
+    {
+        public string Value { get; }
+
+        public HotReloadReflectionTypeName(string value)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(value), "A reflection type name must not be null or empty.");
+
+            Value = value;
+        }
+
+        public bool Equals(HotReloadReflectionTypeName other)
+        {
+            return string.Equals(Value, other.Value, StringComparison.Ordinal);
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is HotReloadReflectionTypeName other && Equals(other);
+        }
+
+        public override int GetHashCode()
+        {
+            return Value == null ? 0 : StringComparer.Ordinal.GetHashCode(Value);
+        }
+
+        public override string ToString()
+        {
+            return Value;
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadTypeNames.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadTypeNames.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d3ea8232e168c42dc9704c4992b661cb
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary
- Gives the two nested type name forms the hot-reload code reads their own types, and moves every separator conversion into them. No behavior change.

## User Impact
- No user-visible change. Every method label, warning, log line and response field is byte-identical to `main`.

## Changes
- A type name has three spellings that differ only in how a nested type is separated: metadata (`Outer/Inner`), reflection (`Outer+Inner`), and display (`Outer.Inner`). All three were bare strings, and the conversion between them was open-coded in three separate places, so a value that crossed from one world to the other silently stopped matching.
- `HotReloadMetadataTypeName` and `HotReloadReflectionTypeName` are read-only structs holding one value each, compared ordinally. The metadata form owns both conversions — `ToReflectionName()` and a display-only `ToDisplayShortName()` whose comment says why it is display-only.
- The label formatter that takes worker rows now takes the metadata form. The label built from a resolved `MethodBase` no longer routes through it: it goes through a private reflection-form assembly step, which the worker path also ends in. A parameter type is converted in that shared step, which is a no-op on the reflection path, so both paths still produce one string.
- The one-shot caller type lookup and the coverage short name now call the struct instead of replacing separators themselves. No separator replacement for nested types remains outside the new file (path separators elsewhere are unrelated).

## Tests
- New `HotReloadTypeNamesTests`: the reflection conversion replaces every nesting step, the display conversion reads as C# source would, a top-level type is unchanged by both, and equality is ordinal (a case difference and a separator difference are both unequal).
- `HotReloadSignatureChangeCoverageTests`: a worker-shaped label spells a nested caller type — and a nested parameter type — the way reflection does; the short caller name of a nested type keeps only the innermost type, which is what the display form's ambiguity leaves it able to say.
- `HotReloadOneShotCallerNoteBuilderTests`: a nested MonoBehaviour caller named in metadata form is still classified.

Red was confirmed before green: with both conversions returning their input unchanged, the four nested-type assertions fail — `Ns.Outer+Middle+Inner` / `Ns.Outer.Inner` / `Example.Outer+Inner.Call(Example.Outer+Argument)` / `Inner.Call` each came back in the metadata spelling. Restoring the conversions returns them to green.

One honest caveat: the nested one-shot caller test passes with and without the conversion, because `Assembly.GetType` in this runtime also accepts the metadata separator. It stands as a regression guard against a future lookup that is stricter, not as a discriminating test for the conversion.

## Verification
- `uloop run-tests --filter-type regex --filter-value "HotReloadAssemblyResolutionDiagnosticsTests|HotReloadTypeNamesTests|HotReloadSignatureChangeCoverageTests|HotReloadOneShotCallerNoteBuilderTests|HotReloadPatcherTests|HotReloadIntroducedTypeCompilerTests|HotReloadOrchestratorTests"` — 256/256 passed.
- `scripts/check-code-complexity.sh` — 0 findings (Go: 0 issues; C#: no CA1502 above threshold 15).
- `scripts/check-file-length.sh` — 0 findings (no file above 500 SLOC).
- `uloop compile` — succeeded with no errors; the two new source files' `.meta` files are in the commit.

Note on running the tests: the regex includes `HotReloadAssemblyResolutionDiagnosticsTests` because some of the other classes do not capture the hot-reload package roots in their own setup, which fails one unrelated test on `main` as well when they run alone.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2721?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

