### PR TITLE
chore: Read the active hot-reload change counts once per report

### DIFF
--- a/Assets/Tests/Editor/HotReload/HotReloadActiveChangeCountsTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadActiveChangeCountsTests.cs
@@ -1,0 +1,79 @@
+using System.Reflection;
+
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
+{
+    /// <summary>
+    /// Coverage for the one read that answers how much this domain currently holds.
+    /// </summary>
+    public class HotReloadActiveChangeCountsTests
+    {
+        private const string AddedMemberFilePath =
+            "Assets/Tests/Editor/HotReload/ActiveChangeCountsFile.cs";
+
+        [TearDown]
+        public void TearDown()
+        {
+            HotReloadPatcher.RevertAll();
+        }
+
+        /// <summary>
+        /// What: an added member with no patched method still counts, both as a patch-and-added
+        /// member and in the total a Domain Reload would discard.
+        /// </summary>
+        [Test]
+        public void Capture_WithAddedMemberOnly_CountsItInBothTotals()
+        {
+            MethodInfo shim = RequireShimMethod();
+            HotReloadAddedMemberRegistry.BeginFileGeneration(AddedMemberFilePath);
+            HotReloadAddedMemberRegistry.Register(
+                AddedMemberFilePath,
+                "Host.AddedPing()",
+                shim,
+                AddedMemberFilePath);
+
+            HotReloadActiveChangeSnapshot snapshot = HotReloadActiveChangeCounts.Capture();
+
+            Assert.That(snapshot.PatchAndAddedMemberCount, Is.EqualTo(1));
+            Assert.That(
+                snapshot.RuntimeChangeTotal,
+                Is.EqualTo(1 + snapshot.IntroducedTypeCount));
+        }
+
+        /// <summary>
+        /// What: the snapshot reports the same three numbers the separate accessors do, so
+        /// removing an accessor or changing one of the sums is caught here.
+        /// </summary>
+        [Test]
+        public void Capture_ReadsTheSameNumbersAsTheAccessors()
+        {
+            HotReloadActiveChangeSnapshot snapshot = HotReloadActiveChangeCounts.Capture();
+
+            Assert.That(
+                snapshot.PatchAndAddedMemberCount,
+                Is.EqualTo(HotReloadPatcher.ActiveChangeCount));
+            Assert.That(
+                snapshot.IntroducedTypeCount,
+                Is.EqualTo(HotReloadActiveChangeCounts.IntroducedTypeCount));
+            Assert.That(
+                snapshot.RuntimeChangeTotal,
+                Is.EqualTo(HotReloadActiveChangeCounts.RuntimeChangeTotal));
+        }
+
+        private static MethodInfo RequireShimMethod()
+        {
+            MethodInfo method = typeof(HotReloadActiveChangeCountsTests).GetMethod(
+                nameof(ShimTarget),
+                BindingFlags.Static | BindingFlags.NonPublic);
+            Assert.That(method, Is.Not.Null);
+            return method;
+        }
+
+        private static void ShimTarget()
+        {
+        }
+    }
+}

--- a/Assets/Tests/Editor/HotReload/HotReloadActiveChangeCountsTests.cs.meta
+++ b/Assets/Tests/Editor/HotReload/HotReloadActiveChangeCountsTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 40685eca79af142f8b492bef012ca3ff
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/HotReload/HotReloadIntroducedTypeHoldTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadIntroducedTypeHoldTests.cs
@@ -78,15 +78,15 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                     HotReloadAutoRefreshHold.IsHeld,
                     Is.True,
                     "A revert cannot unload the artifact assembly, so it must keep the hold.");
