### PR TITLE
chore: Simplify the hot-reload shim-isolation retry entry point

### DIFF
--- a/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
@@ -5052,11 +5052,11 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 }
             };
 
-            List<HotReloadMethodOutcome> outcomes = HotReloadShimIsolation.CollectRetryOnlySkippedOutcomes(
+            List<HotReloadMethodOutcome> outcomes = new HotReloadIsolationOutcomeBuilder().CollectRetryOnlySkippedOutcomes(
                 Array.Empty<TransformWorkerSkippedDto>(),
                 retrySkipped,
                 HotReloadGroupFilePaths.ForSingleFile("Assets/Scripts/Host.cs", "test.dll"),
-                HotReloadConstants.VibeLogIsolationTriggerShimCompileFailure,
+                new HotReloadShimCompileFailureIsolationTrigger(),
                 new[] { "Host::Broken()" });
 
             Assert.That(outcomes.Count, Is.EqualTo(2));
@@ -5091,11 +5091,11 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 }
             };
 
-            List<HotReloadMethodOutcome> outcomes = HotReloadShimIsolation.CollectRetryOnlySkippedOutcomes(
+            List<HotReloadMethodOutcome> outcomes = new HotReloadIsolationOutcomeBuilder().CollectRetryOnlySkippedOutcomes(
                 Array.Empty<TransformWorkerSkippedDto>(),
                 retrySkipped,
                 HotReloadGroupFilePaths.ForSingleFile("Assets/Scripts/Host.cs", "test.dll"),
-                HotReloadConstants.VibeLogIsolationTriggerSignatureChangeGate,
+                new HotReloadSignatureChangeGateIsolationTrigger(),
                 new[] { "Host::Broken()" });
 
             Assert.That(outcomes.Count, Is.EqualTo(2));
@@ -5122,11 +5122,11 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 }
             };
 
