### PR TITLE
chore: Type the hot-reload carriers that hold a metadata type name

### DIFF
--- a/Assets/Tests/Editor/HotReload/HotReloadCallSiteScannerFixture.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadCallSiteScannerFixture.cs
@@ -25,6 +25,23 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             return 2;
         }
 
+        public static int CalledFromNestedType()
+        {
+            return 5;
+        }
+
+        /// <summary>
+        /// A nested caller, so a scan can observe a caller type name that only a metadata
+        /// separator spells correctly.
+        /// </summary>
+        public static class NestedCallerHost
+        {
+            public static int NestedCaller()
+            {
+                return CalledFromNestedType();
+            }
+        }
+
         public static int CalledOnlyViaDelegate()
         {
             return 3;

--- a/Assets/Tests/Editor/HotReload/HotReloadCallSiteScannerTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadCallSiteScannerTests.cs
@@ -22,6 +22,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         private const string FixtureTypeMetadataName =
             "io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload.HotReloadCallSiteScannerFixture";
 
+        private const string NestedCallerHostTypeMetadataName =
+            FixtureTypeMetadataName + "/NestedCallerHost";
+
         private const string GenericHostTypeMetadataName =
             "io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload.GenericHost`1";
 
@@ -78,7 +81,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             HotReloadCallSiteScanner.CompiledMethodIdentity target =
                 new HotReloadCallSiteScanner.CompiledMethodIdentity(
                     missingAssemblyName,
-                    FixtureTypeMetadataName,
+                    new HotReloadMetadataTypeName(FixtureTypeMetadataName),
                     nameof(HotReloadCallSiteScannerFixture.NeverCalled),
                     Array.Empty<string>(),
                     0);
@@ -200,13 +203,13 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 {
                     new HotReloadCallSiteScanner.CompiledMethodIdentity(
                         assemblyName,
-                        FixtureTypeMetadataName,
+                        new HotReloadMetadataTypeName(FixtureTypeMetadataName),
                         nameof(HotReloadCallSiteScannerFixture.CalledFromOrdinaryMethod),
                         Array.Empty<string>(),
                         0),
                     new HotReloadCallSiteScanner.CompiledMethodIdentity(
                         assemblyName,
-                        FixtureTypeMetadataName,
+                        new HotReloadMetadataTypeName(FixtureTypeMetadataName),
                         nameof(HotReloadCallSiteScannerFixture.CalledOnlyViaDelegate),
                         Array.Empty<string>(),
                         0)
@@ -345,6 +348,28 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             Assert.That(hits, Is.Empty);
         }
 
+        /// <summary>
+        /// What: a call from a nested type reports the caller type in the metadata spelling, and
+        /// the wire method key it is assembled into keeps that same separator.
+        /// </summary>
+        [Test]
+        public void FindCallSites_NestedCaller_KeepsTheMetadataSeparator()
+        {
+            List<HotReloadCallSiteScanner.CallSiteHit> hits = FindHits(
+                FixtureTypeMetadataName,
+                nameof(HotReloadCallSiteScannerFixture.CalledFromNestedType),
+                Array.Empty<string>(),
+                0);
+
+            Assert.That(hits.Count, Is.EqualTo(1));
+            Assert.That(
+                hits[0].CallerTypeMetadataName.Value,
+                Is.EqualTo(NestedCallerHostTypeMetadataName));
+            Assert.That(
+                hits[0].CallerMethodKey,
+                Is.EqualTo(NestedCallerHostTypeMetadataName + "::NestedCaller()"));
+        }
+
         private static List<HotReloadCallSiteScanner.CallSiteHit> FindHits(
             string typeMetadataName,
             string methodName,
@@ -359,7 +384,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             HotReloadCallSiteScanner.CompiledMethodIdentity target =
                 new HotReloadCallSiteScanner.CompiledMethodIdentity(
                     assemblyName,
-                    typeMetadataName,
+                    new HotReloadMetadataTypeName(typeMetadataName),
                     methodName,
                     parameterTypeFullNames,
                     genericArity);

--- a/Assets/Tests/Editor/HotReload/HotReloadGroupProcessorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadGroupProcessorTests.cs
@@ -723,7 +723,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                     {
                         CallerAssemblyName = AssemblyName,
                         CallerMethodKey = CallerKey,
-                        CallerTypeMetadataName = "Coverage.Host",
+                        CallerTypeMetadataName = new HotReloadMetadataTypeName("Coverage.Host"),
                         CallerMethodName = "Caller",
                         CallerParameterTypeFullNames = Array.Empty<string>(),
                         TargetMethodKey = TargetKey
@@ -755,7 +755,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                     {
                         CallerAssemblyName = AssemblyName,
                         CallerMethodKey = CallerKey,
-                        CallerTypeMetadataName = "Coverage.Host",
+                        CallerTypeMetadataName = new HotReloadMetadataTypeName("Coverage.Host"),
                         CallerMethodName = "Caller",
                         CallerParameterTypeFullNames = Array.Empty<string>(),
                         TargetMethodKey = TargetKey

--- a/Assets/Tests/Editor/HotReload/HotReloadIntroducedTypeActivationTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadIntroducedTypeActivationTests.cs
@@ -87,7 +87,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 foreach (HotReloadIntroducedTypeDescriptor descriptor
                     in HotReloadIntroducedTypeHolder.Registry.DescribeActive())
                 {
-                    expected.Add(descriptor.MetadataName);
+                    expected.Add(descriptor.MetadataName.Value);
                 }
 
                 Assert.That(describe(), Is.EqualTo(expected));
@@ -1685,7 +1685,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         {
             foreach (HotReloadIntroducedTypeDescriptor descriptor in artifact.Descriptors)
             {
-                if (string.Equals(descriptor.MetadataName, metadataName, StringComparison.Ordinal))
+                if (string.Equals(descriptor.MetadataName.Value, metadataName, StringComparison.Ordinal))
                 {
                     return descriptor;
                 }

--- a/Assets/Tests/Editor/HotReload/HotReloadIntroducedTypeRegistryTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadIntroducedTypeRegistryTests.cs
@@ -822,8 +822,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             Assert.That(registry.ActiveCount, Is.EqualTo(1), "The artifact count must stay one artifact.");
             Assert.That(registry.ActiveTypeCount, Is.EqualTo(2), "Both introduced types must be counted.");
             Assert.That(active.Count, Is.EqualTo(2));
-            Assert.That(active[0].MetadataName, Is.EqualTo("Example.Introduced"), "The snapshot must be ordered.");
-            Assert.That(active[1].MetadataName, Is.EqualTo("Example.OtherIntroduced"));
+            Assert.That(active[0].MetadataName.Value, Is.EqualTo("Example.Introduced"), "The snapshot must be ordered.");
+            Assert.That(active[1].MetadataName.Value, Is.EqualTo("Example.OtherIntroduced"));
         }
 
         private static HotReloadIntroducedTypeArtifact CreateArtifact(string fingerprint)

--- a/Assets/Tests/Editor/HotReload/HotReloadOneShotCallerNoteBuilderTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadOneShotCallerNoteBuilderTests.cs
@@ -868,7 +868,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             return new HotReloadCallSiteScanner.CallSiteHit
             {
                 CallerAssemblyName = typeof(HotReloadOneShotCallerNoteBuilderTests).Assembly.GetName().Name,
-                CallerTypeMetadataName = typeMetadataName,
+                CallerTypeMetadataName = new HotReloadMetadataTypeName(typeMetadataName),
                 CallerMethodName = methodName,
                 CallerParameterTypeFullNames = Array.Empty<string>(),
                 CallerGenericArity = 0
@@ -882,7 +882,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             HotReloadCallSiteScanner.CompiledMethodIdentity identity =
                 new HotReloadCallSiteScanner.CompiledMethodIdentity(
                     assemblyName,
-                    "Type",
+                    new HotReloadMetadataTypeName("Type"),
                     "SetUp",
                     Array.Empty<string>(),
                     0);
@@ -907,7 +907,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             HotReloadCallSiteScanner.CompiledMethodIdentity identity =
                 new HotReloadCallSiteScanner.CompiledMethodIdentity(
                     assemblyName,
-                    type.FullName,
+                    new HotReloadMetadataTypeName(type.FullName),
                     methodName,
                     Array.Empty<string>(),
                     0);
@@ -923,7 +923,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             return new HotReloadCallSiteScanner.CallSiteHit
             {
                 CallerAssemblyName = assemblyName,
-                CallerTypeMetadataName = typeMetadataName,
+                CallerTypeMetadataName = new HotReloadMetadataTypeName(typeMetadataName),
                 CallerMethodName = methodName,
                 CallerParameterTypeFullNames = Array.Empty<string>(),
                 CallerGenericArity = 0,

--- a/Assets/Tests/Editor/HotReload/HotReloadSignatureChangeCoverageTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadSignatureChangeCoverageTests.cs
@@ -487,7 +487,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             return new HotReloadCallSiteScanner.CallSiteHit
             {
                 CallerAssemblyName = callerAssemblyName,
-                CallerTypeMetadataName = "Example.Caller",
+                CallerTypeMetadataName = new HotReloadMetadataTypeName("Example.Caller"),
                 CallerMethodName = "Call",
                 CallerParameterTypeFullNames = Array.Empty<string>(),
                 CallerMethodKey = CallerKey,

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadCallSiteScanner.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadCallSiteScanner.cs
@@ -39,20 +39,19 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         public readonly struct CompiledMethodIdentity
         {
             public readonly string AssemblyName;
-            public readonly string TypeMetadataName;
+            public readonly HotReloadMetadataTypeName TypeMetadataName;
             public readonly string MethodName;
             public readonly string[] ParameterTypeFullNames;
             public readonly int GenericArity;
 
             public CompiledMethodIdentity(
                 string assemblyName,
-                string typeMetadataName,
+                HotReloadMetadataTypeName typeMetadataName,
                 string methodName,
                 string[] parameterTypeFullNames,
                 int genericArity)
             {
                 Debug.Assert(!string.IsNullOrEmpty(assemblyName), "assemblyName must not be null or empty.");
-                Debug.Assert(!string.IsNullOrEmpty(typeMetadataName), "typeMetadataName must not be null or empty.");
                 Debug.Assert(!string.IsNullOrEmpty(methodName), "methodName must not be null or empty.");
                 Debug.Assert(parameterTypeFullNames != null, "parameterTypeFullNames must not be null.");
                 Debug.Assert(genericArity >= 0, "genericArity must not be negative.");
@@ -71,7 +70,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         public sealed class CallSiteHit
         {
             public string CallerAssemblyName;
-            public string CallerTypeMetadataName;
+            public HotReloadMetadataTypeName CallerTypeMetadataName;
             public string CallerMethodName;
             public string[] CallerParameterTypeFullNames;
             public int CallerGenericArity;
@@ -328,7 +327,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             // Why not normalize '/' → '+': Cecil FullName and worker typeMetadataName both use
             // '/' for nested types, and BuildMethodKey keeps that form. Converting here would
             // desync CallerMethodKey from the orchestrator key space on nested types.
-            if (openDeclaringType.FullName != target.TypeMetadataName)
+            if (openDeclaringType.FullName != target.TypeMetadataName.Value)
             {
                 return false;
             }
@@ -467,7 +466,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 parameterTypeFullNames[index] = caller.Parameters[index].ParameterType.FullName;
             }
 
-            string typeMetadataName = caller.DeclaringType.FullName;
+            HotReloadMetadataTypeName typeMetadataName = new HotReloadMetadataTypeName(caller.DeclaringType.FullName);
 
             return new CallSiteHit
             {
@@ -477,12 +476,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 CallerParameterTypeFullNames = parameterTypeFullNames,
                 CallerGenericArity = caller.GenericParameters.Count,
                 CallerMethodKey = HotReloadMethodKeys.BuildMethodKeyParts(
-                    typeMetadataName,
+                    typeMetadataName.Value,
                     caller.Name,
                     parameterTypeFullNames,
                     caller.GenericParameters.Count),
                 TargetMethodKey = HotReloadMethodKeys.BuildMethodKeyParts(
-                    target.TypeMetadataName,
+                    target.TypeMetadataName.Value,
                     target.MethodName,
                     target.ParameterTypeFullNames,
                     target.GenericArity),

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadFileEntryApplier.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadFileEntryApplier.cs
@@ -254,7 +254,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             HotReloadCallSiteScanner.CompiledMethodIdentity identity =
                 new HotReloadCallSiteScanner.CompiledMethodIdentity(
                     assemblyName,
-                    resolved.Entry.typeMetadataName,
+                    new HotReloadMetadataTypeName(resolved.Entry.typeMetadataName),
                     resolved.Entry.methodName,
                     resolved.Entry.parameterTypeFullNames ?? Array.Empty<string>(),
                     resolved.Entry.genericArity);

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupCommitStage.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupCommitStage.cs
@@ -110,7 +110,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             {
                 rows.Add(
                     HotReloadIntroducedTypeOutcome.Introduced(
-                        descriptor.MetadataName,
+                        descriptor.MetadataName.Value,
                         descriptor.OriginalAssemblyName,
                         descriptor.OwnerProjectRelativePath));
             }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadIntroducedTypeArtifactRecords.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadIntroducedTypeArtifactRecords.cs
@@ -41,7 +41,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 HotReloadIntroducedTypeDescriptor descriptor = artifact.Descriptors[index];
                 types[index] = new TransformWorkerIntroducedTypeArtifactTypeDto
                 {
-                    metadataName = descriptor.MetadataName,
+                    metadataName = descriptor.MetadataName.Value,
                     originalAssemblyName = descriptor.OriginalAssemblyName,
                     originalAssemblyMvid = descriptor.OriginalAssemblyMvid,
                     ownerProjectRelativePath = descriptor.OwnerProjectRelativePath,

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadIntroducedTypeCompileFailureOutcomes.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadIntroducedTypeCompileFailureOutcomes.cs
@@ -101,7 +101,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 }
 
                 rows.Add(HotReloadIntroducedTypeOutcome.Failed(
-                    descriptor.MetadataName,
+                    descriptor.MetadataName.Value,
                     targetAssemblyName,
                     owner,
                     ReasonPrefix + string.Join("; ", messages)));

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadIntroducedTypeCompiler.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadIntroducedTypeCompiler.cs
@@ -124,7 +124,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             IReadOnlyCollection<string> emittedTypeNames = environment.ReadDefinedTypeNames(request.DllPath);
             foreach (HotReloadIntroducedTypeDescriptor descriptor in request.Descriptors)
             {
-                if (!emittedTypeNames.Contains(descriptor.MetadataName))
+                if (!emittedTypeNames.Contains(descriptor.MetadataName.Value))
                 {
                     return HotReloadIntroducedTypeCompilerResult.Failure(
                         "Introduced-type artifact does not define every requested type.");

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadIntroducedTypeDescriptor.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadIntroducedTypeDescriptor.cs
@@ -11,7 +11,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
         public string OriginalAssemblyMvid { get; }
 
-        public string MetadataName { get; }
+        public HotReloadMetadataTypeName MetadataName { get; }
 
         public string OwnerProjectRelativePath { get; }
 
@@ -36,7 +36,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             RequireValue(declarationFingerprint, nameof(declarationFingerprint));
             OriginalAssemblyName = originalAssemblyName;
             OriginalAssemblyMvid = originalAssemblyMvid;
-            MetadataName = metadataName;
+            MetadataName = new HotReloadMetadataTypeName(metadataName);
             OwnerProjectRelativePath = ownerProjectRelativePath;
             DeclarationFingerprint = declarationFingerprint;
             Source = source;
@@ -52,7 +52,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
         public string BuildIdentity()
         {
-            return OriginalAssemblyName + "|" + OriginalAssemblyMvid + "|" + MetadataName;
+            return OriginalAssemblyName + "|" + OriginalAssemblyMvid + "|" + MetadataName.Value;
         }
 
         public bool HasSameDefinition(HotReloadIntroducedTypeDescriptor other)

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadIntroducedTypeHolder.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadIntroducedTypeHolder.cs
@@ -54,7 +54,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             List<string> names = new List<string>();
             foreach (HotReloadIntroducedTypeDescriptor descriptor in currentRegistry.DescribeActive())
             {
-                names.Add(descriptor.MetadataName);
+                names.Add(descriptor.MetadataName.Value);
             }
 
             return names;

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadIntroducedTypePreparation.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadIntroducedTypePreparation.cs
@@ -277,14 +277,14 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 ownerPaths.Add(declaration.OwnerProjectRelativePath);
             }
 
-            string reason = "Introduced type " + declarations[0].MetadataName
+            string reason = "Introduced type " + declarations[0].MetadataName.Value
                 + " is declared in more than one file of the group: "
                 + string.Join(", ", ownerPaths) + ".";
             foreach (HotReloadIntroducedTypeDescriptor declaration in declarations)
             {
                 failures.Add(
                     HotReloadIntroducedTypeOutcome.Failed(
-                        declaration.MetadataName,
+                        declaration.MetadataName.Value,
                         targetAssemblyName,
                         declaration.OwnerProjectRelativePath,
                         reason));

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadIntroducedTypeRegistry.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadIntroducedTypeRegistry.cs
@@ -296,7 +296,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 return byAssembly;
             }
 
-            return string.Compare(left.MetadataName, right.MetadataName, StringComparison.Ordinal);
+            return string.Compare(left.MetadataName.Value, right.MetadataName.Value, StringComparison.Ordinal);
         }
 
         private void ValidateActivation(HotReloadIntroducedTypeArtifact artifact)

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadIntroducedTypeStatusSection.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadIntroducedTypeStatusSection.cs
@@ -28,7 +28,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     new HotReloadIntroducedTypeResult
                     {
                         Kind = HotReloadConstants.ActiveIntroducedTypeStatusKind,
-                        TypeName = descriptor.MetadataName,
+                        TypeName = descriptor.MetadataName.Value,
                         AssemblyName = descriptor.OriginalAssemblyName,
                         FilePath = descriptor.OwnerProjectRelativePath ?? string.Empty,
                         Reason = string.Empty

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOneShotCallerClosure.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOneShotCallerClosure.cs
@@ -110,7 +110,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             foreach (HotReloadCallSiteScanner.CompiledMethodIdentity identity in identities)
             {
                 string targetKey = HotReloadMethodKeys.BuildMethodKeyParts(
-                    identity.TypeMetadataName,
+                    identity.TypeMetadataName.Value,
                     identity.MethodName,
                     identity.ParameterTypeFullNames,
                     identity.GenericArity);
@@ -196,7 +196,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             if (string.IsNullOrEmpty(callerKey))
             {
                 callerKey = HotReloadMethodKeys.BuildMethodKeyParts(
-                    hit.CallerTypeMetadataName,
+                    hit.CallerTypeMetadataName.Value,
                     hit.CallerMethodName,
                     hit.CallerParameterTypeFullNames,
                     hit.CallerGenericArity);

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOneShotCallerNoteEnricher.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOneShotCallerNoteEnricher.cs
@@ -60,8 +60,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 return false;
             }
 
-            Type callerType = assembly.GetType(
-                new HotReloadMetadataTypeName(hit.CallerTypeMetadataName).ToReflectionName().Value);
+            Type callerType = assembly.GetType(hit.CallerTypeMetadataName.ToReflectionName().Value);
             if (callerType == null || !typeof(MonoBehaviour).IsAssignableFrom(callerType))
             {
                 return false;
@@ -122,7 +121,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 foreach (Candidate candidate in pair.Value)
                 {
                     string targetKey = HotReloadMethodKeys.BuildMethodKeyParts(
-                        candidate.Identity.TypeMetadataName,
+                        candidate.Identity.TypeMetadataName.Value,
                         candidate.Identity.MethodName,
                         candidate.Identity.ParameterTypeFullNames,
                         candidate.Identity.GenericArity);

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadPlayModeEntryDropRecorder.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadPlayModeEntryDropRecorder.cs
@@ -223,7 +223,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 HotReloadIntroducedTypeDescriptor descriptor = introducedTypes[index];
                 identities.Add(HotReloadPlayModeEntryDropIdentity.ForType(
                     descriptor.OriginalAssemblyName,
-                    descriptor.MetadataName));
+                    descriptor.MetadataName.Value));
             }
 
             return identities;

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadSignatureChangeCoverage.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadSignatureChangeCoverage.cs
@@ -165,7 +165,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         {
             Debug.Assert(hit != null, "hit must not be null.");
             return HotReloadMethodKeys.FormatMethodLabelParts(
-                new HotReloadMetadataTypeName(hit.CallerTypeMetadataName),
+                hit.CallerTypeMetadataName,
                 hit.CallerMethodName,
                 hit.CallerParameterTypeFullNames ?? Array.Empty<string>(),
                 ReadGenericArityFromWireMethodKey(hit.CallerMethodKey, hit.CallerMethodName));

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadSignatureChangeGate.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadSignatureChangeGate.cs
@@ -201,7 +201,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             targets.Add(
                 new HotReloadCallSiteScanner.CompiledMethodIdentity(
                     assemblyName,
-                    typeMetadataName,
+                    new HotReloadMetadataTypeName(typeMetadataName),
                     methodName,
                     parameterTypeFullNames ?? Array.Empty<string>(),
                     genericArity));


### PR DESCRIPTION
## Summary
- Gives the hot-reload carriers that hold a metadata type name their own type, so a value in the reflection or display spelling can no longer be assigned to one silently. No behavior change.

## User Impact
- No user-visible change. Every method key, warning, log line and response field is byte-identical to the base branch.


## Changes
- `HotReloadCallSiteScanner.CompiledMethodIdentity.TypeMetadataName` and `CallSiteHit.CallerTypeMetadataName` are now `HotReloadMetadataTypeName`. The scanner wraps once, at the Cecil `FullName` boundary where a caller is resolved; the Cecil comparison and the wire method-key assembly read `.Value`.
- `HotReloadIntroducedTypeDescriptor.MetadataName` is now `HotReloadMetadataTypeName` as well. Its constructor still takes a `string` and keeps the existing `ArgumentException` on an empty part, so the descriptor's validation is unchanged; the wrap happens after that check.
- Every consumer that needs a plain string — the registry's ordinal ordering, `BuildIdentity`, the artifact record, the status and response rows, the Cecil emitted-name lookup, and the play-mode drop identity — passes `.Value` at that point rather than converting somewhere upstream.

### Type names that stay `string`, and why
- **Worker DTOs** (`TransformWorkerEntryDto.typeMetadataName` and the removed/unchanged signature DTOs): these are the JSON wire contract with the transform worker. Typing them would change deserialization, not just call sites.
- **`HotReloadMethodKeys.BuildMethodKeyParts(string typeMetadataName, ...)`**: it assembles the wire method key, a string that is compared against worker-produced keys. Callers pass `.Value`, which is where the typed world ends.
- **`HotReloadIntroducedTypeOutcome.MetadataName`**: a compile failure that cannot attribute the error to a type reports an empty name (fixed by `HotReloadIntroducedTypeCompileFailureOutcomesTests`), and `HotReloadMetadataTypeName` rejects an empty value by contract. Typing it would either break that row or weaken the struct's precondition.
- **`HotReloadPlayModeEntryDropIdentity.ForType(string, string)`** and **`HotReloadAddedFieldStore.FormatFieldKey`**: both build an identity string from parts; the type name has already left the typed world by then.
- **`HotReloadMethodMatcher`**: it hands the name straight to Cecil's `ModuleDefinition.GetType`, which wants the metadata form and is reached from DTO values.
- Response DTO fields (`TypeName`, `metadataName`) stay `string` because they are serialized output.

## Tests
- New `HotReloadCallSiteScannerTests.FindCallSites_NestedCaller_KeepsTheMetadataSeparator`, with a nested `NestedCallerHost` added to the scanner fixture: a call from a nested type reports `CallerTypeMetadataName.Value` in the metadata spelling, and the wire method key it is assembled into keeps the same separator.
- Red was confirmed before green: with the scanner's wrap changed to `FullName.Replace('/', '+')`, the test fails with `Expected: "...HotReloadCallSiteScannerFixture/NestedCallerHost" But was: "...HotReloadCallSiteScannerFixture+NestedCallerHost"` (22 passed, 1 failed). Restoring the wrap returns it to green.

## Verification
- `uloop run-tests --filter-type regex --filter-value "HotReloadAssemblyResolutionDiagnosticsTests|HotReloadCallSiteScannerTests|HotReloadIntroducedTypeCompilerTests|HotReloadIntroducedTypeActivationTests|HotReloadIntroducedTypeRegistryTests|HotReloadSignatureChangeCoverageTests|HotReloadOneShotCallerNoteBuilderTests|HotReloadOrchestratorTests|HotReloadPlayModeEntryDropRecorderTests|HotReloadGroupProcessorTests|HotReloadIntroducedTypeCompileFailureOutcomesTests"` — 334/334 passed, 0 failed.
- `scripts/check-code-complexity.sh` — 0 findings (Go: 0 issues; C#: no CA1502 above threshold 15).
- `scripts/check-file-length.sh` — 0 findings (no file above 500 SLOC).
- `uloop compile` — succeeded with no errors. No new source file, so no new `.meta`.

Note on running the tests: the regex includes `HotReloadAssemblyResolutionDiagnosticsTests` because some of the other classes do not capture the hot-reload package roots in their own setup, which fails one unrelated test on the base branch as well when they run alone.