-                Assert.That(revert.Message, Does.Contain("Domain Reload"));
                 Assert.That(
                     revert.Message,
-                    Does.Contain("Auto Refresh stays held"),
-                    "A revert that leaves the hold armed must say so and name the release.");
-                Assert.That(
-                    revert.Message,
-                    Does.Contain("uloop compile"),
-                    "The caller needs the command that actually releases the hold.");
+                    Is.EqualTo(
+                        "No active hot-reload changes to revert. 1 introduced type(s) stay loaded "
+                        + "until the next Domain Reload; a revert cannot unload the assembly that "
+                        + "carries them. Auto Refresh stays held for them; run 'uloop compile' to "
+                        + "release it."),
+                    "A revert that leaves the hold armed must say so, name what stayed, and name "
+                    + "the command that releases it.");
                 Assert.That(
                     HotReloadAutoRefreshHoldConstants.NewlyArmedMessageSuffix,
                     Does.Not.Contain("or '--revert-all' to release it"),

--- a/Assets/Tests/Editor/HotReload/HotReloadIntroducedTypeStatusTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadIntroducedTypeStatusTests.cs
@@ -94,8 +94,13 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
                 HotReloadResponse response = HotReloadStatusExecutor.ExecuteRevertAll();
 
-                Assert.That(response.Message, Does.Contain("Domain Reload"));
-                Assert.That(response.Message, Does.Contain("2 introduced type"));
+                Assert.That(
+                    response.Message,
+                    Is.EqualTo(
+                        "No active hot-reload changes to revert. 2 introduced type(s) stay loaded "
+                        + "until the next Domain Reload; a revert cannot unload the assembly that "
+                        + "carries them. Auto Refresh stays held for them; run 'uloop compile' to "
+                        + "release it."));
                 Assert.That(response.ActiveIntroducedTypeTotal, Is.EqualTo(2));
                 Assert.That(
                     response.IntroducedTypes.Count,
@@ -151,7 +156,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 Assert.That(response.ActivePatchTotal, Is.EqualTo(0), "Arrange: no method is patched.");
                 Assert.That(
                     response.Message,
-                    Does.EndWith("2 hot-reload change(s) are still active."),
+                    Is.EqualTo(
+                        "--status cannot be combined with --files or --revert-all. 2 hot-reload "
+                        + "change(s) are still active."),
                     "A refusal must not tell the caller the domain is clean while it holds two types.");
             }
         }

