### PR TITLE
chore: Reset the hot-reload domain-scoped stores from one place

### DIFF
--- a/Assets/Tests/Editor/HotReload/HotReloadDomainStoresTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadDomainStoresTests.cs
@@ -1,0 +1,82 @@
+using System.IO;
+using System.Reflection;
+
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
+{
+    /// <summary>
+    /// EditMode coverage for the domain-scoped store reset a full revert runs.
+    /// </summary>
+    public class HotReloadDomainStoresTests
+    {
+        private const string FixtureProjectRelativePath =
+            "Assets/Tests/Editor/HotReload/DomainStoresFixture.cs";
+        private const string FixtureMethodKey = "DomainStoresFixture.AddedMember()";
+        private const string SupersededMethodKey = "DomainStoresFixture.Superseded()";
+
+        [TearDown]
+        public void TearDown()
+        {
+            HotReloadPatcher.RevertAll();
+        }
+
+        /// <summary>
+        /// What: the reset empties every domain-scoped store, each checked on its own line so a
+        /// single missed store cannot hide behind the others.
+        /// </summary>
+        [Test]
+        public void ResetForRevertAll_EmptiesEveryDomainScopedStore()
+        {
+            string staticFieldKey = HotReloadAddedFieldStore.FormatFieldKey("DomainStoresHost", "seed");
+            FillEveryStore(staticFieldKey);
+
+            HotReloadDomainStores.ResetForRevertAll();
+
+            Assert.That(HotReloadAddedMemberRegistry.HasGeneration(FixtureProjectRelativePath), Is.False);
+            Assert.That(
+                HotReloadAddedFieldStore.GetOrInitStatic(staticFieldKey, () => 20),
+                Is.EqualTo(20));
+            Assert.That(HotReloadAddedFieldRegistry.DescribeAll(), Is.Empty);
+            Assert.That(HotReloadInvocationRegistry.GetCount(FixtureMethodKey), Is.EqualTo(0));
+            Assert.That(HotReloadAppliedSourceLedger.TryGet(FixtureProjectRelativePath), Is.Null);
+            Assert.That(
+                HotReloadSupersededSignatureRegistry.TryGetReplacement(
+                    SupersededMethodKey,
+                    out string _),
+                Is.False);
+        }
+
+        private static void FillEveryStore(string staticFieldKey)
+        {
+            Assembly assembly = typeof(HotReloadDomainStoresTests).Assembly;
+            HotReloadFileGenerations.BeginFileGeneration(
+                FixtureProjectRelativePath,
+                File.ReadAllBytes(assembly.Location),
+                null,
+                assembly);
+            HotReloadAddedMemberRegistry.Register(
+                FixtureProjectRelativePath,
+                FixtureMethodKey,
+                typeof(HotReloadDomainStoresTests).GetMethod(
+                    nameof(AddedTarget),
+                    BindingFlags.Static | BindingFlags.NonPublic),
+                FixtureProjectRelativePath);
+            HotReloadAddedFieldStore.SetStatic(staticFieldKey, 2);
+            HotReloadAddedFieldRegistry.ReplaceForFile(
+                FixtureProjectRelativePath,
+                new[] { "DomainStoresHost.count" });
+            HotReloadInvocationRegistry.Increment(FixtureMethodKey);
+            HotReloadAppliedSourceLedger.Record(FixtureProjectRelativePath, "hash", true);
+            HotReloadSupersededSignatureRegistry.Record(SupersededMethodKey, "Superseded(int)");
+        }
+
+        private static int AddedTarget()
+        {
+            return 1;
+        }
+    }
+}

--- a/Assets/Tests/Editor/HotReload/HotReloadDomainStoresTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadDomainStoresTests.cs
@@ -58,7 +58,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 File.ReadAllBytes(assembly.Location),
                 null,
                 assembly);
