### PR TITLE
chore: Hold one hot-reload input file's run state in one object

### DIFF
--- a/Assets/Tests/Editor/HotReload/HotReloadGroupProcessorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadGroupProcessorTests.cs
@@ -314,12 +314,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         public async Task ResolveInputFile_WhenNewSourceIsPlanned_PreservesEvidenceForPreRevertRevalidation()
         {
             HotReloadRunAccumulator run = new HotReloadRunAccumulator(autoRefreshHeldAtStart: false);
-            HotReloadFileProcessResult[] resultSlots = new HotReloadFileProcessResult[1];
-            string[] resultPaths = new string[1];
-            HotReloadGroupFile[] groupFiles = new HotReloadGroupFile[1];
+            HotReloadInputResolutionSlot slot = new HotReloadInputResolutionSlot();
             List<(int InputIndex, string AssemblyName, string ProjectRelativePath)> plannerInput =
                 new List<(int InputIndex, string AssemblyName, string ProjectRelativePath)>();
-            List<HotReloadMethodOutcome>[] deferredAlreadyActive = new List<HotReloadMethodOutcome>[1];
 
             HotReloadOrchestrator.ResolveInputFile(
                 MissingNewSourcePath,
@@ -328,22 +325,19 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 null,
                 "new-source-planning",
                 run,
-                resultSlots,
-                resultPaths,
-                groupFiles,
-                plannerInput,
-                deferredAlreadyActive);
+                slot,
+                plannerInput);
 
-            Assert.That(resultSlots[0], Is.Null);
-            Assert.That(groupFiles[0], Is.Not.Null);
-            Assert.That(groupFiles[0].NewSourceMembershipEvidence, Is.Not.Null);
+            Assert.That(slot.Result, Is.Null);
+            Assert.That(slot.GroupFile, Is.Not.Null);
+            Assert.That(slot.GroupFile.NewSourceMembershipEvidence, Is.Not.Null);
             Assert.That(plannerInput, Has.Count.EqualTo(1));
 
             HotReloadEditorStateSnapshotProvider.CaptureForTesting = () =>
                 new HotReloadEditorStateSnapshot(false, true, false);
             int revertCalls = 0;
             bool didRevert = await HotReloadGroupProcessor.RevalidateBeforeRevertAsync(
-                new[] { groupFiles[0] },
+                new[] { slot.GroupFile },
                 CancellationToken.None,
                 () => revertCalls++);
 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadInputResolutionSlot.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadInputResolutionSlot.cs
@@ -1,0 +1,27 @@
+using System.Collections.Generic;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Everything one run knows about one input file, from resolution to its final result.
+    /// </summary>
+    /// <remarks>
+    /// Why one object per input instead of parallel arrays: the four pieces are only aligned by a
+    /// shared index, so every helper that reads one of them had to receive all of them, and a
+    /// helper that copied an array lost the write-back the orchestrator depends on.
+    /// </remarks>
+    internal sealed class HotReloadInputResolutionSlot
+    {
+        public HotReloadFileProcessResult Result { get; set; }
+
+        public string ResultPath { get; set; }
+
+        public HotReloadGroupFile GroupFile { get; set; }
+
+        /// <summary>
+        /// AlreadyActive rows held back while the last changed group of the assembly can still
+        /// absorb this input, and applied afterwards when nothing else filled the slot.
+        /// </summary>
+        public List<HotReloadMethodOutcome> DeferredAlreadyActive { get; set; }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadInputResolutionSlot.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadInputResolutionSlot.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8d8f882e80f65421dae3a87cc9008e42
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
@@ -47,10 +47,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             // SessionState, which is a main-thread API.
             HotReloadRunAccumulator run =
                 new HotReloadRunAccumulator(HotReloadAutoRefreshHold.IsHeld);
-            HotReloadFileProcessResult[] resultSlots = new HotReloadFileProcessResult[files.Count];
-            string[] resultPaths = new string[files.Count];
-            HotReloadGroupFile[] groupFiles = new HotReloadGroupFile[files.Count];
-            List<HotReloadMethodOutcome>[] deferredAlreadyActive = new List<HotReloadMethodOutcome>[files.Count];
+            HotReloadInputResolutionSlot[] slots = new HotReloadInputResolutionSlot[files.Count];
+            for (int index = 0; index < slots.Length; index++)
+            {
+                slots[index] = new HotReloadInputResolutionSlot();
+            }
+
             List<(int InputIndex, string AssemblyName, string ProjectRelativePath)> plannerInput =
                 new List<(int InputIndex, string AssemblyName, string ProjectRelativePath)>();
             for (int index = 0; index < files.Count; index++)
@@ -63,25 +65,22 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     contentPathOverrideByFile,
                     correlationId,
                     run,
-                    resultSlots,
-                    resultPaths,
-                    groupFiles,
-                    plannerInput,
-                    deferredAlreadyActive);
+                    slots[index],
+                    plannerInput);
             }
 
             IReadOnlyList<HotReloadFileGroupPlan> plans = HotReloadFileGroupPlanner.Plan(plannerInput);
             HashSet<string> pathsInRun = new HashSet<string>(
                 HotReloadSourcePathNormalizer.ProjectRelativePathComparer());