--- a/Assets/Tests/Editor/HotReload/HotReloadToolTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadToolTests.cs
@@ -121,7 +121,10 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 Assert.That(response.ActivePatchTotal, Is.EqualTo(1));
                 Assert.That(
                     response.Message,
-                    Does.EndWith("1 hot-reload change(s) are still active."));
+                    Is.EqualTo(
+                        "No .cs files changed since the last compile were found. Files that have "
+                        + "never been compiled are not selected automatically; pass them (and any "
+                        + "other path) with --files. 1 hot-reload change(s) are still active."));
                 Assert.That(
                     response.NextActions[response.NextActions.Length - 1],
                     Is.EqualTo(
@@ -947,6 +950,10 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 Assert.That(response.Success, Is.True);
                 Assert.That(response.ActivePatchTotal, Is.EqualTo(0));
                 Assert.That(response.AutoRefreshHeld, Is.False);
+                Assert.That(response.ClearedCount, Is.EqualTo(1));
+                Assert.That(
+                    response.Message,
+                    Is.EqualTo("Reverted all active hot-reload changes."));
             }
             finally
             {

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadActiveChangeCounts.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadActiveChangeCounts.cs
@@ -1,6 +1,32 @@
 namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 {
     /// <summary>
+    /// Every number one report needs about what this domain currently holds, read together.
+    /// </summary>
+    /// <remarks>
+    /// Why one value carries all three: a report names a total and then says what it is made of,
+    /// and reading the parts separately lets another reload activate a type between the reads, so
+    /// the heading, the decision, and the total would answer about different moments.
+    /// </remarks>
+    internal readonly struct HotReloadActiveChangeSnapshot
+    {
+        internal HotReloadActiveChangeSnapshot(int patchAndAddedMemberCount, int introducedTypeCount)
+        {
+            PatchAndAddedMemberCount = patchAndAddedMemberCount;
+            IntroducedTypeCount = introducedTypeCount;
+            RuntimeChangeTotal = patchAndAddedMemberCount + introducedTypeCount;
+        }
+
+        /// <summary>Patched methods plus added members: what a run reports against PatchedTotal.</summary>
+        internal int PatchAndAddedMemberCount { get; }
+
+        internal int IntroducedTypeCount { get; }
+
+        /// <summary>How many hot-reload changes the next Domain Reload discards.</summary>
+        internal int RuntimeChangeTotal { get; }
+    }
+
+    /// <summary>
     /// The one place the hot-reload side reads how many runtime changes this domain holds.
     /// </summary>
     /// <remarks>
@@ -22,6 +48,14 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         /// still has something to lose, and every decision about what a reload would lose reads
         /// this total rather than counting for itself.
         /// </remarks>
-        internal static int RuntimeChangeTotal => HotReloadPatcher.ActiveChangeCount + IntroducedTypeCount;
+        internal static int RuntimeChangeTotal => Capture().RuntimeChangeTotal;
+
+        /// <summary>Reads every active-change number once, so one report cannot mix two moments.</summary>
+        internal static HotReloadActiveChangeSnapshot Capture()
+        {
+            return new HotReloadActiveChangeSnapshot(
+                HotReloadPatcher.ActiveChangeCount,
+                IntroducedTypeCount);
+        }
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadStatusExecutor.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadStatusExecutor.cs
@@ -1,5 +1,7 @@
 using System.Collections.Generic;
 
+using UnityEngine;
+
 using io.github.hatayama.UnityCliLoop.ToolContracts;
 
 namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
@@ -25,23 +27,23 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 hold.SceneRefreshWarning);
             // Why one snapshot: the total and the sentence that names it must agree, and a second
             // read could answer after another reload activated a type.
-            int introducedTypeCount = HotReloadActiveChangeCounts.IntroducedTypeCount;
+            HotReloadActiveChangeSnapshot snapshot = HotReloadActiveChangeCounts.Capture();
             return new HotReloadResponse
             {
                 Success = true,
                 ClearedCount = clearedCount,
-                ActivePatchTotal = HotReloadPatcher.ActiveChangeCount,
+                ActivePatchTotal = snapshot.PatchAndAddedMemberCount,
                 AutoRefreshHeld = hold.Held,
                 Warnings = warnings,
                 // Why the rows too: a total without them names nothing, so a caller told that
                 // types stayed loaded could not tell which ones a revert left behind.
                 IntroducedTypes = HotReloadIntroducedTypeStatusSection.BuildActiveRows(),
-                ActiveIntroducedTypeTotal = introducedTypeCount,
+                ActiveIntroducedTypeTotal = snapshot.IntroducedTypeCount,
                 Message = HotReloadIntroducedTypeStatusSection.AppendRevertAllNote(
                     clearedCount == 0
                         ? "No active hot-reload changes to revert."
                         : "Reverted all active hot-reload changes.",
-                    introducedTypeCount,
+                    snapshot.IntroducedTypeCount,
                     hold.Held)
             };
         }
@@ -96,9 +98,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             // Why one snapshot for the heading, the drop decision, and the reported total: a
             // domain still holding an introduced type has not lost it, and a caller told three
             // different numbers for "what is active" cannot tell which one answers the question.
-            int introducedTypeCount = HotReloadActiveChangeCounts.IntroducedTypeCount;
-            int runtimeChangeTotal = count + introducedTypeCount;
-            string message = $"{runtimeChangeTotal} change(s) currently active.";
+            HotReloadActiveChangeSnapshot snapshot = HotReloadActiveChangeCounts.Capture();
+            Debug.Assert(
+                count == snapshot.PatchAndAddedMemberCount,
+                "The rows built from the two ledgers must total what the snapshot counts.");
+            string message = $"{snapshot.RuntimeChangeTotal} change(s) currently active.";
             if (neverInvokedCount > 0)
             {
                 message += " " + string.Format(
@@ -108,7 +112,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             int droppedCount = HotReloadPlayModeEntryDropLedger.Count;
             string dropMessage = HotReloadPlayModeEntryDropStatusMessageBuilder.Build(
-                runtimeChangeTotal,
+                snapshot.RuntimeChangeTotal,
                 droppedCount);
             if (dropMessage != null)
             {
@@ -130,7 +134,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 Methods = methods,
                 Warnings = warnings,
                 IntroducedTypes = HotReloadIntroducedTypeStatusSection.BuildActiveRows(),
-                ActiveIntroducedTypeTotal = introducedTypeCount,
+                ActiveIntroducedTypeTotal = snapshot.IntroducedTypeCount,
                 ActivePatchTotal = count,
                 AddedFieldTotal = addedFields.Count,
                 AutoRefreshHeld = hold.Held,

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadTools.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadTools.cs
@@ -291,11 +291,13 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         private static HotReloadResponse CreateValidationFailure(HotReloadValidationFailure failure)
         {
             Debug.Assert(failure != null, "failure must not be null.");
-            int activePatchTotal = HotReloadPatcher.ActiveChangeCount;
-            // Why two numbers: the suffix warns that the refusal left something live, and an
-            // introduced type is live even when nothing is patched. ActivePatchTotal stays a patch
-            // count because callers read it against PatchedTotal.
-            int runtimeChangeTotal = HotReloadActiveChangeCounts.RuntimeChangeTotal;
+            // Why two numbers from one read: the suffix warns that the refusal left something
+            // live, and an introduced type is live even when nothing is patched. ActivePatchTotal
+            // counts patched methods and added members, which is what callers read it against
+            // PatchedTotal for; the runtime total adds the introduced types on top.
+            HotReloadActiveChangeSnapshot snapshot = HotReloadActiveChangeCounts.Capture();
+            int activePatchTotal = snapshot.PatchAndAddedMemberCount;
+            int runtimeChangeTotal = snapshot.RuntimeChangeTotal;
             string message = failure.Message;
             string[] nextActions = failure.NextActions;
             if (runtimeChangeTotal > 0)


### PR DESCRIPTION
## Summary
- Hot-reload status, revert-all, and validation-failure responses now take their active-change numbers from one read instead of recomputing them three times.
- No user-visible change: every response field and message string stays byte-identical.

## User Impact
- Before and after: identical CLI output. This removes a way for the three totals to drift apart or to mix two moments in one report; it does not change any current number.

## Changes
- `HotReloadActiveChangeSnapshot` captures the patch-and-added-member count and the introduced-type count in one read and derives the runtime total from them; `HotReloadActiveChangeCounts.Capture()` is the single entry point, and the existing accessors now read through it.
- The status path, the revert-all path, and the validation-failure suffix all take their numbers from one capture per response.
- The status path asserts that the rows built from the two ledgers still total what the snapshot counts.
- New `HotReloadActiveChangeCountsTests`: an added member with no patch must reach both totals, and the snapshot must agree with the accessors.
- Four existing assertions compared only a substring of the response message, so a wrong count inside a message would not have failed them. They now compare the full string.

## Verification
- `uloop run-tests --skip-compile --filter-type regex --filter-value "HotReloadAssemblyResolutionDiagnosticsTests|HotReloadActiveChangeCountsTests|HotReloadPatcherTests|HotReloadToolTests|HotReloadIntroducedTypeStatusTests|HotReloadIntroducedTypeHoldTests|HotReloadPlayModeEntryDropStatusTests"` -> 104 passed, 0 failed.
- Red confirmed for both new guarantees: pointing `Capture()` at the patch-only count fails the added-member test (`Expected: 1 / But was: 0`), and changing one character of a tightened literal fails its test.
- `scripts/check-code-complexity.sh` -> 0 issues, no CA1502 findings. `scripts/check-file-length.sh` -> no files over the limit.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2724?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

