### PR TITLE
chore: Route every per-file hot-reload generation write through one facade

### DIFF
--- a/Assets/Tests/Editor/HotReload/HotReloadFileGenerationsTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadFileGenerationsTests.cs
@@ -1,0 +1,165 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
+{
+    /// <summary>
+    /// EditMode coverage for the write facade over the two per-file generation registries.
+    /// Reads go straight to the registries; only the writes are under test here.
+    /// </summary>
+    public class HotReloadFileGenerationsTests
+    {
+        private const string FixtureProjectRelativePath =
+            "Assets/Tests/Editor/HotReload/FileGenerationsFixture.cs";
+
+        private Func<MethodBase, MethodBase> _originalActiveShimLookup;
+
+        // Why the stand-in: the file lookup hides methods the patch ledger no longer reports as
+        // patched, and these tests register shims without applying a Harmony patch. Reporting
+        // every method as patched makes the lookup show the generation's contents as recorded.
+        [SetUp]
+        public void SetUp()
+        {
+            _originalActiveShimLookup = HotReloadPausePointCoordination.GetActiveShimForMethod;
+            HotReloadPausePointCoordination.GetActiveShimForMethod = method => method;
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            HotReloadPausePointCoordination.GetActiveShimForMethod = _originalActiveShimLookup;
+            HotReloadPatcher.RevertAll();
+        }
+
+        /// <summary>
+        /// What: starting a file generation opens both registries for the path with nothing in them.
+        /// </summary>
+        [Test]
+        public void BeginFileGeneration_StartsBothRegistriesEmpty()
+        {
+            BeginGeneration();
+
+            Assert.That(HotReloadShimRegistry.HasGeneration(FixtureProjectRelativePath), Is.True);
+            Assert.That(HotReloadAddedMemberRegistry.HasGeneration(FixtureProjectRelativePath), Is.True);
+            Assert.That(
+                HotReloadAddedMemberRegistry.ListActiveMethodKeys(FixtureProjectRelativePath),
+                Is.Empty);
+        }
+
+        /// <summary>
+        /// What: an added-member-only start drops the added members but leaves the shim
+        /// generation's registered methods in place.
+        /// </summary>
+        [Test]
+        public void BeginAddedMemberOnlyGeneration_KeepsTheShimGenerationContents()
+        {
+            BeginGeneration();
+            RegisterOneOfEach();
+
+            HotReloadFileGenerations.BeginAddedMemberOnlyGeneration(FixtureProjectRelativePath);
+
+            Assert.That(FindRegisteredShim(), Is.Not.Null);
+            Assert.That(
+                HotReloadAddedMemberRegistry.ListActiveMethodKeys(FixtureProjectRelativePath),
+                Is.Empty);
+        }
+
+        /// <summary>
+        /// What: clearing drops the generation on both registries, not just one of them.
+        /// </summary>
+        [Test]
+        public void ClearAll_DropsBothRegistries()
+        {
+            BeginGeneration();
+            RegisterOneOfEach();
+
+            HotReloadFileGenerations.ClearAll();
+
+            Assert.That(HotReloadShimRegistry.HasGeneration(FixtureProjectRelativePath), Is.False);
+            Assert.That(HotReloadAddedMemberRegistry.HasGeneration(FixtureProjectRelativePath), Is.False);
+        }
+
+        /// <summary>
+        /// What: removing one shim method takes that method out while the file keeps its
+        /// generation, so a sibling registration in the same run still finds the file key.
+        /// </summary>
+        [Test]
+        public void RemoveShimMethod_RemovesTheMethodButKeepsTheGeneration()
+        {
+            BeginGeneration();
+            RegisterOneOfEach();
+
+            HotReloadFileGenerations.RemoveShimMethod(GetShimTarget());
+
+            Assert.That(FindRegisteredShim(), Is.Null);
+            Assert.That(HotReloadShimRegistry.HasGeneration(FixtureProjectRelativePath), Is.True);
+        }
+
+        private static void BeginGeneration()
+        {
+            Assembly assembly = typeof(HotReloadFileGenerationsTests).Assembly;
+            byte[] assemblyBytes = File.ReadAllBytes(assembly.Location);
+            HotReloadFileGenerations.BeginFileGeneration(
+                FixtureProjectRelativePath,
+                assemblyBytes,
+                null,
+                assembly);
+        }
+
+        private static void RegisterOneOfEach()
+        {
+            HotReloadFileGenerations.RegisterShimMethod(
+                FixtureProjectRelativePath,
+                GetShimTarget(),
+                new HotReloadShimRegistry.MethodEntry(GetAddedTarget(), false, 1, 2));
+            HotReloadFileGenerations.RegisterAddedMethod(
+                FixtureProjectRelativePath,
+                "FileGenerationsFixture.AddedMember()",
+                GetAddedTarget(),
+                FixtureProjectRelativePath);
+        }
+
+        private static HotReloadShimMethodLookup FindRegisteredShim()
+        {
+            HotReloadShimFileLookup lookup =
+                HotReloadPausePointCoordination.GetShimLookupForFile?.Invoke(FixtureProjectRelativePath);
+            if (lookup == null)
+            {
+                return null;
+            }
+
+            return lookup.Methods.FirstOrDefault(method => method.OriginalMethod == GetShimTarget());
+        }
+
+        private static MethodInfo GetShimTarget()
+        {
+            return typeof(HotReloadFileGenerationsTests).GetMethod(
+                nameof(ShimTarget),
+                BindingFlags.Static | BindingFlags.NonPublic);
+        }
+
+        private static MethodInfo GetAddedTarget()
+        {
+            return typeof(HotReloadFileGenerationsTests).GetMethod(
+                nameof(AddedTarget),
+                BindingFlags.Static | BindingFlags.NonPublic);
+        }
+
+        private static int ShimTarget()
+        {
+            return 1;
+        }
+
+        private static int AddedTarget()
+        {
+            return 2;
+        }
+    }
+}