-            HotReloadAddedMemberRegistry.Register(
+            HotReloadFileGenerations.RegisterAddedMethod(
                 FixtureProjectRelativePath,
                 FixtureMethodKey,
                 typeof(HotReloadDomainStoresTests).GetMethod(

--- a/Assets/Tests/Editor/HotReload/HotReloadDomainStoresTests.cs.meta
+++ b/Assets/Tests/Editor/HotReload/HotReloadDomainStoresTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ca80b9f272a1f4ef89f67e8e0d7adc1a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/HotReload/HotReloadPatcherTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadPatcherTests.cs
@@ -133,6 +133,23 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
+        /// What: RevertAll runs the domain-scoped store reset, so no change stays counted and
+        /// no added field stays described.
+        /// </summary>
+        [Test]
+        public void RevertAll_RunsTheDomainStoreReset()
+        {
+            HotReloadAddedFieldRegistry.ReplaceForFile(
+                "Assets/Tests/Editor/HotReload/PatcherResetHost.cs",
+                new[] { "PatcherResetHost.count" });
+
+            HotReloadPatcher.RevertAll();
+
+            Assert.That(HotReloadPatcher.ActiveChangeCount, Is.EqualTo(0));
+            Assert.That(HotReloadAddedFieldRegistry.DescribeAll(), Is.Empty);
+        }
+
+        /// <summary>
         /// What: DescribeActivePatches lists the patched fixture method after Apply and is empty
         /// after RevertAll.
         /// </summary>

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadDomainStores.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadDomainStores.cs
@@ -1,0 +1,34 @@
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// The domain-scoped stores a full revert empties, reset as one step.
+    /// </summary>
+    /// <remarks>
+    /// Why one place: a revert-all has to leave the same state a Domain Reload would, so it must
+    /// empty every store whose contents only make sense within the current domain. A new
+    /// domain-scoped store belongs in this method; adding one and forgetting the revert path is
+    /// the failure this exists to prevent.
+    /// Why HotReloadIntroducedTypeRegistry is not here: an introduced type's identity is fixed
+    /// until the next Domain Reload, so a revert cannot drop it (docs/hot-reload-introduced-types.md).
+    /// Why HotReloadPlayModeEntryDropLedger is not here: it lives on SessionState, and
+    /// HotReloadStatusExecutor.ExecuteRevertAll clears it through NotifyRevertAll.
+    /// Static because the stores it fronts are static; it adds no state of its own.
+    /// </remarks>
+    internal static class HotReloadDomainStores
+    {
+        /// <summary>
+        /// Empties every domain-scoped store. Paired with a full revert.
+        /// </summary>
+        internal static void ResetForRevertAll()
+        {
+            HotReloadFileGenerations.ClearAll();
+            HotReloadAddedFieldStore.Clear();
+            HotReloadAddedFieldRegistry.ClearAll();
+            HotReloadInvocationRegistry.Clear();
+            HotReloadAppliedSourceLedger.ClearAll();
+            HotReloadSupersededSignatureRegistry.ClearAll();
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadDomainStores.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadDomainStores.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8bb0f889aea2e4e18915e2b473ea3854
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadPatcher.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadPatcher.cs
@@ -203,8 +203,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         }
 
         /// <summary>
-        /// Removes every hot-reload patch owned by this patcher and clears the patch,
-        /// added-member, and applied-source ledgers.
+        /// Removes every hot-reload patch owned by this patcher and clears every
+        /// domain-scoped store.
         /// </summary>
         public static void RevertAll()
         {
@@ -215,12 +215,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             // so GetActiveShimForMethod / GetShimLookupForFile agree during rebuild.
             List<MethodBase> revertedMethods = Ledger.ListMethods();
             Ledger.Clear();
-            HotReloadFileGenerations.ClearAll();
-            HotReloadAddedFieldStore.Clear();
-            HotReloadAddedFieldRegistry.ClearAll();
-            HotReloadInvocationRegistry.Clear();
-            HotReloadAppliedSourceLedger.ClearAll();
-            HotReloadSupersededSignatureRegistry.ClearAll();
+            HotReloadDomainStores.ResetForRevertAll();
             _pendingShimMethod = null;
             _pendingOriginalMethod = null;
             HarmonyInstance.UnpatchAll(HotReloadConstants.HarmonyId);


### PR DESCRIPTION
## Summary
- A full hot-reload revert now empties its domain-scoped stores from one named place instead of listing six resets inline.
- No user-visible change: the same stores are emptied in the same order at the same point in the revert.

## User Impact
- Before and after: identical CLI output. A revert has to leave the state a Domain Reload would; the set it must empty is now written down where the next domain-scoped store gets added, instead of only inside the patcher.

## Changes
- New `HotReloadDomainStores.ResetForRevertAll` holds the six resets in their original order and records why the introduced-type registry and the Play-mode entry drop ledger are deliberately not among them.
- `HotReloadPatcher.RevertAll` calls it in the place the six lines occupied; the surrounding ordering and its explanation are unchanged.
- New `HotReloadDomainStoresTests` asserts each store on its own line, so a reset that misses one fails on that line. A new patcher test pins that `RevertAll` still runs the reset.

## Verification
- `uloop run-tests --skip-compile --filter-type regex --filter-value "HotReloadAssemblyResolutionDiagnosticsTests|HotReloadDomainStoresTests|HotReloadPatcherTests|HotReloadShimRegistryTests|HotReloadAddedFieldRegistryTests|HotReloadSupersededSignatureRegistryTests|HotReloadToolTests|HotReloadOrchestratorTests|HotReloadFileGenerationsTests"` -> 261 passed, 0 failed (rebased onto the current base).
- Red confirmed both ways: dropping the superseded-signature reset fails exactly that one assertion line, and removing the reset call from `RevertAll` fails the new patcher test.
- `scripts/check-code-complexity.sh` -> 0 issues, no CA1502 findings. `scripts/check-file-length.sh` -> no files over the limit.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2726?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

