### PR TITLE
chore: Split the hot-reload orchestrator into four concerns

### DIFF
--- a/Assets/Tests/Editor/HotReload/HotReloadGroupProcessorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadGroupProcessorTests.cs
@@ -318,7 +318,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             List<(int InputIndex, string AssemblyName, string ProjectRelativePath)> plannerInput =
                 new List<(int InputIndex, string AssemblyName, string ProjectRelativePath)>();
 
-            HotReloadOrchestrator.ResolveInputFile(
+            new HotReloadInputFileResolver().ResolveInputFile(
                 MissingNewSourcePath,
                 0,
                 null,

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadDeferredInputClassifier.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadDeferredInputClassifier.cs
@@ -1,0 +1,119 @@
+using System;
+using System.Collections.Generic;
+
+using UnityEngine;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Decides which group plans hold nothing but inputs that were short-circuited as already
+    /// active, and fills those inputs' results once the changed groups have run.
+    /// </summary>
+    internal sealed class HotReloadDeferredInputClassifier
+    {
+        internal IReadOnlyList<HotReloadDeferredInputPlan> ClassifyAllDeferredPlans(
+            IReadOnlyList<HotReloadFileGroupPlan> plans,
+            HotReloadInputResolutionSlot[] slots)
+        {
+            Debug.Assert(plans != null, "plans must not be null.");
+            Debug.Assert(slots != null, "slots must not be null.");
+
+            List<HotReloadDeferredInputPlan> classified = new List<HotReloadDeferredInputPlan>(plans.Count);
+            for (int planIndex = 0; planIndex < plans.Count; planIndex++)
+            {
+                classified.Add(
+                    new HotReloadDeferredInputPlan(
+                        planIndex,
+                        AreAllInputsDeferredAlreadyActive(plans[planIndex], slots)));
+            }
+
+            return classified;
+        }
+
+        // Why every all-deferred plan of the assembly: a repeated path can open an
+        // all-deferred plan before the last changed group, and that plan can hold a
+        // caller that sibling auto-include cannot add because it is already in pathsInRun.
+        internal void AppendUniqueDeferredInputIndexes(
+            IReadOnlyList<HotReloadFileGroupPlan> plans,
+            IReadOnlyList<HotReloadDeferredInputPlan> classified,
+            int currentPlanIndex,
+            HotReloadInputResolutionSlot[] slots,
+            List<int> inputIndexes)
+        {
+            Debug.Assert(plans != null, "plans must not be null.");
+            Debug.Assert(classified != null, "classified must not be null.");
+            Debug.Assert(slots != null, "slots must not be null.");
+            Debug.Assert(inputIndexes != null, "inputIndexes must not be null.");
+
+            string assemblyName = plans[currentPlanIndex].AssemblyName;
+            HashSet<string> pathsInGroup = new HashSet<string>(
+                HotReloadSourcePathNormalizer.ProjectRelativePathComparer());
+            for (int position = 0; position < inputIndexes.Count; position++)
+            {
+                pathsInGroup.Add(slots[inputIndexes[position]].GroupFile.ProjectRelativePath);
+            }
+
+            for (int planIndex = 0; planIndex < plans.Count; planIndex++)
+            {
+                if (planIndex == currentPlanIndex
+                    || !classified[planIndex].IsAllDeferred
+                    || !string.Equals(
+                        plans[planIndex].AssemblyName,
+                        assemblyName,
+                        StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                IReadOnlyList<int> deferredIndexes = plans[planIndex].InputIndexes;
+                for (int deferredPosition = 0; deferredPosition < deferredIndexes.Count; deferredPosition++)
+                {
+                    int inputIndex = deferredIndexes[deferredPosition];
+                    string path = slots[inputIndex].GroupFile.ProjectRelativePath;
+                    if (pathsInGroup.Add(path))
+                    {
+                        inputIndexes.Add(inputIndex);
+                    }
+                }
+            }
+        }
+
+        internal void ApplyDeferredAlreadyActive(
+            HotReloadFileGroupPlan plan,
+            HotReloadInputResolutionSlot[] slots)
+        {
+            foreach (int inputIndex in plan.InputIndexes)
+            {
+                HotReloadInputResolutionSlot slot = slots[inputIndex];
+                if (slot.Result != null)
+                {
+                    continue;
+                }
+
+                Debug.Assert(
+                    slot.DeferredAlreadyActive != null,
+                    "An unfilled deferred slot must have AlreadyActive rows.");
+                slot.GroupFile.Sinks.Outcomes.AddRange(slot.DeferredAlreadyActive);
+                slot.Result = new HotReloadFileProcessResult(
+                    slot.GroupFile.Sinks.Outcomes,
+                    slot.GroupFile.Sinks.Warnings,
+                    0);
+            }
+        }
+
+        private bool AreAllInputsDeferredAlreadyActive(
+            HotReloadFileGroupPlan plan,
+            HotReloadInputResolutionSlot[] slots)
+        {
+            foreach (int inputIndex in plan.InputIndexes)
+            {
+                if (slots[inputIndex].DeferredAlreadyActive == null)
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadDeferredInputClassifier.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadDeferredInputClassifier.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c278637f78fbb43c1ba9b080e9cca4ec
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadDeferredInputPlan.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadDeferredInputPlan.cs
@@ -1,0 +1,18 @@
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// One group plan's deferred classification: whether every input of that plan was
+    /// short-circuited as already active.
+    /// </summary>
+    internal readonly struct HotReloadDeferredInputPlan
+    {
+        internal HotReloadDeferredInputPlan(int planIndex, bool isAllDeferred)
+        {
+            PlanIndex = planIndex;
+            IsAllDeferred = isAllDeferred;
+        }
+
+        internal int PlanIndex { get; }
+        internal bool IsAllDeferred { get; }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadDeferredInputPlan.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadDeferredInputPlan.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7906d9766bcaa42b08ed2fd118de53b2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadInputFileResolver.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadInputFileResolver.cs
@@ -1,0 +1,113 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Resolves one input path's patch target and the source file the worker reads for it.
+    /// </summary>
+    internal sealed class HotReloadInputFileResolver
+    {
+        // Resolves one input path's patch target and either records its early result or enrolls
+        // it in the group plan.
+        internal void ResolveInputFile(
+            string filePath,
+            int index,
+            string contentPathOverride,
+            IReadOnlyDictionary<string, string> contentPathOverrideByFile,
+            string correlationId,
+            HotReloadRunAccumulator run,
+            HotReloadInputResolutionSlot slot,
+            List<(int InputIndex, string AssemblyName, string ProjectRelativePath)> plannerInput)
+        {
+            string workerSourcePath = ResolveWorkerSourcePath(
+                filePath,
+                contentPathOverride,
+                contentPathOverrideByFile);
+            HotReloadFileSinks sinks = new HotReloadFileSinks(
+                run.SiblingDerivedWarnings,
+                run.OneShotCallerNoteCandidates);
+            List<HotReloadMethodOutcome> alreadyActiveOutcomes = new List<HotReloadMethodOutcome>();
+
+            HotReloadPatchTargetResolution resolution = HotReloadPatchTargetSupport.ResolvePatchTarget(
+                filePath,
+                workerSourcePath,
+                sinks.Outcomes,
+                sinks.Warnings,
+                correlationId,
+                alreadyActiveOutcomes);
+            if (resolution.IsEarlyExit)
+            {
+                slot.Result = resolution.EarlyResult;
+                slot.ResultPath = HotReloadPatchTargetSupport.ToProjectRelativeScriptPath(filePath);
+                return;
+            }
+
+            if (resolution.UnchangedDecision == HotReloadUnchangedSourceDecision.ShortCircuited)
+            {
+                slot.DeferredAlreadyActive = alreadyActiveOutcomes;
+            }
+
+            slot.GroupFile = new HotReloadGroupFile(
+                filePath,
+                workerSourcePath,
+                resolution.ProjectRelativePath,
+                resolution.AssemblyName,
+                resolution.CompilationAssembly,
+                resolution.TargetDllPath,
+                resolution.ProjectRoot,
+                sinks,
+                resolution.NewSourceMembershipEvidence);
+            slot.ResultPath = resolution.ProjectRelativePath;
+            plannerInput.Add((index, resolution.AssemblyName, resolution.ProjectRelativePath));
+        }
+
+        internal string ResolveSiblingWorkerSourcePath(
+            string projectRelativePath,
+            string projectRoot,
+            IReadOnlyDictionary<string, string> overrideByFile)
+        {
+            if (overrideByFile != null)
+            {
+                StringComparer comparer = HotReloadSourcePathNormalizer.ProjectRelativePathComparer();
+                foreach (KeyValuePair<string, string> pair in overrideByFile)
+                {
+                    string keyRelative = HotReloadPatchTargetSupport.ToProjectRelativeScriptPath(pair.Key);
+                    if (comparer.Equals(keyRelative, projectRelativePath))
+                    {
+                        return Path.GetFullPath(pair.Value);
+                    }
+                }
+            }
+
+            return Path.GetFullPath(
+                Path.Combine(
+                    projectRoot,
+                    projectRelativePath.Replace('/', Path.DirectorySeparatorChar)));
+        }
+
+        // Why keyed by path (not by index): one contentPathOverride cannot feed two edited
+        // copies, and a positional list would silently misalign once files are grouped or
+        // reordered before the worker runs.
+        private string ResolveWorkerSourcePath(
+            string filePath,
+            string contentPathOverride,
+            IReadOnlyDictionary<string, string> contentPathOverrideByFile)
+        {
+            if (contentPathOverrideByFile != null
+                && contentPathOverrideByFile.TryGetValue(filePath, out string perFileOverride)
+                && !string.IsNullOrEmpty(perFileOverride))
+            {
+                return perFileOverride;
+            }
+
+            if (string.IsNullOrEmpty(contentPathOverride))
+            {
+                return filePath;
+            }
+
+            return contentPathOverride;
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadInputFileResolver.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadInputFileResolver.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 41d07c7187a114026b367e94a684f2dd
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading;
@@ -8,8 +7,6 @@ using UnityEngine;
 
 using io.github.hatayama.UnityCliLoop.ToolContracts;
 
-using UnityCompilationAssembly = UnityEditor.Compilation.Assembly;
-
 namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 {
     /// <summary>
@@ -18,6 +15,16 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     /// </summary>
     internal static class HotReloadOrchestrator
     {
+        // Why static holders: these collaborators carry no state, and the orchestrator is itself
+        // static in this stage, so there is nothing to inject them into yet. PR-6 turns the
+        // orchestrator into an instance and takes all three through its constructor.
+        private static readonly HotReloadInputFileResolver InputFileResolver =
+            new HotReloadInputFileResolver();
+        private static readonly HotReloadDeferredInputClassifier DeferredInputClassifier =
+            new HotReloadDeferredInputClassifier();
+        private static readonly HotReloadSiblingRebindReporter SiblingRebindReporter =
+            new HotReloadSiblingRebindReporter();
+
         /// <summary>
         /// Runs hot reload for each path in <paramref name="files"/>.
         /// <paramref name="contentPathOverride"/> is test-only: when set, the worker reads that
@@ -58,7 +65,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             for (int index = 0; index < files.Count; index++)
             {
                 ct.ThrowIfCancellationRequested();
-                ResolveInputFile(
+                InputFileResolver.ResolveInputFile(
                     files[index],
                     index,
                     contentPathOverride,
@@ -80,7 +87,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 }
             }
 
-            bool[] allDeferred = ClassifyAllDeferredPlans(plans, slots);
+            IReadOnlyList<HotReloadDeferredInputPlan> classifiedPlans =
+                DeferredInputClassifier.ClassifyAllDeferredPlans(plans, slots);
 
             List<(string Path, HotReloadFileProcessResult Result)> extraResults =
                 new List<(string Path, HotReloadFileProcessResult Result)>();
@@ -88,18 +96,21 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             {
                 ct.ThrowIfCancellationRequested();
                 HotReloadFileGroupPlan plan = plans[planIndex];
-                if (allDeferred[planIndex])
+                if (classifiedPlans[planIndex].IsAllDeferred)
                 {
                     continue;
                 }
 
-                bool isLastChangedGroup = IsLastChangedPlanForAssembly(plans, allDeferred, planIndex);
+                bool isLastChangedGroup = SiblingRebindReporter.IsLastChangedPlanForAssembly(
+                    plans,
+                    classifiedPlans,
+                    planIndex);
                 List<int> inputIndexes = new List<int>(plan.InputIndexes);
                 if (isLastChangedGroup)
                 {
-                    AppendUniqueDeferredInputIndexes(
+                    DeferredInputClassifier.AppendUniqueDeferredInputIndexes(
                         plans,
-                        allDeferred,
+                        classifiedPlans,
                         planIndex,
                         slots,
                         inputIndexes);
@@ -122,9 +133,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             // slots before the last changed group can absorb its unique callers.
             for (int planIndex = 0; planIndex < plans.Count; planIndex++)
             {
-                if (allDeferred[planIndex])
+                if (classifiedPlans[planIndex].IsAllDeferred)
                 {
-                    ApplyDeferredAlreadyActive(plans[planIndex], slots);
+                    DeferredInputClassifier.ApplyDeferredAlreadyActive(plans[planIndex], slots);
                 }
             }
 
@@ -148,162 +159,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return run.BuildResult(correlationId);
         }
 
-        // Resolves one input path's patch target and either records its early result or enrolls
-        // it in the group plan.
-        internal static void ResolveInputFile(
-            string filePath,
-            int index,
-            string contentPathOverride,
-            IReadOnlyDictionary<string, string> contentPathOverrideByFile,
-            string correlationId,
-            HotReloadRunAccumulator run,
-            HotReloadInputResolutionSlot slot,
-            List<(int InputIndex, string AssemblyName, string ProjectRelativePath)> plannerInput)
-        {
-            string workerSourcePath = ResolveWorkerSourcePath(
-                filePath,
-                contentPathOverride,
-                contentPathOverrideByFile);
-            HotReloadFileSinks sinks = new HotReloadFileSinks(
-                run.SiblingDerivedWarnings,
-                run.OneShotCallerNoteCandidates);
-            List<HotReloadMethodOutcome> alreadyActiveOutcomes = new List<HotReloadMethodOutcome>();
-
-            HotReloadPatchTargetResolution resolution = HotReloadPatchTargetSupport.ResolvePatchTarget(
-                filePath,
-                workerSourcePath,
-                sinks.Outcomes,
-                sinks.Warnings,
-                correlationId,
-                alreadyActiveOutcomes);
-            if (resolution.IsEarlyExit)
-            {
-                slot.Result = resolution.EarlyResult;
-                slot.ResultPath = HotReloadPatchTargetSupport.ToProjectRelativeScriptPath(filePath);
-                return;
-            }
-
-            if (resolution.UnchangedDecision == HotReloadUnchangedSourceDecision.ShortCircuited)
-            {
-                slot.DeferredAlreadyActive = alreadyActiveOutcomes;
-            }
-
-            slot.GroupFile = new HotReloadGroupFile(
-                filePath,
-                workerSourcePath,
-                resolution.ProjectRelativePath,
-                resolution.AssemblyName,
-                resolution.CompilationAssembly,
-                resolution.TargetDllPath,
-                resolution.ProjectRoot,
-                sinks,
-                resolution.NewSourceMembershipEvidence);
-            slot.ResultPath = resolution.ProjectRelativePath;
-            plannerInput.Add((index, resolution.AssemblyName, resolution.ProjectRelativePath));
-        }
-
-        private static bool[] ClassifyAllDeferredPlans(
-            IReadOnlyList<HotReloadFileGroupPlan> plans,
-            HotReloadInputResolutionSlot[] slots)
-        {
-            Debug.Assert(plans != null, "plans must not be null.");
-            Debug.Assert(slots != null, "slots must not be null.");
-
-            bool[] allDeferred = new bool[plans.Count];
-            for (int planIndex = 0; planIndex < plans.Count; planIndex++)
-            {
-                allDeferred[planIndex] = AreAllInputsDeferredAlreadyActive(plans[planIndex], slots);
-            }
-
-            return allDeferred;
-        }
-
-        private static bool AreAllInputsDeferredAlreadyActive(
-            HotReloadFileGroupPlan plan,
-            HotReloadInputResolutionSlot[] slots)
-        {
-            foreach (int inputIndex in plan.InputIndexes)
-            {
-                if (slots[inputIndex].DeferredAlreadyActive == null)
-                {
-                    return false;
-                }
-            }
-
-            return true;
-        }
-
-        // Why every all-deferred plan of the assembly: a repeated path can open an
-        // all-deferred plan before the last changed group, and that plan can hold a
-        // caller that sibling auto-include cannot add because it is already in pathsInRun.
-        private static void AppendUniqueDeferredInputIndexes(
-            IReadOnlyList<HotReloadFileGroupPlan> plans,
-            bool[] allDeferred,
-            int currentPlanIndex,
-            HotReloadInputResolutionSlot[] slots,
-            List<int> inputIndexes)
-        {
-            Debug.Assert(plans != null, "plans must not be null.");
-            Debug.Assert(allDeferred != null, "allDeferred must not be null.");
-            Debug.Assert(slots != null, "slots must not be null.");
-            Debug.Assert(inputIndexes != null, "inputIndexes must not be null.");
-
-            string assemblyName = plans[currentPlanIndex].AssemblyName;
-            HashSet<string> pathsInGroup = new HashSet<string>(
-                HotReloadSourcePathNormalizer.ProjectRelativePathComparer());
-            for (int position = 0; position < inputIndexes.Count; position++)
-            {
-                pathsInGroup.Add(slots[inputIndexes[position]].GroupFile.ProjectRelativePath);
-            }
-
-            for (int planIndex = 0; planIndex < plans.Count; planIndex++)
-            {
-                if (planIndex == currentPlanIndex
-                    || !allDeferred[planIndex]
-                    || !string.Equals(
-                        plans[planIndex].AssemblyName,
-                        assemblyName,
-                        StringComparison.Ordinal))
-                {
-                    continue;
-                }
-
-                IReadOnlyList<int> deferredIndexes = plans[planIndex].InputIndexes;
-                for (int deferredPosition = 0; deferredPosition < deferredIndexes.Count; deferredPosition++)
-                {
-                    int inputIndex = deferredIndexes[deferredPosition];
-                    string path = slots[inputIndex].GroupFile.ProjectRelativePath;
-                    if (pathsInGroup.Add(path))
-                    {
-                        inputIndexes.Add(inputIndex);
-                    }
-                }
-            }
-        }
-
-        private static void ApplyDeferredAlreadyActive(
-            HotReloadFileGroupPlan plan,
-            HotReloadInputResolutionSlot[] slots)
-        {
-            foreach (int inputIndex in plan.InputIndexes)
-            {
-                HotReloadInputResolutionSlot slot = slots[inputIndex];
-                if (slot.Result != null)
-                {
-                    continue;
-                }
-
-                Debug.Assert(
-                    slot.DeferredAlreadyActive != null,
-                    "An unfilled deferred slot must have AlreadyActive rows.");
-                slot.GroupFile.Sinks.Outcomes.AddRange(slot.DeferredAlreadyActive);
-                slot.Result = new HotReloadFileProcessResult(
-                    slot.GroupFile.Sinks.Outcomes,
-                    slot.GroupFile.Sinks.Warnings,
-                    0);
-            }
-        }
-
         private static async Task ProcessPlannedGroupAsync(
             IReadOnlyList<int> inputIndexes,
             HotReloadInputResolutionSlot[] slots,
@@ -325,7 +180,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             int inputCount = inputIndexes.Count;
             if (isLastGroupOfAssembly)
             {
-                AppendActiveSiblingsToGroup(filesOfGroup, pathsInRun, contentPathOverrideByFile, run);
+                SiblingRebindReporter.AppendActiveSiblingsToGroup(
+                    filesOfGroup,
+                    pathsInRun,
+                    contentPathOverrideByFile,
+                    run,
+                    InputFileResolver);
             }
 
             // Why ConfigureAwait(false): UnityCliLoopTool forbids capturing Unity's
@@ -351,203 +211,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             if (isLastGroupOfAssembly)
             {
-                AddSiblingRebindResultWarnings(filesOfGroup, inputCount, groupResults);
+                SiblingRebindReporter.AddSiblingRebindResultWarnings(
+                    filesOfGroup,
+                    inputCount,
+                    groupResults);
             }
-        }
-
-        private static void AppendActiveSiblingsToGroup(
-            List<HotReloadGroupFile> filesOfGroup,
-            HashSet<string> pathsInRun,
-            IReadOnlyDictionary<string, string> contentPathOverrideByFile,
-            HotReloadRunAccumulator run)
-        {
-            HotReloadGroupFile firstFile = filesOfGroup[0];
-            HotReloadActiveSiblingRebindPlan rebind = HotReloadActiveSiblingRebindPlanner.Plan(
-                firstFile.AssemblyName,
-                firstFile.CompilationAssembly.sourceFiles,
-                pathsInRun,
-                path => ResolveSiblingWorkerSourcePath(
-                    path,
-                    firstFile.ProjectRoot,
-                    contentPathOverrideByFile));
-            IReadOnlyList<(string ProjectRelativePath, string WorkerSourcePath)> filesToInclude =
-                rebind.FilesToInclude;
-            for (int index = 0; index < filesToInclude.Count; index++)
-            {
-                filesOfGroup.Add(
-                    HotReloadGroupFile.ForActiveSibling(
-                        firstFile,
-                        filesToInclude[index].ProjectRelativePath,
-                        filesToInclude[index].WorkerSourcePath,
-                        new HotReloadFileSinks(run.SiblingDerivedWarnings, run.OneShotCallerNoteCandidates)));
-            }
-
-            AddChangedSinceApplyWarnings(firstFile, rebind);
-        }
-
-        private static void AddChangedSinceApplyWarnings(
-            HotReloadGroupFile firstFile,
-            HotReloadActiveSiblingRebindPlan rebind)
-        {
-            IReadOnlyList<string> changedSinceApplyPaths = rebind.ChangedSinceApplyPaths;
-            for (int index = 0; index < changedSinceApplyPaths.Count; index++)
-            {
-                firstFile.Sinks.Warnings.Add(
-                    string.Format(
-                        HotReloadConstants.ActiveSiblingChangedSinceApplyWarningFormat,
-                        changedSinceApplyPaths[index]));
-            }
-        }
-
-        private static void AddSiblingRebindResultWarnings(
-            List<HotReloadGroupFile> filesOfGroup,
-            int inputCount,
-            IReadOnlyList<HotReloadFileProcessResult> groupResults)
-        {
-            Debug.Assert(filesOfGroup != null, "filesOfGroup must not be null.");
-            Debug.Assert(groupResults != null, "groupResults must not be null.");
-            Debug.Assert(
-                groupResults.Count == filesOfGroup.Count,
-                "Rebind warnings need one result per group file.");
-            Debug.Assert(groupResults.Count > 0, "A processed group must have a result.");
-
-            List<string> reappliedPaths = new List<string>();
-            for (int position = inputCount; position < filesOfGroup.Count; position++)
-            {
-                string path = filesOfGroup[position].ProjectRelativePath;
-                if (ShouldDescribeSiblingAsReapplied(groupResults[position]))
-                {
-                    reappliedPaths.Add(path);
-                }
-                else if (groupResults[position].Outcomes.Count == 0)
-                {
-                    // A run stopped before it applied anything wrote no row for this file, so
-                    // the failed-rebind sentence would send the reader looking for rows that
-                    // were never written.
-                    groupResults[0].Warnings.Add(
-                        string.Format(
-                            HotReloadConstants.ActiveSiblingRebindSkippedWarningFormat,
-                            path));
-                }
-                else
-                {
-                    groupResults[0].Warnings.Add(
-                        string.Format(
-                            HotReloadConstants.ActiveSiblingRebindFailedWarningFormat,
-                            path));
-                }
-            }
-
-            if (reappliedPaths.Count > 0)
-            {
-                groupResults[0].Warnings.Add(
-                    string.Format(
-                        HotReloadConstants.ActiveSiblingsRebindWarningFormat,
-                        reappliedPaths.Count,
-                        filesOfGroup[0].AssemblyName,
-                        string.Join(", ", reappliedPaths)));
-            }
-        }
-
-        // Why not "no Failed row": isolation leaves a sibling as Skipped when its added-method
-        // callee failed to compile, and claiming that file was re-applied would be false.
-        private static bool ShouldDescribeSiblingAsReapplied(HotReloadFileProcessResult result)
-        {
-            Debug.Assert(result != null, "result must not be null.");
-            bool sawApplied = false;
-            foreach (HotReloadMethodOutcome outcome in result.Outcomes)
-            {
-                if (outcome.Kind == HotReloadMethodOutcomeKind.Failed)
-                {
-                    return false;
-                }
-
-                if (outcome.Kind == HotReloadMethodOutcomeKind.Patched
-                    || outcome.Kind == HotReloadMethodOutcomeKind.Added)
-                {
-                    sawApplied = true;
-                }
-            }
-
-            return sawApplied;
-        }
-
-        // Why changed groups only: a trailing all-deferred plan is not the shim that carries
-        // this run's host edits, so auto-include and absorbed callers belong on the last
-        // changed group.
-        private static bool IsLastChangedPlanForAssembly(
-            IReadOnlyList<HotReloadFileGroupPlan> plans,
-            bool[] allDeferred,
-            int planIndex)
-        {
-            Debug.Assert(plans != null, "plans must not be null.");
-            Debug.Assert(allDeferred != null, "allDeferred must not be null.");
-            Debug.Assert(allDeferred.Length == plans.Count, "allDeferred must match plans.");
-            Debug.Assert(planIndex >= 0 && planIndex < plans.Count, "planIndex must be in range.");
-            Debug.Assert(!allDeferred[planIndex], "Last-changed lookup is only for a changed group.");
-
-            string assemblyName = plans[planIndex].AssemblyName;
-            for (int index = planIndex + 1; index < plans.Count; index++)
-            {
-                if (allDeferred[index])
-                {
-                    continue;
-                }
-
-                if (string.Equals(plans[index].AssemblyName, assemblyName, StringComparison.Ordinal))
-                {
-                    return false;
-                }
-            }
-
-            return true;
-        }
-
-        private static string ResolveSiblingWorkerSourcePath(
-            string projectRelativePath,
-            string projectRoot,
-            IReadOnlyDictionary<string, string> overrideByFile)
-        {
-            if (overrideByFile != null)
-            {
-                StringComparer comparer = HotReloadSourcePathNormalizer.ProjectRelativePathComparer();
-                foreach (KeyValuePair<string, string> pair in overrideByFile)
-                {
-                    string keyRelative = HotReloadPatchTargetSupport.ToProjectRelativeScriptPath(pair.Key);
-                    if (comparer.Equals(keyRelative, projectRelativePath))
-                    {
-                        return Path.GetFullPath(pair.Value);
-                    }
-                }
-            }
-
-            return Path.GetFullPath(
-                Path.Combine(
-                    projectRoot,
-                    projectRelativePath.Replace('/', Path.DirectorySeparatorChar)));
-        }
-
-        // Why keyed by path (not by index): one contentPathOverride cannot feed two edited
-        // copies, and a positional list would silently misalign once files are grouped or
-        // reordered before the worker runs.
-        private static string ResolveWorkerSourcePath(
-            string filePath,
-            string contentPathOverride,
-            IReadOnlyDictionary<string, string> contentPathOverrideByFile)
-        {
-            if (contentPathOverrideByFile != null
-                && contentPathOverrideByFile.TryGetValue(filePath, out string perFileOverride)
-                && !string.IsNullOrEmpty(perFileOverride))
-            {
-                return perFileOverride;
-            }
-
-            if (string.IsNullOrEmpty(contentPathOverride))
-            {
-                return filePath;
-            }
-
-            return contentPathOverride;
         }
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadSiblingRebindReporter.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadSiblingRebindReporter.cs
@@ -1,0 +1,165 @@
+using System;
+using System.Collections.Generic;
+
+using UnityEngine;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Adds the active siblings of an assembly to the last changed group and reports how each
+    /// of them came back.
+    /// </summary>
+    internal sealed class HotReloadSiblingRebindReporter
+    {
+        // Why the resolver arrives per call: the reporter holds no collaborator of its own, and
+        // the orchestrator already owns the one resolver this run uses.
+        internal void AppendActiveSiblingsToGroup(
+            List<HotReloadGroupFile> filesOfGroup,
+            HashSet<string> pathsInRun,
+            IReadOnlyDictionary<string, string> contentPathOverrideByFile,
+            HotReloadRunAccumulator run,
+            HotReloadInputFileResolver inputFileResolver)
+        {
+            HotReloadGroupFile firstFile = filesOfGroup[0];
+            HotReloadActiveSiblingRebindPlan rebind = HotReloadActiveSiblingRebindPlanner.Plan(
+                firstFile.AssemblyName,
+                firstFile.CompilationAssembly.sourceFiles,
+                pathsInRun,
+                path => inputFileResolver.ResolveSiblingWorkerSourcePath(
+                    path,
+                    firstFile.ProjectRoot,
+                    contentPathOverrideByFile));
+            IReadOnlyList<(string ProjectRelativePath, string WorkerSourcePath)> filesToInclude =
+                rebind.FilesToInclude;
+            for (int index = 0; index < filesToInclude.Count; index++)
+            {
+                filesOfGroup.Add(
+                    HotReloadGroupFile.ForActiveSibling(
+                        firstFile,
+                        filesToInclude[index].ProjectRelativePath,
+                        filesToInclude[index].WorkerSourcePath,
+                        new HotReloadFileSinks(run.SiblingDerivedWarnings, run.OneShotCallerNoteCandidates)));
+            }
+
+            AddChangedSinceApplyWarnings(firstFile, rebind);
+        }
+
+        internal void AddSiblingRebindResultWarnings(
+            List<HotReloadGroupFile> filesOfGroup,
+            int inputCount,
+            IReadOnlyList<HotReloadFileProcessResult> groupResults)
+        {
+            Debug.Assert(filesOfGroup != null, "filesOfGroup must not be null.");
+            Debug.Assert(groupResults != null, "groupResults must not be null.");
+            Debug.Assert(
+                groupResults.Count == filesOfGroup.Count,
+                "Rebind warnings need one result per group file.");
+            Debug.Assert(groupResults.Count > 0, "A processed group must have a result.");
+
+            List<string> reappliedPaths = new List<string>();
+            for (int position = inputCount; position < filesOfGroup.Count; position++)
+            {
+                string path = filesOfGroup[position].ProjectRelativePath;
+                if (ShouldDescribeSiblingAsReapplied(groupResults[position]))
+                {
+                    reappliedPaths.Add(path);
+                }
+                else if (groupResults[position].Outcomes.Count == 0)
+                {
+                    // A run stopped before it applied anything wrote no row for this file, so
+                    // the failed-rebind sentence would send the reader looking for rows that
+                    // were never written.
+                    groupResults[0].Warnings.Add(
+                        string.Format(
+                            HotReloadConstants.ActiveSiblingRebindSkippedWarningFormat,
+                            path));
+                }
+                else
+                {
+                    groupResults[0].Warnings.Add(
+                        string.Format(
+                            HotReloadConstants.ActiveSiblingRebindFailedWarningFormat,
+                            path));
+                }
+            }
+
+            if (reappliedPaths.Count > 0)
+            {
+                groupResults[0].Warnings.Add(
+                    string.Format(
+                        HotReloadConstants.ActiveSiblingsRebindWarningFormat,
+                        reappliedPaths.Count,
+                        filesOfGroup[0].AssemblyName,
+                        string.Join(", ", reappliedPaths)));
+            }
+        }
+
+        // Why changed groups only: a trailing all-deferred plan is not the shim that carries
+        // this run's host edits, so auto-include and absorbed callers belong on the last
+        // changed group.
+        internal bool IsLastChangedPlanForAssembly(
+            IReadOnlyList<HotReloadFileGroupPlan> plans,
+            IReadOnlyList<HotReloadDeferredInputPlan> classified,
+            int planIndex)
+        {
+            Debug.Assert(plans != null, "plans must not be null.");
+            Debug.Assert(classified != null, "classified must not be null.");
+            Debug.Assert(classified.Count == plans.Count, "classified must match plans.");
+            Debug.Assert(planIndex >= 0 && planIndex < plans.Count, "planIndex must be in range.");
+            Debug.Assert(!classified[planIndex].IsAllDeferred, "Last-changed lookup is only for a changed group.");
+
+            string assemblyName = plans[planIndex].AssemblyName;
+            for (int index = planIndex + 1; index < plans.Count; index++)
+            {
+                if (classified[index].IsAllDeferred)
+                {
+                    continue;
+                }
+
+                if (string.Equals(plans[index].AssemblyName, assemblyName, StringComparison.Ordinal))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        private void AddChangedSinceApplyWarnings(
+            HotReloadGroupFile firstFile,
+            HotReloadActiveSiblingRebindPlan rebind)
+        {
+            IReadOnlyList<string> changedSinceApplyPaths = rebind.ChangedSinceApplyPaths;
+            for (int index = 0; index < changedSinceApplyPaths.Count; index++)
+            {
+                firstFile.Sinks.Warnings.Add(
+                    string.Format(
+                        HotReloadConstants.ActiveSiblingChangedSinceApplyWarningFormat,
+                        changedSinceApplyPaths[index]));
+            }
+        }
+
+        // Why not "no Failed row": isolation leaves a sibling as Skipped when its added-method
+        // callee failed to compile, and claiming that file was re-applied would be false.
+        private bool ShouldDescribeSiblingAsReapplied(HotReloadFileProcessResult result)
+        {
+            Debug.Assert(result != null, "result must not be null.");
+            bool sawApplied = false;
+            foreach (HotReloadMethodOutcome outcome in result.Outcomes)
+            {
+                if (outcome.Kind == HotReloadMethodOutcomeKind.Failed)
+                {
+                    return false;
+                }
+
+                if (outcome.Kind == HotReloadMethodOutcomeKind.Patched
+                    || outcome.Kind == HotReloadMethodOutcomeKind.Added)
+                {
+                    sawApplied = true;
+                }
+            }
+
+            return sawApplied;
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadSiblingRebindReporter.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadSiblingRebindReporter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ab0d8b9581f4c46529b985a4f7d2de9d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary
- No user-visible change. This is an internal restructuring of the hot-reload orchestrator.

## User Impact
- None. Hot-reload behaviour, ordering, warnings and response messages are unchanged.

## Changes
- Input file resolution moves out of the orchestrator into `HotReloadInputFileResolver`.
- Deferred-plan classification moves into `HotReloadDeferredInputClassifier`, and the parallel `bool[]` verdict array becomes `HotReloadDeferredInputPlan` so a plan index and its verdict travel together.
- Sibling rebind reporting moves into `HotReloadSiblingRebindReporter`.
- `HotReloadOrchestrator` keeps only the run flow and the group loop. The three collaborators are held as `private static readonly` fields for now; a later pull request in this series turns the orchestrator into an instance and injects them through its constructor.

## Verification
- `uloop compile`: `ErrorCount 0`.
- `uloop run-tests` over the four affected hot-reload test classes: 257 passed, 0 failed.
- File length: with the threshold set to 400 SLOC, none of the touched files is reported; the repository-wide check exits 0.
- `uloop hot-reload --status` and `--revert-all` responses captured before and after the change are byte-identical.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2728?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