--- a/Assets/Tests/Editor/HotReload/HotReloadFileGenerationsTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadFileGenerationsTests.cs
@@ -18,6 +18,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
     {
         private const string FixtureProjectRelativePath =
             "Assets/Tests/Editor/HotReload/FileGenerationsFixture.cs";
+        private const string AddedMethodKey = "FileGenerationsFixture.AddedMember()";
 
         private Func<MethodBase, MethodBase> _originalActiveShimLookup;
 
@@ -62,6 +63,10 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         {
             BeginGeneration();
             RegisterOneOfEach();
+            Assert.That(
+                HotReloadAddedMemberRegistry.ListActiveMethodKeys(FixtureProjectRelativePath),
+                Does.Contain(AddedMethodKey),
+                "The added member must be recorded before the start under test drops it.");
 
             HotReloadFileGenerations.BeginAddedMemberOnlyGeneration(FixtureProjectRelativePath);
 
@@ -121,7 +126,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 new HotReloadShimRegistry.MethodEntry(GetAddedTarget(), false, 1, 2));
             HotReloadFileGenerations.RegisterAddedMethod(
                 FixtureProjectRelativePath,
-                "FileGenerationsFixture.AddedMember()",
+                AddedMethodKey,
                 GetAddedTarget(),
                 FixtureProjectRelativePath);
         }

--- a/Assets/Tests/Editor/HotReload/HotReloadFileGenerationsTests.cs.meta
+++ b/Assets/Tests/Editor/HotReload/HotReloadFileGenerationsTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a5db7c161781a4d14a7ea6e7d3ed4394
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadFileEntryApplier.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadFileEntryApplier.cs
@@ -67,9 +67,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         /// Drops the file's stale added members when the run left it with no entry to patch.
         /// </summary>
         /// <remarks>