-            List<HotReloadMethodOutcome> outcomes = HotReloadShimIsolation.CollectRetryOnlySkippedOutcomes(
+            List<HotReloadMethodOutcome> outcomes = new HotReloadIsolationOutcomeBuilder().CollectRetryOnlySkippedOutcomes(
                 Array.Empty<TransformWorkerSkippedDto>(),
                 retrySkipped,
                 HotReloadGroupFilePaths.ForSingleFile("Assets/Scripts/Host.cs", "test.dll"),
-                HotReloadConstants.VibeLogIsolationTriggerShimCompileFailure,
+                new HotReloadShimCompileFailureIsolationTrigger(),
                 new[] { "Host::Broken()" });
 
             Assert.That(outcomes.Count, Is.EqualTo(1));

--- a/Assets/Tests/Editor/HotReload/HotReloadRetainedArtifactPropagationTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadRetainedArtifactPropagationTests.cs
@@ -172,11 +172,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             HotReloadRetainedArtifactFixture fixture,
             HotReloadShimIsolation.IsolationExclusions exclusions)
         {
-            return await HotReloadShimIsolation.RunIsolationRetryAsync(
+            HotReloadIsolationRetryContext retryContext = new HotReloadIsolationRetryContext(
                 workerInput,
-                exclusions,
-                new List<HotReloadMethodOutcome>(),
-                new List<HotReloadMethodOutcome>(),
                 HotReloadRetainedArtifactFixture.FindCompilationAssembly(),
                 fixture.TargetAssemblyPath,
                 workerInput.defines,
@@ -184,8 +181,13 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 HotReloadGroupFilePaths.ForSingleFile(
                     fixture.ProjectRelativePath,
                     fixture.TargetAssemblyPath),
-                HotReloadConstants.VibeLogIsolationTriggerShimCompileFailure,
-                "retained-artifact-propagation",
+                "retained-artifact-propagation");
+            return await HotReloadShimIsolation.RunIsolationRetryAsync(
+                retryContext,
+                exclusions,
+                new List<HotReloadMethodOutcome>(),
+                new List<HotReloadMethodOutcome>(),
+                new HotReloadShimCompileFailureIsolationTrigger(),
                 CancellationToken.None);
         }
 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadFileAtomicIsolationPlan.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadFileAtomicIsolationPlan.cs
@@ -85,7 +85,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             if (allFilesFailed)
             {
                 HotReloadShimIsolation.IsolationExclusions exclusions =
-                    HotReloadShimIsolation.BuildIsolationExclusions(attribution.FailedEntries, entries);
+                    new HotReloadIsolationOutcomeBuilder().BuildIsolationExclusions(
+                        attribution.FailedEntries,
+                        entries);
                 return new HotReloadFileAtomicIsolationPlan(
                     failedFiles,
                     true,

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadIsolationOutcomeBuilder.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadIsolationOutcomeBuilder.cs
@@ -1,0 +1,217 @@
+using System;
+using System.Collections.Generic;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Builds the exclusion sets an isolation retry runs with, and turns the entries and skip rows
+    /// it leaves behind into method outcomes.
+    /// </summary>
+    internal sealed class HotReloadIsolationOutcomeBuilder
+    {
+        /// <summary>
+        /// Converts retry-worker skips that are not already in the first-pass skipped list into
+        /// outcomes. Match is (Method, Reason) Ordinal equality so a method skipped for a new
+        /// reason on retry still surfaces. The trigger decides whether the retry-only reasons are
+        /// rewritten before they become outcomes.
+        /// </summary>
+        internal List<HotReloadMethodOutcome> CollectRetryOnlySkippedOutcomes(
+            TransformWorkerSkippedDto[] firstPassSkipped,
+            TransformWorkerSkippedDto[] retrySkipped,
+            HotReloadGroupFilePaths groupFilePaths,
+            IHotReloadIsolationTrigger trigger,
+            IReadOnlyCollection<string> excludedAddedMethodKeys)
+        {
+            List<HotReloadMethodOutcome> retryOnly = new List<HotReloadMethodOutcome>();
+            if (retrySkipped == null)
+            {
+                return retryOnly;
+            }
+
+            TransformWorkerSkippedDto[] baseline =
+                firstPassSkipped ?? Array.Empty<TransformWorkerSkippedDto>();
+            List<TransformWorkerSkippedDto> retryOnlyRows = new List<TransformWorkerSkippedDto>();
+            foreach (TransformWorkerSkippedDto retryRow in retrySkipped)
+            {
+                if (FirstPassContainsSkippedPair(baseline, retryRow))
+                {
+                    continue;
+                }
+
+                retryOnlyRows.Add(retryRow);
+            }
+
+            trigger.RewriteRetryOnlySkippedReasons(retryOnlyRows, excludedAddedMethodKeys);
+
+            foreach (TransformWorkerSkippedDto retryRow in retryOnlyRows)
+            {
+                retryOnly.Add(
+                    HotReloadMethodOutcome.Skipped(
+                        retryRow.method ?? "(unknown)",
+                        retryRow.reason ?? string.Empty,
+                        groupFilePaths.ResolveAssemblyResolvePath(retryRow.sourceProjectRelativePath)));
+            }
+
+            return retryOnly;
+        }
+
+        private bool FirstPassContainsSkippedPair(
+            TransformWorkerSkippedDto[] firstPassSkipped,
+            TransformWorkerSkippedDto retryRow)
+        {
+            string retryMethod = retryRow.method ?? string.Empty;
+            string retryReason = retryRow.reason ?? string.Empty;
+            foreach (TransformWorkerSkippedDto firstPassRow in firstPassSkipped)
+            {
+                string firstMethod = firstPassRow.method ?? string.Empty;
+                string firstReason = firstPassRow.reason ?? string.Empty;
+                if (string.Equals(firstMethod, retryMethod, StringComparison.Ordinal)
+                    && string.Equals(firstReason, retryReason, StringComparison.Ordinal))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        // The project-relative paths of every source the run transformed, for shim-diagnostic
+        // line mapping.
+        internal List<string> CollectSourceProjectRelativePaths(TransformWorkerInputDto workerInput)
+        {
+            List<string> projectRelativePaths = new List<string>(workerInput.sources.Length);
+            foreach (TransformWorkerSourceDto source in workerInput.sources)
+            {
+                projectRelativePaths.Add(source.projectRelativePath);
+            }
+
+            return projectRelativePaths;
+        }
+
+        internal HotReloadShimIsolation.IsolationExclusions BuildIsolationExclusions(
+            IReadOnlyList<TransformWorkerEntryDto> failedEntries,
+            TransformWorkerEntryDto[] allEntries)
+        {
+            HashSet<string> excludedKeys = new HashSet<string>(StringComparer.Ordinal);
+            HashSet<string> excludedAddedMethodKeys = new HashSet<string>(StringComparer.Ordinal);
+            HashSet<string> failedAddedMethodKeys = new HashSet<string>(StringComparer.Ordinal);
+            List<TransformWorkerEntryDto> excludedCallerEntries = new List<TransformWorkerEntryDto>();
+            foreach (TransformWorkerEntryDto failedEntry in failedEntries)
+            {
+                string methodKey = HotReloadMethodKeys.BuildMethodKey(failedEntry);
+                if (failedEntry.patchKind == HotReloadConstants.PatchKindAddedMethod)
+                {
+                    // Why a separate set: dropping a healthy added shim via excludedMethodKeys
+                    // leaves remaining callers with CS0103 (G1). A broken added body must still
+                    // be excluded together with its callers so retry does not re-emit it.
+                    failedAddedMethodKeys.Add(methodKey);
+                    excludedAddedMethodKeys.Add(methodKey);
+                    continue;
+                }
+
+                excludedKeys.Add(methodKey);
+            }
+
+            HashSet<string> failedEntryKeys = new HashSet<string>(StringComparer.Ordinal);
+            foreach (TransformWorkerEntryDto failedEntry in failedEntries)
+            {
+                failedEntryKeys.Add(HotReloadMethodKeys.BuildMethodKey(failedEntry));
+            }
+
+            List<TransformWorkerEntryDto> callers = CollectCallerEntriesOfAddedMethods(
+                failedAddedMethodKeys,
+                failedEntryKeys,
+                allEntries);
+            foreach (TransformWorkerEntryDto entry in callers)
+            {
+                excludedCallerEntries.Add(entry);
+                string callerKey = HotReloadMethodKeys.BuildMethodKey(entry);
+                if (entry.patchKind == HotReloadConstants.PatchKindAddedMethod)
+                {
+                    excludedAddedMethodKeys.Add(callerKey);
+                }
+                else
+                {
+                    excludedKeys.Add(callerKey);
+                }
+            }
+
+            string[] excludedMethodKeys = new string[excludedKeys.Count];
+            excludedKeys.CopyTo(excludedMethodKeys);
+            string[] excludedAddedKeys = new string[excludedAddedMethodKeys.Count];
+            excludedAddedMethodKeys.CopyTo(excludedAddedKeys);
+            return new HotReloadShimIsolation.IsolationExclusions(
+                excludedMethodKeys,
+                excludedAddedKeys,
+                excludedCallerEntries);
+        }
+
+        private List<TransformWorkerEntryDto> CollectCallerEntriesOfAddedMethods(
+            HashSet<string> addedMethodKeys,
+            HashSet<string> alreadyExcludedEntryKeys,
+            TransformWorkerEntryDto[] allEntries)
+        {
+            List<TransformWorkerEntryDto> callerEntries = new List<TransformWorkerEntryDto>();
+            if (addedMethodKeys.Count == 0 || allEntries == null)
+            {
+                return callerEntries;
+            }
+
+            foreach (TransformWorkerEntryDto entry in allEntries)
+            {
+                if (entry.calledAddedMethodKeys == null)
+                {
+                    continue;
+                }
+
+                string callerKey = HotReloadMethodKeys.BuildMethodKey(entry);
+                if (alreadyExcludedEntryKeys.Contains(callerKey))
+                {
+                    continue;
+                }
+
+                bool callsAdded = false;
+                foreach (string calledKey in entry.calledAddedMethodKeys)
+                {
+                    if (addedMethodKeys.Contains(calledKey))
+                    {
+                        callsAdded = true;
+                        break;
+                    }
+                }
+
+                if (!callsAdded)
+                {
+                    continue;
+                }
+
+                callerEntries.Add(entry);
+            }
+
+            return callerEntries;
+        }
+
+        internal List<HotReloadMethodOutcome> BuildSkippedCallerOutcomes(
+            IReadOnlyList<TransformWorkerEntryDto> callerEntries,
+            HotReloadGroupFilePaths groupFilePaths,
+            string skipReason)
+        {
+            List<HotReloadMethodOutcome> skippedCallerOutcomes = new List<HotReloadMethodOutcome>();
+            foreach (TransformWorkerEntryDto caller in callerEntries)
+            {
+                string methodLabel = HotReloadMethodKeys.FormatMethodLabelParts(
+                    new HotReloadMetadataTypeName(caller.typeMetadataName),
+                    caller.methodName,
+                    caller.parameterTypeFullNames ?? Array.Empty<string>(),
+                    caller.genericArity);
+                skippedCallerOutcomes.Add(
+                    HotReloadMethodOutcome.Skipped(
+                        methodLabel,
+                        skipReason,
+                        groupFilePaths.ResolveAssemblyResolvePath(caller.sourceProjectRelativePath)));
+            }
+
+            return skippedCallerOutcomes;
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadIsolationOutcomeBuilder.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadIsolationOutcomeBuilder.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 94657554ec8ae42e483fbb024d95253f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadIsolationRetryContext.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadIsolationRetryContext.cs
@@ -1,0 +1,40 @@
+using UnityCompilationAssembly = UnityEditor.Compilation.Assembly;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// The inputs an isolation retry inherits unchanged from the run that triggered it: the first
+    /// worker input, the assembly it targets, and the identity used for logging.
+    /// </summary>
+    internal sealed class HotReloadIsolationRetryContext
+    {
+        internal HotReloadIsolationRetryContext(
+            TransformWorkerInputDto workerInput,
+            UnityCompilationAssembly compilationAssembly,
+            string targetDllPath,
+            string[] defines,
+            TransformWorkerSkippedDto[] firstPassSkipped,
+            HotReloadGroupFilePaths groupFilePaths,
+            string correlationId)
+        {
+            WorkerInput = workerInput;
+            CompilationAssembly = compilationAssembly;
+            TargetDllPath = targetDllPath;
+            Defines = defines;
+            FirstPassSkipped = firstPassSkipped;
+            GroupFilePaths = groupFilePaths;
+            CorrelationId = correlationId;
+        }
+
+        internal TransformWorkerInputDto WorkerInput { get; }
+        internal UnityCompilationAssembly CompilationAssembly { get; }
+        internal string TargetDllPath { get; }
+        internal string[] Defines { get; }
+
+        // The first-pass skip rows the retry compares against, so only skips new to the retry surface.
+        internal TransformWorkerSkippedDto[] FirstPassSkipped { get; }
+
+        internal HotReloadGroupFilePaths GroupFilePaths { get; }
+        internal string CorrelationId { get; }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadIsolationRetryContext.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadIsolationRetryContext.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7b4c6f7f8fa644e6bbf95631829b30c2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadShimCompileFailureIsolationTrigger.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadShimCompileFailureIsolationTrigger.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Collections.Generic;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// The isolation retry that follows a failed shim compile.
+    /// </summary>
+    internal sealed class HotReloadShimCompileFailureIsolationTrigger : IHotReloadIsolationTrigger
+    {
+        public string LogName => HotReloadConstants.VibeLogIsolationTriggerShimCompileFailure;
+
+        /// <summary>
+        /// Rewrites the reason of every caller that only became unavailable because an added
+        /// method was excluded from this retry, including callers reached over several hops.
+        /// </summary>
+        public void RewriteRetryOnlySkippedReasons(
+            List<TransformWorkerSkippedDto> retryOnlyRows,
+            IReadOnlyCollection<string> excludedAddedMethodKeys)
+        {
+            HashSet<string> reachable = new HashSet<string>(StringComparer.Ordinal);
+            if (excludedAddedMethodKeys != null)
+            {
+                foreach (string key in excludedAddedMethodKeys)
+                {
+                    if (!string.IsNullOrEmpty(key))
+                    {
+                        reachable.Add(key);
+                    }
+                }
+            }
+
+            bool progressed = true;
+            while (progressed)
+            {
+                progressed = false;
+                foreach (TransformWorkerSkippedDto row in retryOnlyRows)
+                {
+                    if (!string.Equals(
+                        row.reason,
+                        HotReloadConstants.UnavailableAddedCallSkipReason,
+                        StringComparison.Ordinal))
+                    {
+                        continue;
+                    }
+
+                    if (string.IsNullOrEmpty(row.calledAddedMethodKey)
+                        || !reachable.Contains(row.calledAddedMethodKey))
+                    {
+                        continue;
+                    }
+
+                    row.reason = HotReloadConstants.IsolatedAddedMethodCallerSkipReason;
+                    progressed = true;
+                    if (!string.IsNullOrEmpty(row.methodKey))
+                    {
+                        reachable.Add(row.methodKey);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadShimCompileFailureIsolationTrigger.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadShimCompileFailureIsolationTrigger.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0548b33e13bd94f97a8e2472547f54dd
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadShimIsolation.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadShimIsolation.cs
@@ -57,7 +57,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 return null;
             }
 
-            List<string> groupPaths = CollectSourceProjectRelativePaths(workerInput);
+            HotReloadIsolationOutcomeBuilder outcomeBuilder = new HotReloadIsolationOutcomeBuilder();
+            List<string> groupPaths = outcomeBuilder.CollectSourceProjectRelativePaths(workerInput);
             HotReloadFileAtomicIsolationPlan plan = HotReloadFileAtomicIsolationPlan.Build(
                 workerOutput.entries,
                 attribution,
@@ -70,42 +71,39 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 plan.ExcludedMethodKeys,
                 plan.ExcludedAddedMethodKeys,
                 plan.CallerEntries);
-            List<HotReloadMethodOutcome> skippedCallerOutcomes = BuildSkippedCallerOutcomes(
+            List<HotReloadMethodOutcome> skippedCallerOutcomes = outcomeBuilder.BuildSkippedCallerOutcomes(
                 plan.CallerEntries,
                 groupFilePaths,
                 HotReloadConstants.IsolatedAddedMethodCallerSkipReason);
 
-            IsolationRetryRunResult retry = await RunIsolationRetryAsync(
+            HotReloadIsolationRetryContext retryContext = new HotReloadIsolationRetryContext(
                 workerInput,
-                exclusions,
-                failedMethodOutcomes,
-                skippedCallerOutcomes,
                 compilationAssembly,
                 targetDllPath,
                 defines,
                 workerOutput.skipped,
                 groupFilePaths,
-                HotReloadConstants.VibeLogIsolationTriggerShimCompileFailure,
-                correlationId,
+                correlationId);
+            IsolationRetryRunResult retry = await RunIsolationRetryAsync(
+                retryContext,
+                exclusions,
+                failedMethodOutcomes,
+                skippedCallerOutcomes,
+                new HotReloadShimCompileFailureIsolationTrigger(),
                 ct).ConfigureAwait(false);
             retry.Isolation?.AttachPlan(plan);
             return retry.Isolation;
         }
 
         internal static async Task<IsolationRetryRunResult> RunIsolationRetryAsync(
-            TransformWorkerInputDto workerInput,
+            HotReloadIsolationRetryContext context,
             IsolationExclusions exclusions,
             List<HotReloadMethodOutcome> failedMethodOutcomes,
             List<HotReloadMethodOutcome> skippedCallerOutcomes,
-            UnityCompilationAssembly compilationAssembly,
-            string targetDllPath,
-            string[] defines,
-            TransformWorkerSkippedDto[] firstPassSkipped,
-            HotReloadGroupFilePaths groupFilePaths,
-            string trigger,
-            string correlationId,
+            IHotReloadIsolationTrigger trigger,
             CancellationToken ct)
         {
+            TransformWorkerInputDto workerInput = context.WorkerInput;
             TransformWorkerInputDto retryInput = new TransformWorkerInputDto
             {
                 // Why share the array: the worker only reads it, and each source carries the
@@ -141,12 +139,13 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     0,
                     0,
                     false,
-                    trigger,
-                    correlationId);
+                    trigger.LogName,
+                    context.CorrelationId);
                 return IsolationRetryRunResult.Failed(
                     "Retry worker failed: " + retryWorkerResult.ErrorMessage);
             }
 
+            HotReloadIsolationOutcomeBuilder outcomeBuilder = new HotReloadIsolationOutcomeBuilder();
             TransformWorkerOutputDto retryOutput = retryWorkerResult.Output;
             Debug.Assert(
                 retryOutput.files.Length == workerInput.sources.Length,
@@ -154,10 +153,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             // Why drop first-pass (Method, Reason) pairs: consuming them again would duplicate
             // every per-file skip. Retry-only pairs are new — typically transitive callers of
             // excluded added methods — and must surface or the edit is applied nowhere.
-            List<HotReloadMethodOutcome> retryOnlySkipped = CollectRetryOnlySkippedOutcomes(
-                firstPassSkipped,
+            List<HotReloadMethodOutcome> retryOnlySkipped = outcomeBuilder.CollectRetryOnlySkippedOutcomes(
+                context.FirstPassSkipped,
                 retryOutput.skipped,
-                groupFilePaths,
+                context.GroupFilePaths,
                 trigger,
                 exclusions.ExcludedAddedMethodKeys);
             skippedCallerOutcomes.AddRange(retryOnlySkipped);
@@ -168,8 +167,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 retryOutput.skipped?.Length ?? 0,
                 retryOnlySkipped.Count,
                 true,
-                trigger,
-                correlationId);
+                trigger.LogName,
+                context.CorrelationId);
             if (string.IsNullOrEmpty(retryOutput.shimSource) || retryOutput.entries.Length == 0)
             {
                 return IsolationRetryRunResult.Succeeded(
@@ -186,8 +185,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             bool includeHarmonyReference = HotReloadShimReferenceBuilder.NeedsHarmonyReference(retryOutput);
             bool includeAddedFieldStoreReference = HotReloadShimReferenceBuilder.NeedsAddedFieldStoreReference(retryOutput);
             HotReloadShimReferenceBuilder.ShimReferencePathsResult shimReferencePaths = HotReloadShimReferenceBuilder.TryBuildShimReferencePaths(
-                compilationAssembly,
-                targetDllPath,
+                context.CompilationAssembly,
+                context.TargetDllPath,
                 includeHarmonyReference,
                 includeAddedFieldStoreReference,
                 workerInput.introducedTypeArtifacts);
@@ -203,15 +202,15 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             HotReloadShimCompileResult retryCompileResult = await HotReloadShimCompiler.CompileAndLoadAsync(
                 retryOutput.shimSource,
                 shimReferences,
-                defines,
-                CollectSourceProjectRelativePaths(workerInput),
+                context.Defines,
+                outcomeBuilder.CollectSourceProjectRelativePaths(workerInput),
                 ct).ConfigureAwait(false);
             if (!retryCompileResult.Success)
             {
                 HotReloadOrchestratorLog.LogHotReloadShimCompileFailed(
                     retryCompileResult,
                     HotReloadConstants.VibeLogShimCompileStageRetry,
-                    correlationId);
+                    context.CorrelationId);
                 return IsolationRetryRunResult.Failed(
                     "Retry shim compile failed: " + retryCompileResult.ErrorMessage);
             }
@@ -224,263 +223,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     retryCompileResult,
                     retryOutput.files,
                     retryOutput.siblingConstDriftWarnings));
-        }
-
-        /// <summary>
-        /// Converts retry-worker skips that are not already in the first-pass skipped list into
-        /// outcomes. Match is (Method, Reason) Ordinal equality so a method skipped for a new
-        /// reason on retry still surfaces. Why rewrite only on shim-compile-failure isolation:
-        /// signature-change-gate retry must keep UnavailableAddedCall for indirect callers.
-        /// </summary>
-        internal static List<HotReloadMethodOutcome> CollectRetryOnlySkippedOutcomes(
-            TransformWorkerSkippedDto[] firstPassSkipped,
-            TransformWorkerSkippedDto[] retrySkipped,
-            HotReloadGroupFilePaths groupFilePaths,
-            string trigger,
-            IReadOnlyCollection<string> excludedAddedMethodKeys)
-        {
-            List<HotReloadMethodOutcome> retryOnly = new List<HotReloadMethodOutcome>();
-            if (retrySkipped == null)
-            {
-                return retryOnly;
-            }
-
-            TransformWorkerSkippedDto[] baseline =
-                firstPassSkipped ?? Array.Empty<TransformWorkerSkippedDto>();
-            List<TransformWorkerSkippedDto> retryOnlyRows = new List<TransformWorkerSkippedDto>();
-            foreach (TransformWorkerSkippedDto retryRow in retrySkipped)
-            {
-                if (FirstPassContainsSkippedPair(baseline, retryRow))
-                {
-                    continue;
-                }
-
-                retryOnlyRows.Add(retryRow);
-            }
-
-            if (string.Equals(
-                trigger,
-                HotReloadConstants.VibeLogIsolationTriggerShimCompileFailure,
-                StringComparison.Ordinal))
-            {
-                RewriteShimCompileFailureIndirectCallerReasons(retryOnlyRows, excludedAddedMethodKeys);
-            }
-
-            foreach (TransformWorkerSkippedDto retryRow in retryOnlyRows)
-            {
-                retryOnly.Add(
-                    HotReloadMethodOutcome.Skipped(
-                        retryRow.method ?? "(unknown)",
-                        retryRow.reason ?? string.Empty,
-                        groupFilePaths.ResolveAssemblyResolvePath(retryRow.sourceProjectRelativePath)));
-            }
-
-            return retryOnly;
-        }
-
-        private static void RewriteShimCompileFailureIndirectCallerReasons(
-            List<TransformWorkerSkippedDto> retryOnlyRows,
-            IReadOnlyCollection<string> excludedAddedMethodKeys)
-        {
-            HashSet<string> reachable = new HashSet<string>(StringComparer.Ordinal);
-            if (excludedAddedMethodKeys != null)
-            {
-                foreach (string key in excludedAddedMethodKeys)
-                {
-                    if (!string.IsNullOrEmpty(key))
-                    {
-                        reachable.Add(key);
-                    }
-                }
-            }
-
-            bool progressed = true;
-            while (progressed)
-            {
-                progressed = false;
-                foreach (TransformWorkerSkippedDto row in retryOnlyRows)
-                {
-                    if (!string.Equals(
-                        row.reason,
-                        HotReloadConstants.UnavailableAddedCallSkipReason,
-                        StringComparison.Ordinal))
-                    {
-                        continue;
-                    }
-
-                    if (string.IsNullOrEmpty(row.calledAddedMethodKey)
-                        || !reachable.Contains(row.calledAddedMethodKey))
-                    {
-                        continue;
-                    }
-
-                    row.reason = HotReloadConstants.IsolatedAddedMethodCallerSkipReason;
-                    progressed = true;
-                    if (!string.IsNullOrEmpty(row.methodKey))
-                    {
-                        reachable.Add(row.methodKey);
-                    }
-                }
-            }
-        }
-
-        private static bool FirstPassContainsSkippedPair(
-            TransformWorkerSkippedDto[] firstPassSkipped,
-            TransformWorkerSkippedDto retryRow)
-        {
-            string retryMethod = retryRow.method ?? string.Empty;
-            string retryReason = retryRow.reason ?? string.Empty;
-            foreach (TransformWorkerSkippedDto firstPassRow in firstPassSkipped)
-            {
-                string firstMethod = firstPassRow.method ?? string.Empty;
-                string firstReason = firstPassRow.reason ?? string.Empty;
-                if (string.Equals(firstMethod, retryMethod, StringComparison.Ordinal)
-                    && string.Equals(firstReason, retryReason, StringComparison.Ordinal))
-                {
-                    return true;
-                }
-            }
-
-            return false;
-        }
-
-        // The project-relative paths of every source the run transformed, for shim-diagnostic
-        // line mapping.
-        internal static List<string> CollectSourceProjectRelativePaths(TransformWorkerInputDto workerInput)
-        {
-            List<string> projectRelativePaths = new List<string>(workerInput.sources.Length);
-            foreach (TransformWorkerSourceDto source in workerInput.sources)
-            {
-                projectRelativePaths.Add(source.projectRelativePath);
-            }
-
-            return projectRelativePaths;
-        }
-
-        internal static IsolationExclusions BuildIsolationExclusions(
-            IReadOnlyList<TransformWorkerEntryDto> failedEntries,
-            TransformWorkerEntryDto[] allEntries)
-        {
-            HashSet<string> excludedKeys = new HashSet<string>(StringComparer.Ordinal);
-            HashSet<string> excludedAddedMethodKeys = new HashSet<string>(StringComparer.Ordinal);
-            HashSet<string> failedAddedMethodKeys = new HashSet<string>(StringComparer.Ordinal);
-            List<TransformWorkerEntryDto> excludedCallerEntries = new List<TransformWorkerEntryDto>();
-            foreach (TransformWorkerEntryDto failedEntry in failedEntries)
-            {
-                string methodKey = HotReloadMethodKeys.BuildMethodKey(failedEntry);
-                if (failedEntry.patchKind == HotReloadConstants.PatchKindAddedMethod)
-                {
-                    // Why a separate set: dropping a healthy added shim via excludedMethodKeys
-                    // leaves remaining callers with CS0103 (G1). A broken added body must still
-                    // be excluded together with its callers so retry does not re-emit it.
-                    failedAddedMethodKeys.Add(methodKey);
-                    excludedAddedMethodKeys.Add(methodKey);
-                    continue;
-                }
-
-                excludedKeys.Add(methodKey);
-            }
-
-            HashSet<string> failedEntryKeys = new HashSet<string>(StringComparer.Ordinal);
-            foreach (TransformWorkerEntryDto failedEntry in failedEntries)
-            {
-                failedEntryKeys.Add(HotReloadMethodKeys.BuildMethodKey(failedEntry));
-            }
-
-            List<TransformWorkerEntryDto> callers = CollectCallerEntriesOfAddedMethods(
-                failedAddedMethodKeys,
-                failedEntryKeys,
-                allEntries);
-            foreach (TransformWorkerEntryDto entry in callers)
-            {
-                excludedCallerEntries.Add(entry);
-                string callerKey = HotReloadMethodKeys.BuildMethodKey(entry);
-                if (entry.patchKind == HotReloadConstants.PatchKindAddedMethod)
-                {
-                    excludedAddedMethodKeys.Add(callerKey);
-                }
-                else
-                {
-                    excludedKeys.Add(callerKey);
-                }
-            }
-
-            string[] excludedMethodKeys = new string[excludedKeys.Count];
-            excludedKeys.CopyTo(excludedMethodKeys);
-            string[] excludedAddedKeys = new string[excludedAddedMethodKeys.Count];
-            excludedAddedMethodKeys.CopyTo(excludedAddedKeys);
-            return new IsolationExclusions(
-                excludedMethodKeys,
-                excludedAddedKeys,
-                excludedCallerEntries);
-        }
-
-        private static List<TransformWorkerEntryDto> CollectCallerEntriesOfAddedMethods(
-            HashSet<string> addedMethodKeys,
-            HashSet<string> alreadyExcludedEntryKeys,
-            TransformWorkerEntryDto[] allEntries)
-        {
-            List<TransformWorkerEntryDto> callerEntries = new List<TransformWorkerEntryDto>();
-            if (addedMethodKeys.Count == 0 || allEntries == null)
-            {
-                return callerEntries;
-            }
-
-            foreach (TransformWorkerEntryDto entry in allEntries)
-            {
-                if (entry.calledAddedMethodKeys == null)
-                {
-                    continue;
-                }
-
-                string callerKey = HotReloadMethodKeys.BuildMethodKey(entry);
-                if (alreadyExcludedEntryKeys.Contains(callerKey))
-                {
-                    continue;
-                }
-
-                bool callsAdded = false;
-                foreach (string calledKey in entry.calledAddedMethodKeys)
-                {
-                    if (addedMethodKeys.Contains(calledKey))
-                    {
-                        callsAdded = true;
-                        break;
-                    }
-                }
-
-                if (!callsAdded)
-                {
-                    continue;
-                }
-
-                callerEntries.Add(entry);
-            }
-
-            return callerEntries;
-        }
-
-        internal static List<HotReloadMethodOutcome> BuildSkippedCallerOutcomes(
-            IReadOnlyList<TransformWorkerEntryDto> callerEntries,
-            HotReloadGroupFilePaths groupFilePaths,
-            string skipReason)
-        {
-            List<HotReloadMethodOutcome> skippedCallerOutcomes = new List<HotReloadMethodOutcome>();
-            foreach (TransformWorkerEntryDto caller in callerEntries)
-            {
-                string methodLabel = HotReloadMethodKeys.FormatMethodLabelParts(
-                    new HotReloadMetadataTypeName(caller.typeMetadataName),
-                    caller.methodName,
-                    caller.parameterTypeFullNames ?? Array.Empty<string>(),
-                    caller.genericArity);
-                skippedCallerOutcomes.Add(
-                    HotReloadMethodOutcome.Skipped(
-                        methodLabel,
-                        skipReason,
-                        groupFilePaths.ResolveAssemblyResolvePath(caller.sourceProjectRelativePath)));
-            }
-
-            return skippedCallerOutcomes;
         }
 
         internal sealed class IsolationExclusions

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadSignatureChangeGate.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadSignatureChangeGate.cs
@@ -59,7 +59,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     deletedCallerExemptions);
             }
 
-            HotReloadShimIsolation.IsolationExclusions exclusions = HotReloadShimIsolation.BuildIsolationExclusions(gatedReplacements, entries);
+            HotReloadIsolationOutcomeBuilder outcomeBuilder = new HotReloadIsolationOutcomeBuilder();
+            HotReloadShimIsolation.IsolationExclusions exclusions = outcomeBuilder.BuildIsolationExclusions(gatedReplacements, entries);
             Dictionary<string, HashSet<HotReloadQualifiedMethodIdentity>> editedFileMethodIdentitiesByFile =
                 HotReloadSignatureChangeCoverage.CollectEditedFileMethodIdentitiesByFile(
                     context.AssemblyName,
@@ -71,23 +72,25 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 editedFileMethodIdentitiesByFile,
                 context.GroupFilePaths);
             skippedOutcomes.AddRange(
-                HotReloadShimIsolation.BuildSkippedCallerOutcomes(
+                outcomeBuilder.BuildSkippedCallerOutcomes(
                     exclusions.CallerEntries,
                     context.GroupFilePaths,
                     HotReloadConstants.SignatureChangedGatedCallerSkipReason));
 
-            HotReloadShimIsolation.IsolationRetryRunResult retry = await HotReloadShimIsolation.RunIsolationRetryAsync(
+            HotReloadIsolationRetryContext retryContext = new HotReloadIsolationRetryContext(
                 context.WorkerInput,
-                exclusions,
-                new List<HotReloadMethodOutcome>(),
-                new List<HotReloadMethodOutcome>(),
                 context.CompilationAssembly,
                 context.TargetDllPath,
                 context.Defines,
                 context.WorkerOutput.skipped,
                 context.GroupFilePaths,
-                HotReloadConstants.VibeLogIsolationTriggerSignatureChangeGate,
-                context.CorrelationId,
+                context.CorrelationId);
+            HotReloadShimIsolation.IsolationRetryRunResult retry = await HotReloadShimIsolation.RunIsolationRetryAsync(
+                retryContext,
+                exclusions,
+                new List<HotReloadMethodOutcome>(),
+                new List<HotReloadMethodOutcome>(),
+                new HotReloadSignatureChangeGateIsolationTrigger(),
                 ct).ConfigureAwait(false);
             List<string> gatedReplacementMethodKeys =
                 CollectGatedReplacementMethodKeys(gatedReplacements);

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadSignatureChangeGateIsolationTrigger.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadSignatureChangeGateIsolationTrigger.cs
@@ -1,0 +1,24 @@
+using System.Collections.Generic;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// The isolation retry that follows the signature-change gate.
+    /// </summary>
+    internal sealed class HotReloadSignatureChangeGateIsolationTrigger : IHotReloadIsolationTrigger
+    {
+        public string LogName => HotReloadConstants.VibeLogIsolationTriggerSignatureChangeGate;
+
+        /// <summary>
+        /// Leaves the retry-only skip reasons as the worker reported them. Why nothing happens
+        /// here: this retry isolates gated replacements rather than a compile failure, so an
+        /// indirect caller of an excluded added method is genuinely unavailable and must keep
+        /// saying so.
+        /// </summary>
+        public void RewriteRetryOnlySkippedReasons(
+            List<TransformWorkerSkippedDto> retryOnlyRows,
+            IReadOnlyCollection<string> excludedAddedMethodKeys)
+        {
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadSignatureChangeGateIsolationTrigger.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadSignatureChangeGateIsolationTrigger.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b4bf92005d32f4b9eab855b7535b5b8f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/IHotReloadIsolationTrigger.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/IHotReloadIsolationTrigger.cs
@@ -1,0 +1,20 @@
+using System.Collections.Generic;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// What drove an isolation retry. Why an interface rather than a trigger string: the retry
+    /// path treats triggers differently in more than one place, and a new trigger would otherwise
+    /// have to be added to every string comparison spread across that path.
+    /// </summary>
+    internal interface IHotReloadIsolationTrigger
+    {
+        /// The trigger name written to the isolation-retry log line.
+        string LogName { get; }
+
+        /// Adjusts the skip reasons that only the retry produced, before they become outcomes.
+        void RewriteRetryOnlySkippedReasons(
+            List<TransformWorkerSkippedDto> retryOnlyRows,
+            IReadOnlyCollection<string> excludedAddedMethodKeys);
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/IHotReloadIsolationTrigger.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/IHotReloadIsolationTrigger.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: cc5975d908195488288b371210d39755
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary
- No user-visible change. This is an internal restructuring of the hot-reload shim-isolation retry.

## User Impact
- None. Isolation behaviour, skip reasons and log output are unchanged.

## Changes
- The seven inputs the retry inherits unchanged from the run that triggered it move into `HotReloadIsolationRetryContext`, taking the retry entry point from thirteen arguments to six.
- The trigger becomes `IHotReloadIsolationTrigger`, with one implementation per trigger. The log name and the retry-only skip-reason rewrite now live with the trigger, so the string comparison in the middle of the retry path is gone and a new trigger no longer has to be threaded through it.
- Exclusion building and outcome collection move to `HotReloadIsolationOutcomeBuilder`.

## Verification
- `uloop compile`: `ErrorCount 0`.
- `uloop run-tests` over the four affected hot-reload test classes: 243 tests, 242 passed, 1 failed. The one failure (`HotReloadGroupProcessorTests.ResolveInputFile_WhenNewSourceIsPlanned_PreservesEvidenceForPreRevertRevalidation`, "Hot-reload package roots were never captured") reproduces identically on the base branch and on `main` with the same filter, and passes when that class is run alone: it is a pre-existing ordering dependency, not a regression from this change.
- File length: with the threshold set to 400 SLOC, none of the touched files is reported; the repository-wide check exits 0.
- `uloop hot-reload --status` and `--revert-all` responses captured before and after the change are byte-identical.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2730?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