-            for (int pathIndex = 0; pathIndex < resultPaths.Length; pathIndex++)
+            for (int pathIndex = 0; pathIndex < slots.Length; pathIndex++)
             {
-                if (!string.IsNullOrEmpty(resultPaths[pathIndex]))
+                if (!string.IsNullOrEmpty(slots[pathIndex].ResultPath))
                 {
-                    pathsInRun.Add(resultPaths[pathIndex]);
+                    pathsInRun.Add(slots[pathIndex].ResultPath);
                 }
             }
 
-            bool[] allDeferred = ClassifyAllDeferredPlans(plans, deferredAlreadyActive);
+            bool[] allDeferred = ClassifyAllDeferredPlans(plans, slots);
 
             List<(string Path, HotReloadFileProcessResult Result)> extraResults =
                 new List<(string Path, HotReloadFileProcessResult Result)>();
@@ -102,14 +101,13 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                         plans,
                         allDeferred,
                         planIndex,
-                        groupFiles,
+                        slots,
                         inputIndexes);
                 }
 
                 await ProcessPlannedGroupAsync(
                         inputIndexes,
-                        groupFiles,
-                        resultSlots,
+                        slots,
                         correlationId,
                         ct,
                         pathsInRun,
@@ -126,17 +124,13 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             {
                 if (allDeferred[planIndex])
                 {
-                    ApplyDeferredAlreadyActive(
-                        plans[planIndex],
-                        groupFiles,
-                        resultSlots,
-                        deferredAlreadyActive);
+                    ApplyDeferredAlreadyActive(plans[planIndex], slots);
                 }
             }
 
             for (int index = 0; index < files.Count; index++)
             {
-                run.Add(resultPaths[index], resultSlots[index]);
+                run.Add(slots[index].ResultPath, slots[index].Result);
             }
 
             for (int extraIndex = 0; extraIndex < extraResults.Count; extraIndex++)
@@ -163,11 +157,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             IReadOnlyDictionary<string, string> contentPathOverrideByFile,
             string correlationId,
             HotReloadRunAccumulator run,
-            HotReloadFileProcessResult[] resultSlots,
-            string[] resultPaths,
-            HotReloadGroupFile[] groupFiles,
-            List<(int InputIndex, string AssemblyName, string ProjectRelativePath)> plannerInput,
-            List<HotReloadMethodOutcome>[] deferredAlreadyActive)
+            HotReloadInputResolutionSlot slot,
+            List<(int InputIndex, string AssemblyName, string ProjectRelativePath)> plannerInput)
         {
             string workerSourcePath = ResolveWorkerSourcePath(
                 filePath,
@@ -187,17 +178,17 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 alreadyActiveOutcomes);
             if (resolution.IsEarlyExit)
             {
-                resultSlots[index] = resolution.EarlyResult;
-                resultPaths[index] = HotReloadPatchTargetSupport.ToProjectRelativeScriptPath(filePath);
+                slot.Result = resolution.EarlyResult;
+                slot.ResultPath = HotReloadPatchTargetSupport.ToProjectRelativeScriptPath(filePath);
                 return;
             }
 
             if (resolution.UnchangedDecision == HotReloadUnchangedSourceDecision.ShortCircuited)
             {
-                deferredAlreadyActive[index] = alreadyActiveOutcomes;
+                slot.DeferredAlreadyActive = alreadyActiveOutcomes;
             }
 
-            groupFiles[index] = new HotReloadGroupFile(
+            slot.GroupFile = new HotReloadGroupFile(
                 filePath,
                 workerSourcePath,
                 resolution.ProjectRelativePath,
@@ -207,23 +198,21 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 resolution.ProjectRoot,
                 sinks,
                 resolution.NewSourceMembershipEvidence);
-            resultPaths[index] = resolution.ProjectRelativePath;
+            slot.ResultPath = resolution.ProjectRelativePath;
             plannerInput.Add((index, resolution.AssemblyName, resolution.ProjectRelativePath));
         }
 
         private static bool[] ClassifyAllDeferredPlans(
             IReadOnlyList<HotReloadFileGroupPlan> plans,
-            List<HotReloadMethodOutcome>[] deferredAlreadyActive)
+            HotReloadInputResolutionSlot[] slots)
         {
             Debug.Assert(plans != null, "plans must not be null.");
-            Debug.Assert(deferredAlreadyActive != null, "deferredAlreadyActive must not be null.");
+            Debug.Assert(slots != null, "slots must not be null.");
 
             bool[] allDeferred = new bool[plans.Count];
             for (int planIndex = 0; planIndex < plans.Count; planIndex++)
             {
-                allDeferred[planIndex] = AreAllInputsDeferredAlreadyActive(
-                    plans[planIndex],
-                    deferredAlreadyActive);
+                allDeferred[planIndex] = AreAllInputsDeferredAlreadyActive(plans[planIndex], slots);
             }
 
             return allDeferred;
@@ -231,11 +220,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
         private static bool AreAllInputsDeferredAlreadyActive(
             HotReloadFileGroupPlan plan,
-            List<HotReloadMethodOutcome>[] deferredAlreadyActive)
+            HotReloadInputResolutionSlot[] slots)
         {
             foreach (int inputIndex in plan.InputIndexes)
             {
-                if (deferredAlreadyActive[inputIndex] == null)
+                if (slots[inputIndex].DeferredAlreadyActive == null)
                 {
                     return false;
                 }
@@ -251,12 +240,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             IReadOnlyList<HotReloadFileGroupPlan> plans,
             bool[] allDeferred,
             int currentPlanIndex,
-            HotReloadGroupFile[] groupFiles,
+            HotReloadInputResolutionSlot[] slots,
             List<int> inputIndexes)
         {
             Debug.Assert(plans != null, "plans must not be null.");
             Debug.Assert(allDeferred != null, "allDeferred must not be null.");
-            Debug.Assert(groupFiles != null, "groupFiles must not be null.");
+            Debug.Assert(slots != null, "slots must not be null.");
             Debug.Assert(inputIndexes != null, "inputIndexes must not be null.");
 
             string assemblyName = plans[currentPlanIndex].AssemblyName;
@@ -264,7 +253,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 HotReloadSourcePathNormalizer.ProjectRelativePathComparer());
             for (int position = 0; position < inputIndexes.Count; position++)
             {
-                pathsInGroup.Add(groupFiles[inputIndexes[position]].ProjectRelativePath);
+                pathsInGroup.Add(slots[inputIndexes[position]].GroupFile.ProjectRelativePath);
             }
 
             for (int planIndex = 0; planIndex < plans.Count; planIndex++)
@@ -283,7 +272,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 for (int deferredPosition = 0; deferredPosition < deferredIndexes.Count; deferredPosition++)
                 {
                     int inputIndex = deferredIndexes[deferredPosition];
-                    string path = groupFiles[inputIndex].ProjectRelativePath;
+                    string path = slots[inputIndex].GroupFile.ProjectRelativePath;
                     if (pathsInGroup.Add(path))
                     {
                         inputIndexes.Add(inputIndex);
@@ -294,32 +283,30 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
         private static void ApplyDeferredAlreadyActive(
             HotReloadFileGroupPlan plan,
-            HotReloadGroupFile[] groupFiles,
-            HotReloadFileProcessResult[] resultSlots,
-            List<HotReloadMethodOutcome>[] deferredAlreadyActive)
+            HotReloadInputResolutionSlot[] slots)
         {
             foreach (int inputIndex in plan.InputIndexes)
             {
-                if (resultSlots[inputIndex] != null)
+                HotReloadInputResolutionSlot slot = slots[inputIndex];
+                if (slot.Result != null)
                 {
                     continue;
                 }
 
                 Debug.Assert(
-                    deferredAlreadyActive[inputIndex] != null,
+                    slot.DeferredAlreadyActive != null,
                     "An unfilled deferred slot must have AlreadyActive rows.");
-                groupFiles[inputIndex].Sinks.Outcomes.AddRange(deferredAlreadyActive[inputIndex]);
-                resultSlots[inputIndex] = new HotReloadFileProcessResult(
-                    groupFiles[inputIndex].Sinks.Outcomes,
-                    groupFiles[inputIndex].Sinks.Warnings,
+                slot.GroupFile.Sinks.Outcomes.AddRange(slot.DeferredAlreadyActive);
+                slot.Result = new HotReloadFileProcessResult(
+                    slot.GroupFile.Sinks.Outcomes,
+                    slot.GroupFile.Sinks.Warnings,
                     0);
             }
         }
 
         private static async Task ProcessPlannedGroupAsync(
             IReadOnlyList<int> inputIndexes,
-            HotReloadGroupFile[] groupFiles,
-            HotReloadFileProcessResult[] resultSlots,
+            HotReloadInputResolutionSlot[] slots,
             string correlationId,
             CancellationToken ct,
             HashSet<string> pathsInRun,
@@ -332,7 +319,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             List<HotReloadGroupFile> filesOfGroup = new List<HotReloadGroupFile>(inputIndexes.Count);
             foreach (int inputIndex in inputIndexes)
             {
-                filesOfGroup.Add(groupFiles[inputIndex]);
+                filesOfGroup.Add(slots[inputIndex].GroupFile);
             }
 
             int inputCount = inputIndexes.Count;
@@ -354,7 +341,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 "A group must report one result per file, including re-applied siblings.");
             for (int position = 0; position < inputIndexes.Count; position++)
             {
-                resultSlots[inputIndexes[position]] = groupResults[position];
+                slots[inputIndexes[position]].Result = groupResults[position];
             }
 
             for (int position = inputCount; position < filesOfGroup.Count; position++)


### PR DESCRIPTION
## Summary
- Replaces the orchestrator's four index-aligned arrays with one object per input file. No behavior change.

## User Impact
- No user-visible change. Outcome order, warnings, log lines and response fields are byte-identical to `main`.

## Changes
- A run kept an input file's result, project-relative path, group file and deferred AlreadyActive rows in four separate arrays, aligned only by a shared index. Every helper that needed one of them had to take all four, and nothing stopped a helper from receiving a copy whose write-back the run would then drop.
- New `HotReloadInputResolutionSlot` holds those four pieces for one input. The orchestrator allocates one per file up front, so a slot always exists and the helpers assign into it.
- `ResolveInputFile` takes eight arguments instead of eleven: the slot replaces the three arrays it wrote into and the deferred-rows array.
- The five helpers that used to take the arrays — `ClassifyAllDeferredPlans`, `AreAllInputsDeferredAlreadyActive`, `AppendUniqueDeferredInputIndexes`, `ApplyDeferredAlreadyActive`, `ProcessPlannedGroupAsync` — now take `slots`, and `ApplyDeferredAlreadyActive` drops from four parameters to two. Both write-back sites assign through `slots[i].Result`.
- `HotReloadOrchestrator.cs` goes from 470 to 456 SLOC.

## Tests
- No new test: this is a mechanical collapse with no new branch. `HotReloadGroupProcessorTests.ResolveInputFile_WhenNewSourceIsPlanned_PreservesEvidenceForPreRevertRevalidation` is updated to the new signature and still pins the same three facts (no early result, a group file with membership evidence, one planner row), now read off the slot.

## Verification
- `uloop run-tests --filter-type regex --filter-value "HotReloadAssemblyResolutionDiagnosticsTests|HotReloadOrchestratorTests|HotReloadGroupProcessorTests|HotReloadNewSourceMembershipTests|HotReloadCrossFileE2ETests"` — 229/229 passed, 0 failed.
- `scripts/check-code-complexity.sh` — 0 findings (Go: 0 issues; C#: no CA1502 above threshold 15).
- `scripts/check-file-length.sh` — 0 findings (no file above 500 SLOC).
- `uloop compile` — succeeded with no errors; the new source file's `.meta` is in the commit.

Note on running the tests: the regex includes `HotReloadAssemblyResolutionDiagnosticsTests` because some of the other classes do not capture the hot-reload package roots in their own setup, which fails one unrelated test on `main` as well when they run alone.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2723?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