-        /// Why not HotReloadFileGenerations.BeginFileGeneration: this file contributed no body to
-        /// the shim assembly, so there are no bytes to register a shim generation with. Only the
-        /// added-member side has stale rows to drop.
+        /// Why the added-member-only start: this file contributed no body to the shim assembly,
+        /// so it has no shim generation to replace.
         /// </remarks>
         internal static void ClearFileGeneration(HotReloadApplyContext context, HotReloadGroupFile file)
         {
@@ -79,7 +78,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             IReadOnlyList<string> addedLabelsAtClear =
                 HotReloadFileGenerations.ListActiveAddedMethodKeys(file.ProjectRelativePath);
             HotReloadOrchestratorLog.LogHotReloadEmptyEntriesClear(addedLabelsAtClear, context.CorrelationId);
-            HotReloadAddedMemberRegistry.BeginFileGeneration(file.ProjectRelativePath);
+            HotReloadFileGenerations.BeginAddedMemberOnlyGeneration(file.ProjectRelativePath);
             // Why AddedFieldNames first: a retry (gate or isolation) replaces this file's added
             // field names, and committing the first-pass names would resurrect a field the
             // retry no longer emits. The worker row is the first-pass fallback.
@@ -270,7 +269,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         {
             if (resolved.IsAddedMethod)
             {
-                HotReloadAddedMemberRegistry.Register(
+                HotReloadFileGenerations.RegisterAddedMethod(
                     projectRelativePath,
                     resolved.MethodLabel,
                     resolved.ShimMethod,
@@ -283,7 +282,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             // Why before Apply: Apply notifies OnHotReloadPatchStateChanged(true) after the
             // ledger write; registration must already expose this method's shim for retarget.
-            HotReloadShimRegistry.RegisterMethod(
+            HotReloadFileGenerations.RegisterShimMethod(
                 projectRelativePath,
                 resolved.OriginalMethod,
                 new HotReloadShimRegistry.MethodEntry(
@@ -298,7 +297,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 projectRelativePath);
             if (!patchResult.Success)
             {
-                HotReloadShimRegistry.RemoveMethod(resolved.OriginalMethod);
+                HotReloadFileGenerations.RemoveShimMethod(resolved.OriginalMethod);
                 return HotReloadMethodOutcome.Failed(
                     resolved.MethodLabel,
                     patchResult.ErrorMessage,

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadFileGenerations.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadFileGenerations.cs
@@ -6,12 +6,14 @@ using UnityEngine;
 namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 {
     /// <summary>
-    /// The single entry point for starting and resetting a file's hot reload generation state.
+    /// The single entry point for every write to a file's hot reload generation state:
+    /// starting, registering, removing, and resetting.
     /// </summary>
     /// <remarks>
-    /// Why: per-file generation state lives in two registries that must start and reset together.
-    /// Routing both through one place keeps them in lockstep, and gives the per-assembly grouping
-    /// of the next stage one place to widen from file to group.
+    /// Why: per-file generation state lives in two registries that must move in lockstep, and
+    /// only writes can take them out of step. Reads stay on the registries; routing every write
+    /// through one place keeps the two sides consistent, and gives the per-assembly grouping of
+    /// the next stage one place to widen from file to group.
     /// Static because the registries it fronts are static; it adds no state of its own.
     /// </remarks>
     internal static class HotReloadFileGenerations
@@ -33,6 +35,62 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 pdbBytes,
                 loadedAssembly);
             HotReloadAddedMemberRegistry.BeginFileGeneration(projectRelativePath);
+        }
+
+        /// <summary>
+        /// Starts a new added-member generation for one file, leaving its shim generation alone.
+        /// </summary>
+        /// <remarks>
+        /// Why not BeginFileGeneration: a file that contributed no body to the shim assembly has
+        /// no bytes to register a shim generation with. Only the added-member side has stale rows
+        /// to drop, so this is the one write that must not move the two registries together.
+        /// </remarks>
+        internal static void BeginAddedMemberOnlyGeneration(string projectRelativePath)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(projectRelativePath), "projectRelativePath must not be empty.");
+
+            HotReloadAddedMemberRegistry.BeginFileGeneration(projectRelativePath);
+        }
+
+        /// <summary>
+        /// Records an added method's shim in the file's current added-member generation.
+        /// </summary>
+        internal static void RegisterAddedMethod(
+            string projectRelativePath,
+            string methodKey,
+            MethodInfo shimMethod,
+            string filePath)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(projectRelativePath), "projectRelativePath must not be empty.");
+
+            HotReloadAddedMemberRegistry.Register(
+                projectRelativePath,
+                methodKey,
+                shimMethod,
+                filePath);
+        }
+
+        /// <summary>
+        /// Records a patched method's shim in the file's current shim generation.
+        /// </summary>
+        internal static void RegisterShimMethod(
+            string projectRelativePath,
+            MethodBase originalMethod,
+            HotReloadShimRegistry.MethodEntry entry)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(projectRelativePath), "projectRelativePath must not be empty.");
+
+            HotReloadShimRegistry.RegisterMethod(projectRelativePath, originalMethod, entry);
+        }
+
+        /// <summary>
+        /// Removes one method's shim from every file generation, keeping the generations.
+        /// </summary>
+        internal static void RemoveShimMethod(MethodBase originalMethod)
+        {
+            Debug.Assert(originalMethod != null, "originalMethod must not be null.");
+
+            HotReloadShimRegistry.RemoveMethod(originalMethod);
         }
 
         /// <summary>

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadPatcher.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadPatcher.cs
@@ -257,7 +257,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 return HotReloadRevertOutcome.NotPatched;
             }
 
-            HotReloadShimRegistry.RemoveMethod(method);
+            HotReloadFileGenerations.RemoveShimMethod(method);
             string methodKey = HotReloadMethodKeys.FormatMethodLabel(method);
             HotReloadInvocationRegistry.Remove(methodKey);
             // Why here, not only RevertAll: RevertUnchangedPatches uses this path, and a


### PR DESCRIPTION
## Summary
- Every write to a file's hot-reload generation state now goes through one facade instead of reaching the two underlying registries directly from five call sites.
- No user-visible change: same order, same arguments, same failure paths.

## User Impact
- Before and after: identical CLI output. The two registries that hold a file's generation state have to move in lockstep, and only writes can take them out of step; this closes the five ways a write could touch one side without the other.

## Changes
- `HotReloadFileGenerations` gains `BeginAddedMemberOnlyGeneration`, `RegisterAddedMethod`, `RegisterShimMethod`, and `RemoveShimMethod`. Its summary now states that it owns every write; reads stay on the registries.
- The reason a file with no shim bytes starts only the added-member side moved onto the facade method, where the decision now lives.
- The five call sites in the entry applier and the patcher call the facade.
- New `HotReloadFileGenerationsTests` covers the four writes.

## Verification
- `uloop run-tests --skip-compile --filter-type regex --filter-value "HotReloadAssemblyResolutionDiagnosticsTests|HotReloadFileGenerationsTests|HotReloadShimRegistryTests|HotReloadAddedMemberRegistryTests|HotReloadPatcherTests|HotReloadOrchestratorTests|HotReloadCrossFileE2ETests|HotReloadGroupProcessorTests"` -> 238 passed, 0 failed.
- Red confirmed for three of the four tests: making the added-member-only start replace the shim generation, dropping one registry from the reset, and emptying the shim removal each fail exactly the test that covers them (3 failed / 1 passed).
- A generation probe alone cannot catch those breaks, so each test reads the generation's recorded contents instead.
- `scripts/check-code-complexity.sh` -> 0 issues, no CA1502 findings. `scripts/check-file-length.sh` -> no files over the limit.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2725?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

