### PR TITLE
chore: Make the hot-reload patcher and appliers injected instances

### DIFF
--- a/Assets/Tests/Editor/HotReload/HotReloadAutoRefreshHoldTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadAutoRefreshHoldTests.cs
@@ -330,7 +330,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         public void ReconcileForTesting_StaleFlagWithEmptyLedger_AllowsOnceAndClearsFlag()
         {
             FakeEnvironment environment = new FakeEnvironment { Held = true };
-            HotReloadPatcher.RevertAll();
+            HotReloadCompositionRoot.Services.Patcher.RevertAll();
             HotReloadAutoRefreshHoldService previous = HotReloadAutoRefreshHold.OverrideServiceForTesting;
             try
             {
@@ -365,7 +365,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 Held = true,
                 AllowException = new InvalidOperationException("reload")
             };
-            HotReloadPatcher.RevertAll();
+            HotReloadCompositionRoot.Services.Patcher.RevertAll();
             HotReloadAutoRefreshHoldService previous = HotReloadAutoRefreshHold.OverrideServiceForTesting;
             try
             {

--- a/Assets/Tests/Editor/HotReload/HotReloadCrossFileE2ETests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadCrossFileE2ETests.cs
@@ -62,14 +62,14 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             // The production run captures these at its entry point; a direct call to the path
             // normalizer in a test has to do the same.
             HotReloadPackageRootProvider.CaptureCurrent();
-            HotReloadPatcher.RevertAll();
+            HotReloadCompositionRoot.Services.Patcher.RevertAll();
             HotReloadAutoRefreshHold.SyncToActiveChanges();
         }
 
         [TearDown]
         public void TearDown()
         {
-            HotReloadPatcher.RevertAll();
+            HotReloadCompositionRoot.Services.Patcher.RevertAll();
             HotReloadAutoRefreshHold.SyncToActiveChanges();
             VibeLogger.ClearMemoryLogs();
         }
@@ -304,7 +304,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             AssertKind(applied, HotReloadMethodOutcomeKind.Patched, "Scaled");
             AssertKind(applied, HotReloadMethodOutcomeKind.Patched, "CalledFromCrossAssembly");
 
-            HotReloadPatcher.RevertAll();
+            HotReloadCompositionRoot.Services.Patcher.RevertAll();
             HotReloadAutoRefreshHold.SyncToActiveChanges();
 
             HotReloadOrchestratorResult isolated = await HotReloadOrchestrator.RunAsync(
@@ -936,7 +936,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                     // The patches belong to the replacement domain, and the TearDown revert runs
                     // after the scope has already put the outer domain back, which knows nothing
                     // about them and would leave them live in Harmony.
-                    HotReloadPatcher.RevertAll();
+                    HotReloadCompositionRoot.Services.Patcher.RevertAll();
                 }
             }
         }

--- a/Assets/Tests/Editor/HotReload/HotReloadDomainTestAccess.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadDomainTestAccess.cs
@@ -40,7 +40,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                         sourceEndLine: 0));
             }
 
-            return HotReloadPatcher.Apply(method, shimMethod, patchShape, projectRelativePath);
+            return HotReloadCompositionRoot.Services.Patcher.Apply(method, shimMethod, patchShape, projectRelativePath);
         }
 
         internal HotReloadFileGeneration GetOrBeginShimGeneration(string projectRelativePath)

--- a/Assets/Tests/Editor/HotReload/HotReloadDomainTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadDomainTests.cs
@@ -38,7 +38,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         [TearDown]
         public void TearDown()
         {
-            HotReloadPatcher.RevertAll();
+            HotReloadCompositionRoot.Services.Patcher.RevertAll();
         }
 
         /// <summary>
@@ -290,7 +290,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 Is.EqualTo(FileTwo));
 
             Assert.That(
-                HotReloadPatcher.Revert(original, out string _),
+                HotReloadCompositionRoot.Services.Patcher.Revert(original, out string _),
                 Is.EqualTo(HotReloadRevertOutcome.Reverted));
 
             Assert.That(_access.Domain.ActivePatchCount, Is.EqualTo(0));

--- a/Assets/Tests/Editor/HotReload/HotReloadGlobalNamespaceShimE2ETests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadGlobalNamespaceShimE2ETests.cs
@@ -27,14 +27,14 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         [SetUp]
         public void SetUp()
         {
-            HotReloadPatcher.RevertAll();
+            HotReloadCompositionRoot.Services.Patcher.RevertAll();
             HotReloadAutoRefreshHold.SyncToActiveChanges();
         }
 
         [TearDown]
         public void TearDown()
         {
-            HotReloadPatcher.RevertAll();
+            HotReloadCompositionRoot.Services.Patcher.RevertAll();
             HotReloadAutoRefreshHold.SyncToActiveChanges();
             VibeLogger.ClearMemoryLogs();
         }

--- a/Assets/Tests/Editor/HotReload/HotReloadGroupProcessorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadGroupProcessorTests.cs
@@ -555,7 +555,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                         TransformWorkerClientResult.Failure("transform worker failed")),
                     HotReloadGroupProcessor.GateAndCompileAsync,
                     HotReloadGroupEntryPreparation.PrepareGroup,
-                    HotReloadEntryApplier.ApplyPreparedEntries)))
+                    HotReloadCompositionRoot.Services.EntryApplier.ApplyPreparedEntries)))
             {
                 results = await HotReloadGroupProcessor.ProcessGroupAsync(
                     new[] { file },

--- a/Assets/Tests/Editor/HotReload/HotReloadIntroducedTypeActivationTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadIntroducedTypeActivationTests.cs
@@ -28,7 +28,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             // normalizer in a test has to do the same.
             HotReloadPackageRootProvider.CaptureCurrent();
             _previousSnapshotProvider = HotReloadEditorStateSnapshotProvider.CaptureForTesting;
-            HotReloadPatcher.RevertAll();
+            HotReloadCompositionRoot.Services.Patcher.RevertAll();
             HotReloadAutoRefreshHold.SyncToActiveChanges();
         }
 
@@ -39,7 +39,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         public void TearDown()
         {
             HotReloadEditorStateSnapshotProvider.CaptureForTesting = _previousSnapshotProvider;
-            HotReloadPatcher.RevertAll();
+            HotReloadCompositionRoot.Services.Patcher.RevertAll();
             HotReloadAutoRefreshHold.SyncToActiveChanges();
         }
 
@@ -191,7 +191,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                         },
                         HotReloadGroupProcessor.GateAndCompileAsync,
                         HotReloadGroupEntryPreparation.PrepareGroup,
-                        HotReloadEntryApplier.ApplyPreparedEntries)))
+                        HotReloadCompositionRoot.Services.EntryApplier.ApplyPreparedEntries)))
                 {
                     HotReloadOrchestratorResult result = await HotReloadOrchestrator.RunAsync(
                         new[] { hostPath, callerPath },
@@ -253,7 +253,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                         },
                         HotReloadGroupProcessor.GateAndCompileAsync,
                         HotReloadGroupEntryPreparation.PrepareGroup,
-                        HotReloadEntryApplier.ApplyPreparedEntries)))
+                        HotReloadCompositionRoot.Services.EntryApplier.ApplyPreparedEntries)))
                 {
                     await HotReloadOrchestrator.RunAsync(
                         new[] { callerPath },
@@ -669,7 +669,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                     Is.EqualTo(0),
                     "A refused group must activate no type.");
                 Assert.That(
-                    HotReloadPatcher.ActivePatchCount,
+                    HotReloadCompositionRoot.Services.Patcher.ActivePatchCount,
                     Is.EqualTo(0),
                     "A refused group must apply no patch.");
             }
@@ -930,7 +930,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 Is.EqualTo(0),
                 "A run stopped at the commit boundary must activate no type.");
             Assert.That(
-                HotReloadPatcher.ActivePatchCount,
+                HotReloadCompositionRoot.Services.Patcher.ActivePatchCount,
                 Is.EqualTo(0),
                 "A run stopped at the commit boundary must apply no patch.");
         }
@@ -1031,7 +1031,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 TransformWorkerClient.RunAsync,
                 HotReloadGroupProcessor.GateAndCompileAsync,
                 HotReloadGroupEntryPreparation.PrepareGroup,
-                HotReloadEntryApplier.ApplyPreparedEntries);
+                HotReloadCompositionRoot.Services.EntryApplier.ApplyPreparedEntries);
         }
 
         private static HotReloadGroupProcessorDependencies CreateArtifactCapturingDependencies(
@@ -1049,7 +1049,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 TransformWorkerClient.RunAsync,
                 HotReloadGroupProcessor.GateAndCompileAsync,
                 HotReloadGroupEntryPreparation.PrepareGroup,
-                HotReloadEntryApplier.ApplyPreparedEntries);
+                HotReloadCompositionRoot.Services.EntryApplier.ApplyPreparedEntries);
         }
 
         // The window between the preparation run and the transform run, which is where an owner
@@ -1067,7 +1067,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 },
                 HotReloadGroupProcessor.GateAndCompileAsync,
                 HotReloadGroupEntryPreparation.PrepareGroup,
-                HotReloadEntryApplier.ApplyPreparedEntries);
+                HotReloadCompositionRoot.Services.EntryApplier.ApplyPreparedEntries);
         }
 
         // The window between the shim compile and the commit boundary, which is the last instant
@@ -1087,7 +1087,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                     return gateAndCompile;
                 },
                 HotReloadGroupEntryPreparation.PrepareGroup,
-                HotReloadEntryApplier.ApplyPreparedEntries);
+                HotReloadCompositionRoot.Services.EntryApplier.ApplyPreparedEntries);
         }
 
         // The reason of the preflight failure this test injects at the PrepareGroupEntries seam.
@@ -1126,7 +1126,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                         "Precondition: the group had to resolve " + failingFileName + " to fail it.");
                     return replaced;
                 },
-                HotReloadEntryApplier.ApplyPreparedEntries);
+                HotReloadCompositionRoot.Services.EntryApplier.ApplyPreparedEntries);
         }
 
         private static HotReloadPreparedGroupFile FailResolutionOfMatchingFile(
@@ -1174,7 +1174,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 },
                 HotReloadGroupProcessor.GateAndCompileAsync,
                 HotReloadGroupEntryPreparation.PrepareGroup,
-                HotReloadEntryApplier.ApplyPreparedEntries);
+                HotReloadCompositionRoot.Services.EntryApplier.ApplyPreparedEntries);
         }
 
         // An artifact whose owner hash is keyed by a path the transform run reported no row for,
@@ -1200,7 +1200,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 TransformWorkerClient.RunAsync,
                 HotReloadGroupProcessor.GateAndCompileAsync,
                 HotReloadGroupEntryPreparation.PrepareGroup,
-                HotReloadEntryApplier.ApplyPreparedEntries);
+                HotReloadCompositionRoot.Services.EntryApplier.ApplyPreparedEntries);
         }
 
         private static Dictionary<string, string> RekeyOwnerHashesToUnreportedPaths(
@@ -1232,7 +1232,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 },
                 HotReloadGroupProcessor.GateAndCompileAsync,
                 HotReloadGroupEntryPreparation.PrepareGroup,
-                HotReloadEntryApplier.ApplyPreparedEntries);
+                HotReloadCompositionRoot.Services.EntryApplier.ApplyPreparedEntries);
         }
 
         private static void BlankSourceHashOf(TransformWorkerOutputDto output, string fileName)
@@ -1374,7 +1374,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             string hostPath = FixturePath("HotReloadCrossFileAddedMemberHost.cs");
             string callerPath = FixturePath("HotReloadCrossFileAddedMemberCaller.cs");
             List<string> stages = new List<string>();
-            int patchesBefore = HotReloadPatcher.ActivePatchCount;
+            int patchesBefore = HotReloadCompositionRoot.Services.Patcher.ActivePatchCount;
 
             using (HotReloadCompositionRoot.BeginReplacement(HotReloadCompositionRoot.CreateProductionServices()))
             {
@@ -1403,7 +1403,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 Is.EqualTo(new[] { ValidateStage, PrepareStage }),
                 "A failed preparation must stop the run before the transform worker.");
             Assert.That(
-                HotReloadPatcher.ActivePatchCount,
+                HotReloadCompositionRoot.Services.Patcher.ActivePatchCount,
                 Is.EqualTo(patchesBefore),
                 "A failed preparation must leave the patch ledger unchanged.");
         }
@@ -1457,7 +1457,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 (context, compileResult, preparedFiles) =>
                 {
                     stages.Add(ApplyStage);
-                    return HotReloadEntryApplier.ApplyPreparedEntries(context, compileResult, preparedFiles);
+                    return HotReloadCompositionRoot.Services.EntryApplier.ApplyPreparedEntries(context, compileResult, preparedFiles);
                 });
         }
 
@@ -1488,7 +1488,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 },
                 HotReloadGroupProcessor.GateAndCompileAsync,
                 HotReloadGroupEntryPreparation.PrepareGroup,
-                HotReloadEntryApplier.ApplyPreparedEntries);
+                HotReloadCompositionRoot.Services.EntryApplier.ApplyPreparedEntries);
         }
 
         // Why the failure is injected: an artifact compile failure cannot be provoked from a
@@ -1523,7 +1523,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 },
                 HotReloadGroupProcessor.GateAndCompileAsync,
                 HotReloadGroupEntryPreparation.PrepareGroup,
-                HotReloadEntryApplier.ApplyPreparedEntries);
+                HotReloadCompositionRoot.Services.EntryApplier.ApplyPreparedEntries);
         }
 
         private static HotReloadIntroducedTypeArtifact CreateArtifactForTarget(

--- a/Assets/Tests/Editor/HotReload/HotReloadIntroducedTypeHoldTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadIntroducedTypeHoldTests.cs
@@ -23,7 +23,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         [SetUp]
         public void SetUp()
         {
-            HotReloadPatcher.RevertAll();
+            HotReloadCompositionRoot.Services.Patcher.RevertAll();
             ReleaseTheHold();
         }
 
@@ -32,7 +32,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         [TearDown]
         public void TearDown()
         {
-            HotReloadPatcher.RevertAll();
+            HotReloadCompositionRoot.Services.Patcher.RevertAll();
             ReleaseTheHold();
         }
 

--- a/Assets/Tests/Editor/HotReload/HotReloadIntroducedTypeResponseTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadIntroducedTypeResponseTests.cs
@@ -19,7 +19,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         [SetUp]
         public void SetUp()
         {
-            HotReloadPatcher.RevertAll();
+            HotReloadCompositionRoot.Services.Patcher.RevertAll();
             HotReloadAutoRefreshHold.SyncToActiveChanges();
         }
 
@@ -29,7 +29,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         [TearDown]
         public void TearDown()
         {
-            HotReloadPatcher.RevertAll();
+            HotReloadCompositionRoot.Services.Patcher.RevertAll();
             HotReloadAutoRefreshHold.SyncToActiveChanges();
         }
 
@@ -384,8 +384,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                     }
 
                     return failTheMethod
-                        ? HotReloadFileEntryApplier.BuildUnappliedGroupResults(context.Files)
-                        : HotReloadEntryApplier.ApplyPreparedEntries(context, compile, preparedFiles);
+                        ? HotReloadCompositionRoot.Services.FileEntryApplier.BuildUnappliedGroupResults(context.Files)
+                        : HotReloadCompositionRoot.Services.EntryApplier.ApplyPreparedEntries(context, compile, preparedFiles);
                 });
         }
 
@@ -431,7 +431,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                                 file.ProjectRelativePath));
                     }
 
-                    return HotReloadFileEntryApplier.BuildUnappliedGroupResults(context.Files);
+                    return HotReloadCompositionRoot.Services.FileEntryApplier.BuildUnappliedGroupResults(context.Files);
                 });
         }
 
@@ -462,7 +462,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                                 file.ProjectRelativePath));
                     }
 
-                    return HotReloadFileEntryApplier.BuildUnappliedGroupResults(context.Files);
+                    return HotReloadCompositionRoot.Services.FileEntryApplier.BuildUnappliedGroupResults(context.Files);
                 });
         }
 
@@ -676,7 +676,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 TransformWorkerClient.RunAsync,
                 HotReloadGroupProcessor.GateAndCompileAsync,
                 HotReloadGroupEntryPreparation.PrepareGroup,
-                HotReloadEntryApplier.ApplyPreparedEntries);
+                HotReloadCompositionRoot.Services.EntryApplier.ApplyPreparedEntries);
         }
 
         private static async Task<HotReloadResponse> RunAgainstTheHostAsync()

--- a/Assets/Tests/Editor/HotReload/HotReloadIntroducedTypeStatusTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadIntroducedTypeStatusTests.cs
@@ -25,14 +25,14 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         [SetUp]
         public void SetUp()
         {
-            HotReloadPatcher.RevertAll();
+            HotReloadCompositionRoot.Services.Patcher.RevertAll();
             HotReloadAutoRefreshHold.SyncToActiveChanges();
         }
 
         [TearDown]
         public void TearDown()
         {
-            HotReloadPatcher.RevertAll();
+            HotReloadCompositionRoot.Services.Patcher.RevertAll();
             HotReloadAutoRefreshHold.SyncToActiveChanges();
         }
 

--- a/Assets/Tests/Editor/HotReload/HotReloadJitInliningInvestigationTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadJitInliningInvestigationTests.cs
@@ -22,7 +22,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         [TearDown]
         public void TearDown()
         {
-            HotReloadPatcher.RevertAll();
+            HotReloadCompositionRoot.Services.Patcher.RevertAll();
         }
 
         /// <summary>

--- a/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
@@ -35,14 +35,14 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             // The production run captures these at its entry point; a direct call to the path
             // normalizer in a test has to do the same.
             HotReloadPackageRootProvider.CaptureCurrent();
-            HotReloadPatcher.RevertAll();
+            HotReloadCompositionRoot.Services.Patcher.RevertAll();
             HotReloadAutoRefreshHold.SyncToActiveChanges();
         }
 
         [TearDown]
         public void TearDown()
         {
-            HotReloadPatcher.RevertAll();
+            HotReloadCompositionRoot.Services.Patcher.RevertAll();
             HotReloadAutoRefreshHold.SyncToActiveChanges();
             VibeLogger.ClearMemoryLogs();
         }
@@ -728,8 +728,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 Is.True,
                 "Status must list Active get_HeightAmplitude after apply with the same Method label.");
 
-            HotReloadPatcher.RevertAll();
-            Assert.That(HotReloadPatcher.DescribeActivePatches(), Is.Empty);
+            HotReloadCompositionRoot.Services.Patcher.RevertAll();
+            Assert.That(HotReloadCompositionRoot.Services.Patcher.DescribeActivePatches(), Is.Empty);
             Assert.That(
                 HotReloadPropertyGetterFixture.HeightAmplitude,
                 Is.EqualTo(5f),
@@ -1280,7 +1280,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         {
             int callsBefore = HotReloadBindProbeShim.BindCalls;
 
-            Dictionary<string, string> failures = HotReloadEntryApplier.BindShimAccessors(
+            Dictionary<string, string> failures = HotReloadCompositionRoot.Services.EntryApplier.BindShimAccessors(
                 typeof(HotReloadBindFailShim).Assembly);
 
             Assert.That(HotReloadBindProbeShim.BindCalls, Is.EqualTo(callsBefore + 1));
@@ -2000,7 +2000,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                             TransformWorkerClient.RunAsync,
                             HotReloadGroupProcessor.GateAndCompileAsync,
                             HotReloadGroupEntryPreparation.PrepareGroup,
-                            HotReloadEntryApplier.ApplyPreparedEntries)))
+                            HotReloadCompositionRoot.Services.EntryApplier.ApplyPreparedEntries)))
                     {
                         await HotReloadOrchestrator.RunAsync(
                             new[] { fixturePath },
@@ -2013,7 +2013,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                     // The patches belong to the replacement domain, and the TearDown revert runs
                     // after the scope has already put the outer domain back, which knows nothing
                     // about them and would leave them live in Harmony.
-                    HotReloadPatcher.RevertAll();
+                    HotReloadCompositionRoot.Services.Patcher.RevertAll();
                 }
             }
 
@@ -2303,7 +2303,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             AssertNoFileLevelFailure(first);
             AssertHasPatched(first, nameof(HotReloadE2EFixture.ComputeWithPrivate));
 
-            HotReloadPatcher.RevertAll();
+            HotReloadCompositionRoot.Services.Patcher.RevertAll();
 
             HotReloadOrchestratorResult second = await HotReloadOrchestrator.RunAsync(
                 new[] { fixturePath },
@@ -2937,7 +2937,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             }
             finally
             {
-                HotReloadPatcher.RevertAll();
+                HotReloadCompositionRoot.Services.Patcher.RevertAll();
             }
         }
 
@@ -2981,7 +2981,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             }
             finally
             {
-                HotReloadPatcher.RevertAll();
+                HotReloadCompositionRoot.Services.Patcher.RevertAll();
             }
         }
 
@@ -3073,7 +3073,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             }
             finally
             {
-                HotReloadPatcher.RevertAll();
+                HotReloadCompositionRoot.Services.Patcher.RevertAll();
             }
         }
 
@@ -3159,7 +3159,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             HotReloadShimCompileResult compileResult,
             TransformWorkerEntryDto[] entriesToPatch)
         {
-            return HotReloadEntryApplier.ApplyPreparedEntries(
+            return HotReloadCompositionRoot.Services.EntryApplier.ApplyPreparedEntries(
                 context,
                 compileResult,
                 HotReloadGroupEntryPreparation.PrepareGroup(context, compileResult, entriesToPatch));

--- a/Assets/Tests/Editor/HotReload/HotReloadPatcherTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadPatcherTests.cs
@@ -24,7 +24,56 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         [TearDown]
         public void TearDown()
         {
-            HotReloadPatcher.RevertAll();
+            HotReloadCompositionRoot.Services.Patcher.RevertAll();
+        }
+
+        /// <summary>
+        /// Real Harmony for every call except the unpatch a test wants to see fail, so the
+        /// transpiler under test is genuinely live while the rebuild is refused.
+        /// </summary>
+        private sealed class RefusingUnpatchHarmony : IHotReloadHarmony
+        {
+            private readonly IHotReloadHarmony _inner;
+
+            internal RefusingUnpatchHarmony(IHotReloadHarmony inner)
+            {
+                _inner = inner;
+            }
+
+            internal bool RefuseUnpatch { get; set; }
+
+            public void Patch(MethodBase original, HarmonyMethod transpiler)
+            {
+                _inner.Patch(original, transpiler);
+            }
+
+            public void Unpatch(MethodBase original, HarmonyPatchType patchType, string harmonyId)
+            {
+                if (RefuseUnpatch)
+                {
+                    throw new InvalidOperationException("rebuild failed");
+                }
+
+                _inner.Unpatch(original, patchType, harmonyId);
+            }
+
+            public void UnpatchAll(string harmonyId)
+            {
+                _inner.UnpatchAll(harmonyId);
+            }
+        }
+
+        private static RefusingUnpatchHarmony CreateRefusingUnpatchHarmony()
+        {
+            return new RefusingUnpatchHarmony(
+                new HotReloadHarmonyGateway(new Harmony(HotReloadConstants.HarmonyId)));
+        }
+
+        private static IDisposable BeginReplacementWith(IHotReloadHarmony harmony)
+        {
+            return HotReloadCompositionRoot.BeginReplacement(
+                HotReloadCompositionRoot.CreateServices(
+                    HotReloadCompositionRoot.CreateProductionDomain(), harmony));
         }
 
         /// <summary>
@@ -104,8 +153,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 Is.True);
             Assert.That(fixture.ReplaceableCompute(5), Is.EqualTo(47));
 
-            HotReloadPatcher.RevertAll();
-            Assert.That(HotReloadPatcher.ActivePatchCount, Is.EqualTo(0));
+            HotReloadCompositionRoot.Services.Patcher.RevertAll();
+            Assert.That(HotReloadCompositionRoot.Services.Patcher.ActivePatchCount, Is.EqualTo(0));
             Assert.That(fixture.ReplaceableCompute(5), Is.EqualTo(-5));
         }
 
@@ -125,7 +174,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 "Assets/Tests/Editor/HotReload/Host.cs",
                 new[] { "Host.count" });
 
-            HotReloadPatcher.RevertAll();
+            HotReloadCompositionRoot.Services.Patcher.RevertAll();
 
             Assert.That(HotReloadAddedFieldStore.GetOrInit(host, instanceKey, () => 10), Is.EqualTo(10));
             Assert.That(HotReloadAddedFieldStore.GetOrInitStatic(staticKey, () => 20), Is.EqualTo(20));
@@ -143,9 +192,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 "Assets/Tests/Editor/HotReload/PatcherResetHost.cs",
                 new[] { "PatcherResetHost.count" });
 
-            HotReloadPatcher.RevertAll();
+            HotReloadCompositionRoot.Services.Patcher.RevertAll();
 
-            Assert.That(HotReloadPatcher.ActiveChangeCount, Is.EqualTo(0));
+            Assert.That(HotReloadCompositionRoot.Services.Patcher.ActiveChangeCount, Is.EqualTo(0));
             Assert.That(HotReloadCompositionRoot.Services.Domain.DescribeAddedFields(), Is.Empty);
         }
 
@@ -166,15 +215,15 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                     original, shim, HotReloadPatchShape.Transplant, "Assets/Tests/Fixture.cs").Success,
                 Is.True);
 
-            IReadOnlyList<HotReloadActivePatchInfo> afterApply = HotReloadPatcher.DescribeActivePatches();
+            IReadOnlyList<HotReloadActivePatchInfo> afterApply = HotReloadCompositionRoot.Services.Patcher.DescribeActivePatches();
             Assert.That(afterApply.Count, Is.EqualTo(1));
             Assert.That(
                 afterApply[0].MethodKey,
                 Does.Contain(nameof(HotReloadCoreFixture)).And.Contain(nameof(HotReloadCoreFixture.ReplaceableCompute)));
             Assert.That(afterApply[0].FilePath, Is.EqualTo("Assets/Tests/Fixture.cs"));
 
-            HotReloadPatcher.RevertAll();
-            IReadOnlyList<HotReloadActivePatchInfo> afterRevert = HotReloadPatcher.DescribeActivePatches();
+            HotReloadCompositionRoot.Services.Patcher.RevertAll();
+            IReadOnlyList<HotReloadActivePatchInfo> afterRevert = HotReloadCompositionRoot.Services.Patcher.DescribeActivePatches();
             Assert.That(afterRevert, Is.Empty);
         }
 
@@ -208,7 +257,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 .Where(patch => patch.owner == HotReloadConstants.HarmonyId)
                 .ToArray();
             Assert.That(ownedTranspilers.Length, Is.EqualTo(1), "Re-apply must not stack hot-reload transpilers.");
-            Assert.That(HotReloadPatcher.ActivePatchCount, Is.EqualTo(1));
+            Assert.That(HotReloadCompositionRoot.Services.Patcher.ActivePatchCount, Is.EqualTo(1));
         }
 
         /// <summary>
@@ -251,8 +300,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             Assert.That(result.Success, Is.True, result.ErrorMessage);
             Assert.That(await fixture.ReplaceableComputeAsync(5), Is.EqualTo(10 + 5 + 1));
 
-            HotReloadPatcher.RevertAll();
-            Assert.That(HotReloadPatcher.ActivePatchCount, Is.EqualTo(0));
+            HotReloadCompositionRoot.Services.Patcher.RevertAll();
+            Assert.That(HotReloadCompositionRoot.Services.Patcher.ActivePatchCount, Is.EqualTo(0));
             Assert.That(await fixture.ReplaceableComputeAsync(5), Is.EqualTo(-5));
         }
 
@@ -278,7 +327,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             Assert.That(result.Success, Is.False);
             Assert.That(result.FailureReason, Is.EqualTo(HotReloadPatchFailureReason.ApplyFailed));
             Assert.That(result.ErrorMessage, Does.Contain("ReplaceableCompute"));
-            Assert.That(HotReloadPatcher.ActivePatchCount, Is.EqualTo(0));
+            Assert.That(HotReloadCompositionRoot.Services.Patcher.ActivePatchCount, Is.EqualTo(0));
 
             HotReloadCoreFixture fixture = new HotReloadCoreFixture();
             Assert.That(fixture.ReplaceableCompute(5), Is.EqualTo(-5), "Original body must survive.");
@@ -322,9 +371,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             Assert.That(status.Methods[0].Method, Is.EqualTo(methodKey));
             Assert.That(status.Methods[0].InvocationCount, Is.EqualTo(2L));
 
-            HotReloadPatcher.RevertAll();
+            HotReloadCompositionRoot.Services.Patcher.RevertAll();
             Assert.That(HotReloadInvocationRegistry.GetCount(methodKey), Is.EqualTo(0L));
-            Assert.That(HotReloadPatcher.DescribeActivePatches(), Is.Empty);
+            Assert.That(HotReloadCompositionRoot.Services.Patcher.DescribeActivePatches(), Is.Empty);
         }
 
         /// <summary>
@@ -458,45 +507,50 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             MethodInfo survivingShim = AccessTools.Method(
                 typeof(HotReloadHandwrittenShims), nameof(HotReloadHandwrittenShims.StaticPing__shim0));
             string failingKey = HotReloadMethodKeys.FormatMethodLabel(failing);
-            Assert.That(
-                new HotReloadDomainTestAccess().ApplyPatch(failing, failingShim, HotReloadPatchShape.Transplant, "Assets/Tests/Fixture.cs").Success,
-                Is.True);
-            Assert.That(
-                new HotReloadDomainTestAccess().ApplyPatch(surviving, survivingShim, HotReloadPatchShape.Transplant, "Assets/Tests/Fixture.cs").Success,
-                Is.True);
-            Assert.That(HotReloadPatcher.ActivePatchCount, Is.EqualTo(2));
-
-            HotReloadRevertOutcome failedOutcome;
-            string failureReason;
-            HotReloadPatcher.UnpatchForTesting = _ => throw new InvalidOperationException("rebuild failed");
-            try
+            RefusingUnpatchHarmony harmony = CreateRefusingUnpatchHarmony();
+            using (BeginReplacementWith(harmony))
             {
-                failedOutcome = HotReloadPatcher.Revert(failing, out failureReason);
-            }
-            finally
-            {
-                HotReloadPatcher.UnpatchForTesting = null;
-            }
+                try
+                {
+                    Assert.That(
+                        new HotReloadDomainTestAccess().ApplyPatch(failing, failingShim, HotReloadPatchShape.Transplant, "Assets/Tests/Fixture.cs").Success,
+                        Is.True);
+                    Assert.That(
+                        new HotReloadDomainTestAccess().ApplyPatch(surviving, survivingShim, HotReloadPatchShape.Transplant, "Assets/Tests/Fixture.cs").Success,
+                        Is.True);
+                    Assert.That(HotReloadCompositionRoot.Services.Patcher.ActivePatchCount, Is.EqualTo(2));
 
-            Assert.That(failedOutcome, Is.EqualTo(HotReloadRevertOutcome.UnpatchFailed));
-            Assert.That(failureReason, Does.Contain("rebuild failed"));
-            Assert.That(
-                HotReloadPatcher.ActivePatchCount,
-                Is.EqualTo(2),
-                "The transpiler is still live, so the ledger must keep describing it.");
-            Assert.That(
-                HotReloadPatcher.DescribeActivePatches().Select(patch => patch.MethodKey),
-                Does.Contain(failingKey),
-                "Status has to keep reporting a patch Harmony could not remove.");
-            Assert.That(
-                HotReloadPatcher.Revert(failing, out string _),
-                Is.EqualTo(HotReloadRevertOutcome.Reverted),
-                "Once the rebuild works, the retained entry must revert instead of reporting NotPatched.");
-            Assert.That(HotReloadPatcher.ActivePatchCount, Is.EqualTo(1));
-            Assert.That(
-                HotReloadPatcher.Revert(surviving, out string _),
-                Is.EqualTo(HotReloadRevertOutcome.Reverted),
-                "A contained revert failure must not stop the remaining methods from reverting.");
+                    harmony.RefuseUnpatch = true;
+                    HotReloadRevertOutcome failedOutcome =
+                        HotReloadCompositionRoot.Services.Patcher.Revert(failing, out string failureReason);
+                    harmony.RefuseUnpatch = false;
+
+                    Assert.That(failedOutcome, Is.EqualTo(HotReloadRevertOutcome.UnpatchFailed));
+                    Assert.That(failureReason, Does.Contain("rebuild failed"));
+                    Assert.That(
+                        HotReloadCompositionRoot.Services.Patcher.ActivePatchCount,
+                        Is.EqualTo(2),
+                        "The transpiler is still live, so the ledger must keep describing it.");
+                    Assert.That(
+                        HotReloadCompositionRoot.Services.Patcher.DescribeActivePatches().Select(patch => patch.MethodKey),
+                        Does.Contain(failingKey),
+                        "Status has to keep reporting a patch Harmony could not remove.");
+                    Assert.That(
+                        HotReloadCompositionRoot.Services.Patcher.Revert(failing, out string _),
+                        Is.EqualTo(HotReloadRevertOutcome.Reverted),
+                        "Once the rebuild works, the retained entry must revert instead of reporting NotPatched.");
+                    Assert.That(HotReloadCompositionRoot.Services.Patcher.ActivePatchCount, Is.EqualTo(1));
+                    Assert.That(
+                        HotReloadCompositionRoot.Services.Patcher.Revert(surviving, out string _),
+                        Is.EqualTo(HotReloadRevertOutcome.Reverted),
+                        "A contained revert failure must not stop the remaining methods from reverting.");
+                }
+                finally
+                {
+                    harmony.RefuseUnpatch = false;
+                    HotReloadCompositionRoot.Services.Patcher.RevertAll();
+                }
+            }
         }
 
         /// <summary>
@@ -511,34 +565,40 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 typeof(HotReloadCoreFixture), nameof(HotReloadCoreFixture.ReplaceableCompute));
             MethodInfo failingShim = AccessTools.Method(
                 typeof(HotReloadHandwrittenShims), nameof(HotReloadHandwrittenShims.ReplaceableCompute__shim0));
-            Assert.That(
-                new HotReloadDomainTestAccess().ApplyPatch(failing, failingShim, HotReloadPatchShape.Transplant, "Assets/Tests/Fixture.cs").Success,
-                Is.True);
-            Assert.That(
-                HotReloadPausePointCoordination.GetTransplantLocals(failing),
-                Is.Not.Null,
-                "A transplant apply must record the shim locals the test then checks are retained.");
-
-            HotReloadPatcher.UnpatchForTesting = _ => throw new InvalidOperationException("rebuild failed");
-            try
+            RefusingUnpatchHarmony harmony = CreateRefusingUnpatchHarmony();
+            using (BeginReplacementWith(harmony))
             {
-                Assert.That(
-                    HotReloadPatcher.Revert(failing, out string _),
-                    Is.EqualTo(HotReloadRevertOutcome.UnpatchFailed));
-            }
-            finally
-            {
-                HotReloadPatcher.UnpatchForTesting = null;
-            }
+                try
+                {
+                    Assert.That(
+                        new HotReloadDomainTestAccess().ApplyPatch(failing, failingShim, HotReloadPatchShape.Transplant, "Assets/Tests/Fixture.cs").Success,
+                        Is.True);
+                    Assert.That(
+                        HotReloadPausePointCoordination.GetTransplantLocals(failing),
+                        Is.Not.Null,
+                        "A transplant apply must record the shim locals the test then checks are retained.");
 
-            Assert.That(
-                HotReloadPausePointCoordination.GetTransplantLocals(failing),
-                Is.Not.Null,
-                "The transpiler is still live, so pause-point must still find its transplant locals.");
-            Assert.That(
-                HotReloadPausePointCoordination.GetTransplantPreambleLength(failing),
-                Is.GreaterThan(0),
-                "The retained entry must keep the preamble length pause-point offsets against.");
+                    harmony.RefuseUnpatch = true;
+                    Assert.That(
+                        HotReloadCompositionRoot.Services.Patcher.Revert(failing, out string _),
+                        Is.EqualTo(HotReloadRevertOutcome.UnpatchFailed));
+                    harmony.RefuseUnpatch = false;
+
+                    Assert.That(
+                        HotReloadPausePointCoordination.GetTransplantLocals(failing),
+                        Is.Not.Null,
+                        "The transpiler is still live, so pause-point must still find its transplant locals.");
+                    Assert.That(
+                        HotReloadPausePointCoordination.GetTransplantPreambleLength(failing),
+                        Is.GreaterThan(0),
+                        "The retained entry must keep the preamble length pause-point offsets against.");
+                }
+                finally
+                {
+                    harmony.RefuseUnpatch = false;
+                    HotReloadCompositionRoot.Services.Patcher.RevertAll();
+                }
+            }
         }
 
         /// <summary>
@@ -561,7 +621,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             Assert.That(HotReloadInvocationRegistry.GetCount(methodKey), Is.EqualTo(1L));
 
             Assert.That(
-                HotReloadPatcher.Revert(original, out string _),
+                HotReloadCompositionRoot.Services.Patcher.Revert(original, out string _),
                 Is.EqualTo(HotReloadRevertOutcome.Reverted));
             Assert.That(HotReloadInvocationRegistry.GetCount(methodKey), Is.EqualTo(0L));
             Assert.That(fixture.ReplaceableCompute(5), Is.EqualTo(-5));

--- a/Assets/Tests/Editor/HotReload/HotReloadPausePointContractTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadPausePointContractTests.cs
@@ -37,7 +37,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         [TearDown]
         public void TearDown()
         {
-            HotReloadPatcher.RevertAll();
+            HotReloadCompositionRoot.Services.Patcher.RevertAll();
             SourcePausePointPatcher.UnpatchAll();
             UloopPausePointRegistry.ResetForTests();
         }
@@ -376,7 +376,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             Assert.That(UloopPausePointRegistry.GetStatus(enable.Id).RetargetedToHotReloadPatch, Is.True);
 
             UloopPausePointRegistry.SetResolvedLine(enable.Id, 0, null);
-            HotReloadPatcher.RevertAll();
+            HotReloadCompositionRoot.Services.Patcher.RevertAll();
 
             UloopPausePointSnapshot afterRevert = UloopPausePointRegistry.GetStatus(enable.Id);
             Assert.That(afterRevert.RetargetedToHotReloadPatch, Is.False);
@@ -442,7 +442,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             Assert.That(enable.Success, Is.True, enable.Message);
             Assert.That(enable.RetargetedToHotReloadPatch, Is.True);
 
-            HotReloadPatcher.RevertAll();
+            HotReloadCompositionRoot.Services.Patcher.RevertAll();
 
             UloopPausePointSnapshot status = UloopPausePointRegistry.GetStatus(enable.Id);
             Assert.That(status.SuppressedByHotReload, Is.True);
@@ -609,7 +609,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             Assert.That(enable.Success, Is.True, enable.Message + " / " + enable.RecommendedNextAction);
             Assert.That(enable.RetargetedToHotReloadPatch, Is.True);
 
-            HotReloadPatcher.RevertAll();
+            HotReloadCompositionRoot.Services.Patcher.RevertAll();
 
             UloopPausePointSnapshot afterRevert = UloopPausePointRegistry.GetStatus(enable.Id);
             Assert.That(afterRevert.SuppressedByHotReload, Is.False);
@@ -766,7 +766,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             Assert.That(
                 new HotReloadDomainTestAccess().ApplyPatch(original, shim, HotReloadPatchShape.Transplant, "Assets/Tests/Fixture.cs").Success,
                 Is.True);
-            HotReloadPatcher.RevertAll();
+            HotReloadCompositionRoot.Services.Patcher.RevertAll();
 
             SourcePausePointResolution resolution = BuildSyntheticResolution(original, instructionIndex: 0);
             SourcePausePointPatchResult result = SourcePausePointPatcher.Patch(
@@ -870,7 +870,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 "ContractRestoreAfterRevert.cs");
             Assert.That(UloopPausePointRegistry.GetStatus(enable.Id).RetargetedToHotReloadPatch, Is.True);
 
-            HotReloadPatcher.RevertAll();
+            HotReloadCompositionRoot.Services.Patcher.RevertAll();
 
             HotReloadE2EFixture fixture = new HotReloadE2EFixture();
             int result = fixture.ComputeWithPrivate(5);

--- a/Assets/Tests/Editor/HotReload/HotReloadPausePointE2ETests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadPausePointE2ETests.cs
@@ -38,7 +38,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         [TearDown]
         public void TearDown()
         {
-            HotReloadPatcher.RevertAll();
+            HotReloadCompositionRoot.Services.Patcher.RevertAll();
             SourcePausePointPatcher.UnpatchAll();
             UloopPausePointRegistry.ResetForTests();
         }
@@ -62,7 +62,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 "E2E_c_BeforeRevert.cs");
             Assert.That(UloopPausePointRegistry.GetStatus(enable.Id).RetargetedToHotReloadPatch, Is.True);
 
-            HotReloadPatcher.RevertAll();
+            HotReloadCompositionRoot.Services.Patcher.RevertAll();
 
             HotReloadE2EFixture fixture = new HotReloadE2EFixture();
             int result = fixture.ComputeWithPrivate(5);

--- a/Assets/Tests/Editor/HotReload/HotReloadPausePointLineDriftTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadPausePointLineDriftTests.cs
@@ -46,7 +46,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         [TearDown]
         public void TearDown()
         {
-            HotReloadPatcher.RevertAll();
+            HotReloadCompositionRoot.Services.Patcher.RevertAll();
             SourcePausePointPatcher.UnpatchAll();
             UloopPausePointRegistry.ResetForTests();
         }
@@ -272,7 +272,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 };
             try
             {
-                HotReloadPatcher.RevertAll();
+                HotReloadCompositionRoot.Services.Patcher.RevertAll();
             }
             finally
             {
@@ -298,7 +298,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             HotReloadPausePointCoordination.GetVerifiedSnapshotSource = null;
             try
             {
-                HotReloadPatcher.RevertAll();
+                HotReloadCompositionRoot.Services.Patcher.RevertAll();
             }
             finally
             {

--- a/Assets/Tests/Editor/HotReload/HotReloadPlayModeEntryDropRecorderTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadPlayModeEntryDropRecorderTests.cs
@@ -181,36 +181,46 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         {
             using (HotReloadCompositionRoot.BeginReplacement(HotReloadCompositionRoot.CreateProductionServices()))
             {
-                HotReloadOrchestratorResult result = await RunPatchingABodyAndIntroducingATypeAsync();
+                try
+                {
+                    HotReloadOrchestratorResult result = await RunPatchingABodyAndIntroducingATypeAsync();
 
-                Assert.That(
-                    result.ActivePatchTotal,
-                    Is.EqualTo(1),
-                    "Precondition: the run must have patched exactly one method.");
-                Assert.That(
-                    result.IntroducedTypes.Count,
-                    Is.EqualTo(1),
-                    "Precondition: the run must have introduced exactly one type.");
-                HotReloadIntroducedTypeOutcome introduced = result.IntroducedTypes[0];
+                    Assert.That(
+                        result.ActivePatchTotal,
+                        Is.EqualTo(1),
+                        "Precondition: the run must have patched exactly one method.");
+                    Assert.That(
+                        result.IntroducedTypes.Count,
+                        Is.EqualTo(1),
+                        "Precondition: the run must have introduced exactly one type.");
+                    HotReloadIntroducedTypeOutcome introduced = result.IntroducedTypes[0];
 
-                List<string> identities =
-                    new List<string>(HotReloadPlayModeEntryDropRecorder.CollectActiveIdentities());
+                    List<string> identities =
+                        new List<string>(HotReloadPlayModeEntryDropRecorder.CollectActiveIdentities());
 
-                Assert.That(
-                    identities.Count,
-                    Is.EqualTo(2),
-                    "One patch and one type are two changes the reload would discard.");
-                Assert.That(
-                    identities,
-                    Does.Contain(
-                        HotReloadPlayModeEntryDropIdentity.ForType(
-                            introduced.OriginalAssemblyName,
-                            introduced.MetadataName)),
-                    "The type must be recorded in the shape a later apply can recover.");
-                Assert.That(
-                    identities.FindAll(identity => identity.Contains("Scaled")).Count,
-                    Is.EqualTo(1),
-                    "The patched method must still be collected next to the type.");
+                    Assert.That(
+                        identities.Count,
+                        Is.EqualTo(2),
+                        "One patch and one type are two changes the reload would discard.");
+                    Assert.That(
+                        identities,
+                        Does.Contain(
+                            HotReloadPlayModeEntryDropIdentity.ForType(
+                                introduced.OriginalAssemblyName,
+                                introduced.MetadataName)),
+                        "The type must be recorded in the shape a later apply can recover.");
+                    Assert.That(
+                        identities.FindAll(identity => identity.Contains("Scaled")).Count,
+                        Is.EqualTo(1),
+                        "The patched method must still be collected next to the type.");
+                }
+                finally
+                {
+                    // The patch belongs to the replacement domain, and the TearDown revert runs
+                    // after the scope has already put the outer domain back, which knows nothing
+                    // about it and would leave it live in Harmony.
+                    HotReloadCompositionRoot.Services.Patcher.RevertAll();
+                }
             }
         }
 

--- a/Assets/Tests/Editor/HotReload/HotReloadPlayModeEntryDropRecorderTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadPlayModeEntryDropRecorderTests.cs
@@ -31,7 +31,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         {
             _ledgerSessionScope = new HotReloadPlayModeEntryDropLedgerSessionScope();
             _previousApply = HotReloadTool.RunApplyAsyncForTesting;
-            HotReloadPatcher.RevertAll();
+            HotReloadCompositionRoot.Services.Patcher.RevertAll();
             HotReloadAutoRefreshHold.SyncToActiveChanges();
         }
 
@@ -42,7 +42,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         public void TearDown()
         {
             HotReloadTool.RunApplyAsyncForTesting = _previousApply;
-            HotReloadPatcher.RevertAll();
+            HotReloadCompositionRoot.Services.Patcher.RevertAll();
             HotReloadAutoRefreshHold.SyncToActiveChanges();
             _ledgerSessionScope.Restore();
         }

--- a/Assets/Tests/Editor/HotReload/HotReloadPlayModeEntryDropStatusTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadPlayModeEntryDropStatusTests.cs
@@ -24,13 +24,13 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         public void SetUp()
         {
             _ledgerSessionScope = new HotReloadPlayModeEntryDropLedgerSessionScope();
-            HotReloadPatcher.RevertAll();
+            HotReloadCompositionRoot.Services.Patcher.RevertAll();
         }
 
         [TearDown]
         public void TearDown()
         {
-            HotReloadPatcher.RevertAll();
+            HotReloadCompositionRoot.Services.Patcher.RevertAll();
             _ledgerSessionScope.Restore();
         }
 

--- a/Assets/Tests/Editor/HotReload/HotReloadShimLookupTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadShimLookupTests.cs
@@ -27,7 +27,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         [TearDown]
         public void TearDown()
         {
-            HotReloadPatcher.RevertAll();
+            HotReloadCompositionRoot.Services.Patcher.RevertAll();
         }
 
         /// <summary>
@@ -97,7 +97,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 "Precondition: Replace of `return _secret + delta;` must patch ComputeWithPrivate " +
                 "plus at least one sibling so revert cannot clear the whole file lookup.");
 
-            HotReloadRevertOutcome reverted = HotReloadPatcher.Revert(computeMethod, out string _);
+            HotReloadRevertOutcome reverted = HotReloadCompositionRoot.Services.Patcher.Revert(computeMethod, out string _);
             Assert.That(reverted, Is.EqualTo(HotReloadRevertOutcome.Reverted));
 
             HotReloadShimFileLookup lookup =
@@ -120,7 +120,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         public async Task RevertAll_ClearsShimLookup()
         {
             await PatchComputeWithPrivateAsync();
-            HotReloadPatcher.RevertAll();
+            HotReloadCompositionRoot.Services.Patcher.RevertAll();
 
             HotReloadShimFileLookup lookup =
                 HotReloadPausePointCoordination.GetShimLookupForFile?.Invoke(FixtureProjectRelativePath);

--- a/Assets/Tests/Editor/HotReload/HotReloadToolTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadToolTests.cs
@@ -30,14 +30,14 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         public void SetUp()
         {
             _ledgerSessionScope = new HotReloadPlayModeEntryDropLedgerSessionScope();
-            HotReloadPatcher.RevertAll();
+            HotReloadCompositionRoot.Services.Patcher.RevertAll();
             HotReloadAutoRefreshHold.SyncToActiveChanges();
         }
 
         [TearDown]
         public void TearDown()
         {
-            HotReloadPatcher.RevertAll();
+            HotReloadCompositionRoot.Services.Patcher.RevertAll();
             HotReloadAutoRefreshHold.SyncToActiveChanges();
             _ledgerSessionScope.Restore();
         }
@@ -103,7 +103,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         [Test]
         public async Task ExecuteAsync_NoChangedFiles_WhenActivePatchExists_ReportsActiveCountAndRecovery()
         {
-            HotReloadPatcher.RevertAll();
+            HotReloadCompositionRoot.Services.Patcher.RevertAll();
             Func<HotReloadChangedFileAggregationResult> previousDetector =
                 HotReloadTool.DetectChangedFilesForTesting;
             try
@@ -137,7 +137,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             finally
             {
                 HotReloadTool.DetectChangedFilesForTesting = previousDetector;
-                HotReloadPatcher.RevertAll();
+                HotReloadCompositionRoot.Services.Patcher.RevertAll();
             }
         }
 
@@ -148,7 +148,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         [Test]
         public async Task ExecuteAsync_NoChangedFiles_WhenNoActivePatches_KeepsOriginalMessageAndNextActions()
         {
-            HotReloadPatcher.RevertAll();
+            HotReloadCompositionRoot.Services.Patcher.RevertAll();
             Func<HotReloadChangedFileAggregationResult> previousDetector =
                 HotReloadTool.DetectChangedFilesForTesting;
             try
@@ -183,7 +183,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             finally
             {
                 HotReloadTool.DetectChangedFilesForTesting = previousDetector;
-                HotReloadPatcher.RevertAll();
+                HotReloadCompositionRoot.Services.Patcher.RevertAll();
             }
         }
 
@@ -224,7 +224,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         [Test]
         public async Task ExecuteAsync_Status_NeverInvokedActiveRow_SetsNeverInvokedReason()
         {
-            HotReloadPatcher.RevertAll();
+            HotReloadCompositionRoot.Services.Patcher.RevertAll();
             try
             {
                 ApplyCoreFixtureTransplant(
@@ -255,7 +255,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             }
             finally
             {
-                HotReloadPatcher.RevertAll();
+                HotReloadCompositionRoot.Services.Patcher.RevertAll();
             }
         }
 
@@ -266,7 +266,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         [Test]
         public async Task ExecuteAsync_Status_InvokedActiveRow_LeavesReasonEmpty()
         {
-            HotReloadPatcher.RevertAll();
+            HotReloadCompositionRoot.Services.Patcher.RevertAll();
             try
             {
                 ApplyCoreFixtureTransplant(
@@ -291,7 +291,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             }
             finally
             {
-                HotReloadPatcher.RevertAll();
+                HotReloadCompositionRoot.Services.Patcher.RevertAll();
             }
         }
 
@@ -304,7 +304,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         {
             const string filePath = "Assets/Tests/Editor/HotReload/StatusAddedReason.cs";
             const string methodKey = "Host.NewHelper(System.Int32)";
-            HotReloadPatcher.RevertAll();
+            HotReloadCompositionRoot.Services.Patcher.RevertAll();
             try
             {
                 ApplyCoreFixtureTransplant(
@@ -334,7 +334,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             }
             finally
             {
-                HotReloadPatcher.RevertAll();
+                HotReloadCompositionRoot.Services.Patcher.RevertAll();
             }
         }
 
@@ -345,7 +345,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         [Test]
         public void Revert_RemovesSupersededMappingForThatMethod()
         {
-            HotReloadPatcher.RevertAll();
+            HotReloadCompositionRoot.Services.Patcher.RevertAll();
             try
             {
                 ApplyCoreFixtureTransplant(
@@ -353,7 +353,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                     BindingFlags.Instance | BindingFlags.Public,
                     nameof(HotReloadHandwrittenShims.ReplaceableCompute__shim0));
                 IReadOnlyList<HotReloadActivePatchInfo> patches =
-                    HotReloadPatcher.DescribeActivePatches();
+                    HotReloadCompositionRoot.Services.Patcher.DescribeActivePatches();
                 Assert.That(patches.Count, Is.EqualTo(1));
                 string methodKey = patches[0].MethodKey;
                 new HotReloadDomainTestAccess().RecordSupersededSignature(
@@ -366,7 +366,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                     BindingFlags.Instance | BindingFlags.Public);
                 Assert.That(original, Is.Not.Null);
                 Assert.That(
-                    HotReloadPatcher.Revert(original, out string _),
+                    HotReloadCompositionRoot.Services.Patcher.Revert(original, out string _),
                     Is.EqualTo(HotReloadRevertOutcome.Reverted));
 
                 bool found = HotReloadCompositionRoot.Services.Domain.TryGetSupersededReplacement(
@@ -376,7 +376,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             }
             finally
             {
-                HotReloadPatcher.RevertAll();
+                HotReloadCompositionRoot.Services.Patcher.RevertAll();
             }
         }
 
@@ -388,7 +388,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         public async Task ExecuteAsync_Status_SupersededActiveRow_SetsSupersededReason()
         {
             const string replacementDisplayName = "Host.Replacement(System.String)";
-            HotReloadPatcher.RevertAll();
+            HotReloadCompositionRoot.Services.Patcher.RevertAll();
             try
             {
                 ApplyCoreFixtureTransplant(
@@ -396,7 +396,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                     BindingFlags.Instance | BindingFlags.Public,
                     nameof(HotReloadHandwrittenShims.ReplaceableCompute__shim0));
                 IReadOnlyList<HotReloadActivePatchInfo> patches =
-                    HotReloadPatcher.DescribeActivePatches();
+                    HotReloadCompositionRoot.Services.Patcher.DescribeActivePatches();
                 Assert.That(patches.Count, Is.EqualTo(1));
                 new HotReloadDomainTestAccess().RecordSupersededSignature(
                     SupersededFixturePath,
@@ -422,7 +422,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             }
             finally
             {
-                HotReloadPatcher.RevertAll();
+                HotReloadCompositionRoot.Services.Patcher.RevertAll();
             }
         }
 
@@ -435,7 +435,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         {
             const string filePath = "Assets/Tests/Editor/HotReload/StatusAddedField.cs";
             const string methodKey = "Host.NewHelper(System.Int32)";
-            HotReloadPatcher.RevertAll();
+            HotReloadCompositionRoot.Services.Patcher.RevertAll();
             new HotReloadDomainTestAccess().ClearAddedMembersAndFields();
             try
             {
@@ -469,7 +469,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             }
             finally
             {
-                HotReloadPatcher.RevertAll();
+                HotReloadCompositionRoot.Services.Patcher.RevertAll();
                 new HotReloadDomainTestAccess().ClearAddedMembersAndFields();
             }
         }
@@ -914,7 +914,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         public async Task ExecuteAsync_RevertAllWithNoActivePatches_ReportsClearedCountZero()
         {
             // Verifies --revert-all succeeds with a clear message when the ledger is empty.
-            HotReloadPatcher.RevertAll();
+            HotReloadCompositionRoot.Services.Patcher.RevertAll();
             HotReloadTool tool = new HotReloadTool();
             JObject parameters = new JObject
             {
@@ -938,7 +938,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         [Test]
         public async Task ExecuteAsync_RevertAll_ClearsAutoRefreshHeld()
         {
-            HotReloadPatcher.RevertAll();
+            HotReloadCompositionRoot.Services.Patcher.RevertAll();
             try
             {
                 ApplyCoreFixtureTransplant(
@@ -965,7 +965,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             }
             finally
             {
-                HotReloadPatcher.RevertAll();
+                HotReloadCompositionRoot.Services.Patcher.RevertAll();
                 HotReloadAutoRefreshHold.SyncToActiveChanges();
             }
         }
@@ -1059,7 +1059,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             HotReloadAutoRefreshHoldService previous = HotReloadAutoRefreshHold.OverrideServiceForTesting;
             try
             {
-                HotReloadPatcher.RevertAll();
+                HotReloadCompositionRoot.Services.Patcher.RevertAll();
                 bool held = true;
                 bool isPlaying = true;
                 bool preflightCanProceed = true;
@@ -1089,7 +1089,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             finally
             {
                 HotReloadAutoRefreshHold.OverrideServiceForTesting = previous;
-                HotReloadPatcher.RevertAll();
+                HotReloadCompositionRoot.Services.Patcher.RevertAll();
                 HotReloadAutoRefreshHold.SyncToActiveChanges();
             }
         }

--- a/Assets/Tests/Editor/HotReload/HotReloadTransplantControlFlowTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadTransplantControlFlowTests.cs
@@ -20,7 +20,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         [TearDown]
         public void TearDown()
         {
-            HotReloadPatcher.RevertAll();
+            HotReloadCompositionRoot.Services.Patcher.RevertAll();
         }
 
         // Why NoInlining: repo convention for patch-target fixtures — without it the

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadCompositionRoot.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadCompositionRoot.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
 
+using HarmonyLib;
+
 using io.github.hatayama.UnityCliLoop.ToolContracts;
 
 namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
@@ -41,12 +43,40 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         /// </summary>
         internal static HotReloadServices CreateProductionServices()
         {
+            HotReloadHarmonyGateway harmony =
+                new HotReloadHarmonyGateway(new Harmony(HotReloadConstants.HarmonyId));
+            return CreateServices(CreateProductionDomain(), harmony);
+        }
+
+        /// <summary>
+        /// Builds an empty domain of the shape production runs on. A test that has to substitute
+        /// the patch engine builds the domain through this and passes its own harmony to
+        /// <see cref="CreateServices"/>.
+        /// </summary>
+        internal static HotReloadDomain CreateProductionDomain()
+        {
             HotReloadIntroducedTypeRegistry registry = new HotReloadIntroducedTypeRegistry();
             // The resolver comes back detached and answers no bind until Install attaches it, so
-            // building services here can never race the resolver that is still installed.
+            // building a domain here can never race the resolver that is still installed.
             HotReloadIntroducedTypeAssemblyResolver resolver =
                 new HotReloadIntroducedTypeAssemblyResolver(registry);
-            return new HotReloadServices(new HotReloadDomain(registry, resolver));
+            return new HotReloadDomain(registry, resolver);
+        }
+
+        /// <summary>
+        /// Builds the services around <paramref name="domain"/> and <paramref name="harmony"/>,
+        /// without installing them. A test replaces the patch engine through this.
+        /// </summary>
+        internal static HotReloadServices CreateServices(HotReloadDomain domain, IHotReloadHarmony harmony)
+        {
+            HotReloadPatcher patcher = new HotReloadPatcher(domain, harmony);
+            HotReloadFileEntryApplier fileEntryApplier = new HotReloadFileEntryApplier(domain, patcher);
+            return new HotReloadServices(
+                domain,
+                harmony,
+                patcher,
+                fileEntryApplier,
+                new HotReloadEntryApplier(domain, patcher, fileEntryApplier));
         }
 
         /// <summary>

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadEntryApplier.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadEntryApplier.cs
@@ -13,8 +13,25 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     /// <summary>
     /// Applies worker entries: bind accessors, Harmony patch/revert, added-method register.
     /// </summary>
-    internal static class HotReloadEntryApplier
+    internal sealed class HotReloadEntryApplier
     {
+        private readonly HotReloadDomain _domain;
+        private readonly HotReloadPatcher _patcher;
+        private readonly HotReloadFileEntryApplier _fileEntryApplier;
+
+        internal HotReloadEntryApplier(
+            HotReloadDomain domain,
+            HotReloadPatcher patcher,
+            HotReloadFileEntryApplier fileEntryApplier)
+        {
+            Debug.Assert(domain != null, "domain must not be null.");
+            Debug.Assert(patcher != null, "patcher must not be null.");
+            Debug.Assert(fileEntryApplier != null, "fileEntryApplier must not be null.");
+            _domain = domain;
+            _patcher = patcher;
+            _fileEntryApplier = fileEntryApplier;
+        }
+
         /// <summary>
         /// Applies the group's prepared files against the one compiled shim assembly, and returns
         /// one result per file in the order the files were sent to the worker.
@@ -26,7 +43,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         /// (bound and resolved) by an earlier stage, so nothing is mutated while a sibling can
         /// still fail preflight.
         /// </remarks>
-        internal static IReadOnlyList<HotReloadFileProcessResult> ApplyPreparedEntries(
+        internal IReadOnlyList<HotReloadFileProcessResult> ApplyPreparedEntries(
             HotReloadApplyContext context,
             HotReloadShimCompileResult compileResult,
             IReadOnlyList<HotReloadPreparedGroupFile> preparedFiles)
@@ -45,7 +62,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return results;
         }
 
-        private static HotReloadFileProcessResult ApplyPreparedFile(
+        private HotReloadFileProcessResult ApplyPreparedFile(
             HotReloadApplyContext context,
             HotReloadShimCompileResult compileResult,
             HotReloadPreparedGroupFile prepared)
@@ -53,32 +70,23 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             HotReloadGroupFile file = prepared.File;
             if (prepared.Kind == HotReloadGroupFilePreparationKind.SkippedByGroup)
             {
-                return HotReloadFileEntryApplier.BuildUnappliedResult(file);
+                return _fileEntryApplier.BuildUnappliedResult(file);
             }
 
             if (prepared.Kind == HotReloadGroupFilePreparationKind.NoEntriesToApply)
             {
-                HotReloadFileEntryApplier.ClearFileGeneration(context, file);
-                return HotReloadFileEntryApplier.BuildUnappliedResult(file);
+                _fileEntryApplier.ClearFileGeneration(context, file);
+                return _fileEntryApplier.BuildUnappliedResult(file);
             }
 
             if (prepared.Kind == HotReloadGroupFilePreparationKind.ResolutionFailed)
             {
-                return HotReloadFileEntryApplier.BuildResolutionFailedResult(
+                return _fileEntryApplier.BuildResolutionFailedResult(
                     context, file, prepared.Resolution);
             }
 
-            return HotReloadFileEntryApplier.ApplyResolvedFileAndBuildResult(
+            return _fileEntryApplier.ApplyResolvedFileAndBuildResult(
                 context, file, compileResult, prepared.Entries, prepared.Resolution);
-        }
-
-        // Why only here and the empty-entries deactivation: a failed worker or shim compile
-        // returns empty AddedFieldNames while leaving existing patches, so writing the ledger
-        // from the run response would wipe added fields that are still live.
-        internal static void CommitAddedFieldsForFile(string projectRelativePath, string[] addedFieldNames)
-        {
-            HotReloadCompositionRoot.Services.Domain.FindGeneration(projectRelativePath)?.ReplaceAddedFields(
-                addedFieldNames ?? Array.Empty<string>());
         }
 
         // Peels leftover Harmony patches when the source again matches the verified baseline.
@@ -86,7 +94,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         // A method Harmony could not restore becomes that method's Failed outcome instead of
         // aborting the peel, so the remaining unchanged methods still get reverted.
         // Returns how many Revert calls actually removed a live patch.
-        internal static int RevertUnchangedPatches(
+        internal int RevertUnchangedPatches(
             string assemblyName,
             TransformWorkerUnchangedMethodDto[] unchangedMethods,
             List<HotReloadMethodOutcome> outcomes,
@@ -122,7 +130,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     continue;
                 }
 
-                HotReloadRevertOutcome revertOutcome = HotReloadPatcher.Revert(
+                HotReloadRevertOutcome revertOutcome = _patcher.Revert(
                     matchResult.Method,
                     out string revertFailureReason);
                 if (revertOutcome == HotReloadRevertOutcome.Reverted)
@@ -148,7 +156,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         /// Peels every file's leftover patches on the methods the worker reported unchanged, and
         /// records per file how many patches that removed.
         /// </summary>
-        internal static void RevertUnchangedPatchesPerFile(
+        internal void RevertUnchangedPatchesPerFile(
             IReadOnlyList<HotReloadGroupFile> files,
             HotReloadWorkerRowsByFile rows)
         {
@@ -179,7 +187,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         /// Internal so tests can pin the failure contract directly — an end-to-end bind failure
         /// cannot be fabricated once shim compilation has succeeded against the same assembly.
         /// </summary>
-        internal static Dictionary<string, string> BindShimAccessors(Assembly shimAssembly)
+        internal Dictionary<string, string> BindShimAccessors(Assembly shimAssembly)
         {
             Debug.Assert(shimAssembly != null, "shimAssembly must not be null.");
 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadFileEntryApplier.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadFileEntryApplier.cs
@@ -12,12 +12,23 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     /// Applies one file of a group: preflight resolution, generation start, added-field commit,
     /// Harmony patch/register, and that file's result.
     /// </summary>
-    internal static class HotReloadFileEntryApplier
+    internal sealed class HotReloadFileEntryApplier
     {
+        private readonly HotReloadDomain _domain;
+        private readonly HotReloadPatcher _patcher;
+
+        internal HotReloadFileEntryApplier(HotReloadDomain domain, HotReloadPatcher patcher)
+        {
+            Debug.Assert(domain != null, "domain must not be null.");
+            Debug.Assert(patcher != null, "patcher must not be null.");
+            _domain = domain;
+            _patcher = patcher;
+        }
+
         // Why the resolution is passed in: preflight for the whole group runs before any file
         // is mutated, so a match/bind/CheckPatchable failure cannot replace this file's shim or
         // added-member generation.
-        internal static HotReloadFileProcessResult ApplyResolvedFileAndBuildResult(
+        internal HotReloadFileProcessResult ApplyResolvedFileAndBuildResult(
             HotReloadApplyContext context,
             HotReloadGroupFile file,
             HotReloadShimCompileResult compileResult,
@@ -29,12 +40,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             Debug.Assert(fileEntries.Length > 0, "An applied file must hold an entry.");
             Debug.Assert(resolution != null && resolution.AllResolved, "resolution must be resolved.");
 
-            HotReloadCompositionRoot.Services.Domain.BeginGeneration(
+            _domain.BeginGeneration(
                 file.ProjectRelativePath,
                 compileResult.AssemblyBytes,
                 compileResult.PdbBytes,
                 compileResult.Assembly);
-            HotReloadEntryApplier.CommitAddedFieldsForFile(file.ProjectRelativePath, file.AddedFieldNames);
+            CommitAddedFieldsForFile(file.ProjectRelativePath, file.AddedFieldNames);
             List<string> inlineRiskMethodLabels = new List<string>();
             int patchedCount = ApplyResolvedEntries(
                 resolution.ResolvedEntries,
@@ -50,7 +61,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         /// The result of a file whose preflight resolution failed: its failure outcomes are
         /// reported and nothing of this file is applied.
         /// </summary>
-        internal static HotReloadFileProcessResult BuildResolutionFailedResult(
+        internal HotReloadFileProcessResult BuildResolutionFailedResult(
             HotReloadApplyContext context,
             HotReloadGroupFile file,
             HotReloadEntryResolution.Result resolution)
@@ -70,20 +81,20 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         /// Why the added-member-only start: this file contributed no body to the shim assembly,
         /// so it has no shim generation to replace.
         /// </remarks>
-        internal static void ClearFileGeneration(HotReloadApplyContext context, HotReloadGroupFile file)
+        internal void ClearFileGeneration(HotReloadApplyContext context, HotReloadGroupFile file)
         {
             Debug.Assert(context != null, "context must not be null.");
             Debug.Assert(file != null, "file must not be null.");
 
             IReadOnlyList<string> addedLabelsAtClear =
-                HotReloadCompositionRoot.Services.Domain.ListActiveAddedMethodKeys(file.ProjectRelativePath);
+                _domain.ListActiveAddedMethodKeys(file.ProjectRelativePath);
             HotReloadOrchestratorLog.LogHotReloadEmptyEntriesClear(addedLabelsAtClear, context.CorrelationId);
-            HotReloadCompositionRoot.Services.Domain.BeginAddedMemberOnlyGeneration(file.ProjectRelativePath);
+            _domain.BeginAddedMemberOnlyGeneration(file.ProjectRelativePath);
             // Why AddedFieldNames first: a retry (gate or isolation) replaces this file's added
             // field names, and committing the first-pass names would resurrect a field the
             // retry no longer emits. The worker row is the first-pass fallback.
             string[] addedFieldNames = file.AddedFieldNames ?? file.FileOutput.addedFieldNames;
-            HotReloadEntryApplier.CommitAddedFieldsForFile(file.ProjectRelativePath, addedFieldNames);
+            CommitAddedFieldsForFile(file.ProjectRelativePath, addedFieldNames);
             // Why recorded: a file that only declares an added member has no entry of its own,
             // yet a sibling file's applied body uses that field, so the run must report it.
             file.ClearedAddedFieldNames = addedFieldNames;
@@ -103,7 +114,16 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         /// failure of another stage, or a file left with no entry to patch. It reports added
         /// field names only when the clear path committed them.
         /// </summary>
-        internal static HotReloadFileProcessResult BuildUnappliedResult(HotReloadGroupFile file)
+        // Why only here and the empty-entries deactivation: a failed worker or shim compile
+        // returns empty AddedFieldNames while leaving existing patches, so writing the ledger
+        // from the run response would wipe added fields that are still live.
+        private void CommitAddedFieldsForFile(string projectRelativePath, string[] addedFieldNames)
+        {
+            _domain.FindGeneration(projectRelativePath)?.ReplaceAddedFields(
+                addedFieldNames ?? Array.Empty<string>());
+        }
+
+        internal HotReloadFileProcessResult BuildUnappliedResult(HotReloadGroupFile file)
         {
             Debug.Assert(file != null, "file must not be null.");
 
@@ -125,7 +145,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         /// <summary>
         /// The results of a group no file of which was applied, one unapplied result per file.
         /// </summary>
-        internal static List<HotReloadFileProcessResult> BuildUnappliedGroupResults(
+        internal List<HotReloadFileProcessResult> BuildUnappliedGroupResults(
             IReadOnlyList<HotReloadGroupFile> files)
         {
             List<HotReloadFileProcessResult> results =
@@ -137,7 +157,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             return results;
         }
-        private static HotReloadFileProcessResult FinishFileResult(
+        private HotReloadFileProcessResult FinishFileResult(
             HotReloadApplyContext context,
             HotReloadGroupFile file,
             int patchedCount,
@@ -169,7 +189,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 introducedTypes: sinks.IntroducedTypes);
         }
 
-        private static int ApplyResolvedEntries(
+        private int ApplyResolvedEntries(
             IReadOnlyList<HotReloadEntryResolution.ResolvedEntry> resolvedEntries,
             TransformWorkerEntryDto[] entriesToPatch,
             HotReloadGroupFile file,
@@ -232,7 +252,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return patchedCount;
         }
 
-        private static void AppendOneShotCallerNoteCandidate(
+        private void AppendOneShotCallerNoteCandidate(
             HotReloadEntryResolution.ResolvedEntry resolved,
             HotReloadMethodOutcome outcome,
             string assemblyName,
@@ -260,7 +280,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             candidates.Add(new HotReloadOneShotCallerNoteEnricher.Candidate(identity, outcome));
         }
 
-        private static HotReloadMethodOutcome ApplyResolvedEntry(
+        private HotReloadMethodOutcome ApplyResolvedEntry(
             HotReloadEntryResolution.ResolvedEntry resolved,
             string projectRelativePath,
             List<string> inlineRiskMethodLabels,
@@ -268,7 +288,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             List<string> retargetedPausePointIds)
         {
             HotReloadFileGeneration generation =
-                HotReloadCompositionRoot.Services.Domain.FindGeneration(projectRelativePath);
+                _domain.FindGeneration(projectRelativePath);
             Debug.Assert(generation != null, "The file's generation must have started before its entries apply.");
             if (resolved.IsAddedMethod)
             {
@@ -291,7 +311,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     resolved.PatchShape == HotReloadPatchShape.Delegation,
                     resolved.Entry.sourceStartLine,
                     resolved.Entry.sourceEndLine));
-            HotReloadPatchResult patchResult = HotReloadPatcher.Apply(
+            HotReloadPatchResult patchResult = _patcher.Apply(
                 resolved.OriginalMethod,
                 resolved.ShimMethod,
                 resolved.PatchShape,
@@ -326,7 +346,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         // What: after Apply (+ retarget handler), splits armed markers into retargeted vs suppressed.
         // Expired skips are recorded as a pending-drain event inside SourcePausePointPatcher and
         // surfaced from HotReloadTools.BuildApplyResponse (same pattern as line-drift warnings).
-        private static void AppendPausePointTransitionIds(
+        private void AppendPausePointTransitionIds(
             MethodBase method,
             List<string> suppressedPausePointIds,
             List<string> retargetedPausePointIds)

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupCommitStage.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupCommitStage.cs
@@ -39,12 +39,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             {
                 if (prepared.Kind == HotReloadGroupFilePreparationKind.ResolutionFailed)
                 {
-                    results.Add(HotReloadFileEntryApplier.BuildResolutionFailedResult(
+                    results.Add(HotReloadCompositionRoot.Services.FileEntryApplier.BuildResolutionFailedResult(
                         context, prepared.File, prepared.Resolution));
                     continue;
                 }
 
-                results.Add(HotReloadFileEntryApplier.BuildUnappliedResult(prepared.File));
+                results.Add(HotReloadCompositionRoot.Services.FileEntryApplier.BuildUnappliedResult(prepared.File));
             }
 
             return results;
@@ -74,7 +74,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             bool commitsIntroducedTypes = CommitsIntroducedTypes(prepared, files[0].AssemblyName);
             if (commitsIntroducedTypes)
             {
-                HotReloadEntryApplier.RevertUnchangedPatchesPerFile(
+                HotReloadCompositionRoot.Services.EntryApplier.RevertUnchangedPatchesPerFile(
                     files,
                     HotReloadWorkerRowsByFile.Build(context.WorkerOutput, context.ProjectRelativePaths));
             }
@@ -89,7 +89,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     ClearEmptyFileGenerations(context);
                 }
 
-                return HotReloadFileEntryApplier.BuildUnappliedGroupResults(files);
+                return HotReloadCompositionRoot.Services.FileEntryApplier.BuildUnappliedGroupResults(files);
             }
 
             HotReloadGroupProcessorDependencies dependencies = HotReloadGroupProcessorDependencies.Current;
@@ -144,7 +144,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     continue;
                 }
 
-                HotReloadFileEntryApplier.ClearFileGeneration(context, file);
+                HotReloadCompositionRoot.Services.FileEntryApplier.ClearFileGeneration(context, file);
             }
         }
 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupEntryPreparation.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupEntryPreparation.cs
@@ -32,7 +32,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             // Why once for the group: every shim type of the group lives in this one assembly, so
             // binding per file would re-run the same binders and hide which file first failed.
             Dictionary<string, string> bindFailures =
-                HotReloadEntryApplier.BindShimAccessors(compileResult.Assembly);
+                HotReloadCompositionRoot.Services.EntryApplier.BindShimAccessors(compileResult.Assembly);
             List<HotReloadPreparedGroupFile> prepared =
                 new List<HotReloadPreparedGroupFile>(context.Files.Count);
             foreach (HotReloadGroupFile file in context.Files)

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupProcessor.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupProcessor.cs
@@ -34,7 +34,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             await MainThreadSwitcher.SwitchToMainThread(ct);
             if (!HotReloadGroupProcessorDependencies.Current.ValidateNewSourceMembership(files))
             {
-                return HotReloadFileEntryApplier.BuildUnappliedGroupResults(files);
+                return HotReloadCompositionRoot.Services.FileEntryApplier.BuildUnappliedGroupResults(files);
             }
 
             SnapshotGroupState(files);
@@ -82,7 +82,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     HotReloadGroupOutcomeRouter.AppendGroupFailure(files, "(file)", preparation.ErrorMessage);
                 }
 
-                return HotReloadFileEntryApplier.BuildUnappliedGroupResults(files);
+                return HotReloadCompositionRoot.Services.FileEntryApplier.BuildUnappliedGroupResults(files);
             }
 
             if (preparation.Prepared == null)
@@ -155,7 +155,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             if (!workerResult.Success)
             {
                 HotReloadGroupOutcomeRouter.AppendGroupFailure(files, "(file)", workerResult.ErrorMessage);
-                return HotReloadFileEntryApplier.BuildUnappliedGroupResults(files);
+                return HotReloadCompositionRoot.Services.FileEntryApplier.BuildUnappliedGroupResults(files);
             }
 
             TransformWorkerOutputDto workerOutput = workerResult.Output;
@@ -182,9 +182,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 && !await RevalidateBeforeRevertAsync(
                     files,
                     ct,
-                    () => HotReloadEntryApplier.RevertUnchangedPatchesPerFile(files, rows)).ConfigureAwait(false))
+                    () => HotReloadCompositionRoot.Services.EntryApplier.RevertUnchangedPatchesPerFile(files, rows)).ConfigureAwait(false))
             {
-                return HotReloadFileEntryApplier.BuildUnappliedGroupResults(files);
+                return HotReloadCompositionRoot.Services.FileEntryApplier.BuildUnappliedGroupResults(files);
             }
 
             HotReloadApplyContext context = new HotReloadApplyContext(
@@ -204,7 +204,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 .ConfigureAwait(false);
             if (gateAndCompile.Outcome == HotReloadGroupGateAndCompileOutcome.Failed)
             {
-                return HotReloadFileEntryApplier.BuildUnappliedGroupResults(files);
+                return HotReloadCompositionRoot.Services.FileEntryApplier.BuildUnappliedGroupResults(files);
             }
 
             return await CompleteApplyAfterCoverageAsync(
@@ -290,14 +290,14 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 && gateResult.DidScan
                 && !AppendSignatureChangeCoverageNotices(context, gateResult, compile))
             {
-                return HotReloadFileEntryApplier.BuildUnappliedGroupResults(context.Files);
+                return HotReloadCompositionRoot.Services.FileEntryApplier.BuildUnappliedGroupResults(context.Files);
             }
 
             await MainThreadSwitcher.SwitchToMainThread(ct);
             ct.ThrowIfCancellationRequested();
             if (!TryAppendNewSourceMembershipFailure(context.Files))
             {
-                return HotReloadFileEntryApplier.BuildUnappliedGroupResults(context.Files);
+                return HotReloadCompositionRoot.Services.FileEntryApplier.BuildUnappliedGroupResults(context.Files);
             }
 
             ct.ThrowIfCancellationRequested();
@@ -305,7 +305,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             if (staleReason != null)
             {
                 HotReloadGroupOutcomeRouter.AppendGroupFailure(context.Files, "(file)", staleReason);
-                return HotReloadFileEntryApplier.BuildUnappliedGroupResults(context.Files);
+                return HotReloadCompositionRoot.Services.FileEntryApplier.BuildUnappliedGroupResults(context.Files);
             }
 
             // Why the whole group is resolved before any file is mutated: a file whose entries

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupProcessorDependencies.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupProcessorDependencies.cs
@@ -80,7 +80,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 TransformWorkerClient.RunAsync,
                 HotReloadGroupProcessor.GateAndCompileAsync,
                 HotReloadGroupEntryPreparation.PrepareGroup,
-                HotReloadEntryApplier.ApplyPreparedEntries);
+                // A lambda, not a method group: the static field below is built once per domain
+                // reload, and a captured instance would keep applying into the domain that was
+                // installed then, while the transpilers read whichever domain is installed now.
+                (context, compileResult, preparedFiles) =>
+                    HotReloadCompositionRoot.Services.EntryApplier.ApplyPreparedEntries(
+                        context, compileResult, preparedFiles));
         }
 
         internal static HotReloadGroupProcessorDependencies Create(

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadHarmonyGateway.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadHarmonyGateway.cs
@@ -1,0 +1,37 @@
+using System.Reflection;
+
+using HarmonyLib;
+
+using UnityEngine;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// The production <see cref="IHotReloadHarmony"/>: forwards straight to one Harmony instance.
+    /// </summary>
+    internal sealed class HotReloadHarmonyGateway : IHotReloadHarmony
+    {
+        private readonly Harmony _harmony;
+
+        internal HotReloadHarmonyGateway(Harmony harmony)
+        {
+            Debug.Assert(harmony != null, "harmony must not be null.");
+            _harmony = harmony;
+        }
+
+        public void Patch(MethodBase original, HarmonyMethod transpiler)
+        {
+            _harmony.Patch(original, transpiler: transpiler);
+        }
+
+        public void Unpatch(MethodBase original, HarmonyPatchType patchType, string harmonyId)
+        {
+            _harmony.Unpatch(original, patchType, harmonyId);
+        }
+
+        public void UnpatchAll(string harmonyId)
+        {
+            _harmony.UnpatchAll(harmonyId);
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadHarmonyGateway.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadHarmonyGateway.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 465b50b43b41c4788b5f76dd560db38f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadPatcher.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadPatcher.cs
@@ -18,9 +18,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     /// forwards every argument to a normally-JIT-compiled shim whose inaccessible accesses
     /// were rewritten to accessor delegates.
     /// </summary>
-    internal static class HotReloadPatcher
+    internal sealed class HotReloadPatcher
     {
-        private static readonly Harmony HarmonyInstance = new Harmony(HotReloadConstants.HarmonyId);
         private static readonly MethodInfo TransplantTranspilerMethodInfo =
             typeof(HotReloadPatcher).GetMethod(
                 nameof(ReplaceWithTransplantSourceTranspiler),
@@ -37,9 +36,20 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 new[] { typeof(string) },
                 null);
 
+        private readonly HotReloadDomain _domain;
+        private readonly IHotReloadHarmony _harmony;
+
+        internal HotReloadPatcher(HotReloadDomain domain, IHotReloadHarmony harmony)
+        {
+            Debug.Assert(domain != null, "domain must not be null.");
+            Debug.Assert(harmony != null, "harmony must not be null.");
+            _domain = domain;
+            _harmony = harmony;
+        }
+
         // Harmony resolves transpilers as static methods, so the domain cannot be a parameter of
-        // one; the transpilers below read it from the slot instead.
-        private static HotReloadDomain Domain => HotReloadTranspilerDomainGateway.Current;
+        // one; the transpilers below read it from the gateway instead.
+        private static HotReloadDomain TranspilerDomain => HotReloadTranspilerDomainGateway.Current;
 
         /// <summary>
         /// Patches <paramref name="method"/> with <paramref name="shimMethodInfo"/> using
@@ -48,7 +58,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         /// Engine failures during apply never throw; they are contained as an
         /// <see cref="HotReloadPatchFailureReason.ApplyFailed"/> result for that method only.
         /// </summary>
-        public static HotReloadPatchResult Apply(
+        public HotReloadPatchResult Apply(
             MethodBase method,
             MethodInfo shimMethodInfo,
             HotReloadPatchShape patchShape,
@@ -74,7 +84,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 return patchability;
             }
 
-            HotReloadFileGeneration generation = Domain.FindGeneration(filePath);
+            HotReloadFileGeneration generation = _domain.FindGeneration(filePath);
             if (generation == null)
             {
                 return HotReloadPatchResult.Failure(
@@ -86,7 +96,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             // generation: a method's live patch belongs to whichever file's generation applied it,
             // and a rename or move re-applies the same method from a different path. Asking only
             // this generation would miss that patch and stack a second transpiler on the method.
-            HotReloadFileGeneration patchOwner = Domain.FindGenerationForMethod(method);
+            HotReloadFileGeneration patchOwner = _domain.FindGenerationForMethod(method);
             if (patchOwner != null && patchOwner.IsPatchActive(method))
             {
                 // Why the patch is retired before Unpatch: same as Revert — during Unpatch Harmony
@@ -96,7 +106,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 // this method into the new generation before calling Apply.
                 patchOwner.DeactivatePatch(method);
                 HotReloadInvocationRegistry.Remove(HotReloadMethodKeys.FormatMethodLabel(method));
-                HarmonyInstance.Unpatch(method, HarmonyPatchType.Transpiler, HotReloadConstants.HarmonyId);
+                _harmony.Unpatch(method, HarmonyPatchType.Transpiler, HotReloadConstants.HarmonyId);
                 // Mirror the removal: if the re-Patch below fails, its contained Unpatch rebuilds
                 // with markers restored (no live patch), and RevertAll can never reach this method
                 // again — leaving suppress stuck true would make status lie forever.
@@ -115,9 +125,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 // Why Priority.First: same numeric priority sorts by registration index, and
                 // Unpatch does not reindex — Patch/Unpatch cycles make same-priority order
                 // unstable. pause-point must run after hot-reload so it sees the shim stream.
-                HarmonyInstance.Patch(
+                _harmony.Patch(
                     method,
-                    transpiler: new HarmonyMethod(transpilerMethodInfo)
+                    new HarmonyMethod(transpilerMethodInfo)
                     {
                         priority = Priority.First
                     });
@@ -143,7 +153,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 // method's Failed outcome so the per-method contract holds. Unpatch removes
                 // the transpiler this call registered before failing and rebuilds the
                 // wrapper, restoring the original body (verified by the extern-shim test).
-                HarmonyInstance.Unpatch(method, HarmonyPatchType.Transpiler, HotReloadConstants.HarmonyId);
+                _harmony.Unpatch(method, HarmonyPatchType.Transpiler, HotReloadConstants.HarmonyId);
                 // Why after Unpatch: retarget may have already replaced markers onto the shim;
                 // restore them onto the original body now that GetActiveShim is null.
                 HotReloadPausePointCoordination.OnHotReloadPatchStateChanged?.Invoke(method, false);
@@ -169,30 +179,25 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         /// Removes every hot-reload patch owned by this patcher and clears every
         /// domain-scoped store.
         /// </summary>
-        public static void RevertAll()
+        public void RevertAll()
         {
             // Snapshot and empty the domain BEFORE UnpatchAll: Harmony rebuilds every patched
             // method during UnpatchAll, and the pause-point transpiler guard must see those
             // methods as unpatched so armed markers are re-instrumented into the restored
             // original IL. Shim registration clears in the same window so GetActiveShimForMethod
             // and GetShimLookupForFile agree during rebuild.
-            IReadOnlyList<MethodBase> revertedMethods = Domain.RevertAll();
-            HarmonyInstance.UnpatchAll(HotReloadConstants.HarmonyId);
+            IReadOnlyList<MethodBase> revertedMethods = _domain.RevertAll();
+            _harmony.UnpatchAll(HotReloadConstants.HarmonyId);
             foreach (MethodBase revertedMethod in revertedMethods)
             {
                 HotReloadPausePointCoordination.OnHotReloadPatchStateChanged?.Invoke(revertedMethod, false);
             }
         }
 
-        // Set by tests only. A Harmony rebuild failure cannot be provoked from outside, and the
-        // contained-failure contract of Revert has to be pinned by a test. Production leaves it
-        // null and reverts through Harmony.
-        internal static Action<MethodBase> UnpatchForTesting;
-
         /// <summary>
         /// Removes the hot-reload patch on <paramref name="method"/> when one is recorded.
         /// </summary>
-        public static HotReloadRevertOutcome Revert(MethodBase method, out string failureReason)
+        public HotReloadRevertOutcome Revert(MethodBase method, out string failureReason)
         {
             Debug.Assert(method != null, "method must not be null.");
 
@@ -205,7 +210,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             // next apply's "unpatch the previous transpiler first" decision and pause-point's
             // chain-join offsets all read it, so a rebuild failure that leaves the patch live must
             // leave the whole entry describing that patch.
-            HotReloadFileGeneration generation = Domain.FindGenerationForMethod(method);
+            HotReloadFileGeneration generation = _domain.FindGenerationForMethod(method);
             HotReloadActivePatchEntry removedEntry = generation?.DeactivatePatch(method);
             if (removedEntry == null)
             {
@@ -267,47 +272,41 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return false;
         }
 
-        private static void Unpatch(MethodBase method)
+        private void Unpatch(MethodBase method)
         {
-            if (UnpatchForTesting != null)
-            {
-                UnpatchForTesting(method);
-                return;
-            }
-
-            HarmonyInstance.Unpatch(method, HarmonyPatchType.Transpiler, HotReloadConstants.HarmonyId);
+            _harmony.Unpatch(method, HarmonyPatchType.Transpiler, HotReloadConstants.HarmonyId);
         }
 
         /// <summary>
         /// How many methods currently have a live hot-reload patch.
         /// </summary>
-        public static int ActivePatchCount => Domain.ActivePatchCount;
+        public int ActivePatchCount => _domain.ActivePatchCount;
 
         /// <summary>
         /// Harmony patches plus added-method shims. Domain reload drops both, so Play-entry
         /// warnings and ActivePatchTotal count this sum.
         /// </summary>
-        public static int ActiveChangeCount => Domain.ActiveChangeCount;
+        public int ActiveChangeCount => _domain.ActiveChangeCount;
 
         /// <summary>
         /// Returns a sorted list of active patches (method key + source file path) for status
         /// reporting without applying or reverting patches.
         /// </summary>
-        public static IReadOnlyList<HotReloadActivePatchInfo> DescribeActivePatches()
+        public IReadOnlyList<HotReloadActivePatchInfo> DescribeActivePatches()
         {
-            return Domain.DescribeActivePatches();
+            return _domain.DescribeActivePatches();
         }
 
         // Why projectRelativePath, not DescribeActivePatches FilePath filtering by callers: a
         // patch belongs to the generation of the orchestrator's project-relative path.
-        public static IReadOnlyList<string> ListActiveMethodKeys(string projectRelativePath)
+        public IReadOnlyList<string> ListActiveMethodKeys(string projectRelativePath)
         {
-            return Domain.ListActiveMethodKeys(projectRelativePath);
+            return _domain.ListActiveMethodKeys(projectRelativePath);
         }
 
-        public static IReadOnlyList<string> ListActiveFilePaths()
+        public IReadOnlyList<string> ListActiveFilePaths()
         {
-            return Domain.ListActiveFilePaths();
+            return _domain.ListActiveFilePaths();
         }
 
         private static IEnumerable<CodeInstruction> ReplaceWithTransplantSourceTranspiler(
@@ -315,7 +314,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             ILGenerator generator,
             MethodBase original)
         {
-            HotReloadFileGeneration generation = Domain.FindGenerationForMethod(original);
+            HotReloadFileGeneration generation = TranspilerDomain.FindGenerationForMethod(original);
             MethodInfo shimMethod = generation?.FindPatchShim(original);
             Debug.Assert(shimMethod != null, "Shim must be registered before Patch runs.");
             // Discard the original (and any prior transpiler) instructions entirely — the shim IL
@@ -343,7 +342,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             IEnumerable<CodeInstruction> instructions,
             MethodBase original)
         {
-            HotReloadFileGeneration generation = Domain.FindGenerationForMethod(original);
+            HotReloadFileGeneration generation = TranspilerDomain.FindGenerationForMethod(original);
             MethodInfo shimMethod = generation?.FindPatchShim(original);
             Debug.Assert(shimMethod != null, "Shim must be registered before Patch runs.");
 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadPlayModeEntryDropRecorder.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadPlayModeEntryDropRecorder.cs
@@ -201,7 +201,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         /// </summary>
         internal static IReadOnlyList<string> CollectActiveIdentities()
         {
-            IReadOnlyList<HotReloadActivePatchInfo> patches = HotReloadPatcher.DescribeActivePatches();
+            IReadOnlyList<HotReloadActivePatchInfo> patches = HotReloadCompositionRoot.Services.Patcher.DescribeActivePatches();
             IReadOnlyList<HotReloadAddedMemberInfo> addedMembers =
                 HotReloadCompositionRoot.Services.Domain.DescribeAddedMembers();
             List<string> identities = new List<string>(patches.Count + addedMembers.Count);

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadRunAccumulator.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadRunAccumulator.cs
@@ -139,7 +139,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 methods: _outcomes,
                 warnings: _warnings,
                 patchedTotal: _patchedTotal,
-                activePatchTotal: HotReloadPatcher.ActiveChangeCount,
+                activePatchTotal: HotReloadCompositionRoot.Services.Patcher.ActiveChangeCount,
                 suppressedPausePointIds: _suppressedPausePointIds,
                 unchangedTotal: _unchangedTotal,
                 retargetedPausePointIds: _retargetedPausePointIds,

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadServices.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadServices.cs
@@ -8,12 +8,33 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     /// </summary>
     internal sealed class HotReloadServices
     {
-        internal HotReloadServices(HotReloadDomain domain)
+        internal HotReloadServices(
+            HotReloadDomain domain,
+            IHotReloadHarmony harmony,
+            HotReloadPatcher patcher,
+            HotReloadFileEntryApplier fileEntryApplier,
+            HotReloadEntryApplier entryApplier)
         {
             Debug.Assert(domain != null, "domain must not be null.");
+            Debug.Assert(harmony != null, "harmony must not be null.");
+            Debug.Assert(patcher != null, "patcher must not be null.");
+            Debug.Assert(fileEntryApplier != null, "fileEntryApplier must not be null.");
+            Debug.Assert(entryApplier != null, "entryApplier must not be null.");
             Domain = domain;
+            Harmony = harmony;
+            Patcher = patcher;
+            FileEntryApplier = fileEntryApplier;
+            EntryApplier = entryApplier;
         }
 
         internal HotReloadDomain Domain { get; }
+
+        internal IHotReloadHarmony Harmony { get; }
+
+        internal HotReloadPatcher Patcher { get; }
+
+        internal HotReloadFileEntryApplier FileEntryApplier { get; }
+
+        internal HotReloadEntryApplier EntryApplier { get; }
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadStalePatchOutcomes.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadStalePatchOutcomes.cs
@@ -25,7 +25,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             HashSet<string> activeDisplayKeys = new HashSet<string>(
-                HotReloadPatcher.ListActiveMethodKeys(projectRelativePath),
+                HotReloadCompositionRoot.Services.Patcher.ListActiveMethodKeys(projectRelativePath),
                 StringComparer.Ordinal);
             if (activeDisplayKeys.Count == 0)
             {

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadStatusExecutor.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadStatusExecutor.cs
@@ -13,8 +13,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     {
         public static HotReloadResponse ExecuteRevertAll()
         {
-            int clearedCount = HotReloadPatcher.ActiveChangeCount;
-            HotReloadPatcher.RevertAll();
+            int clearedCount = HotReloadCompositionRoot.Services.Patcher.ActiveChangeCount;
+            HotReloadCompositionRoot.Services.Patcher.RevertAll();
             HotReloadPlayModeEntryDropRecorder.NotifyRevertAll();
             HotReloadAutoRefreshHoldSyncResult hold =
                 HotReloadAutoRefreshHold.SyncToActiveChanges();
@@ -50,7 +50,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
         public static HotReloadResponse ExecuteStatus()
         {
-            IReadOnlyList<HotReloadActivePatchInfo> active = HotReloadPatcher.DescribeActivePatches();
+            IReadOnlyList<HotReloadActivePatchInfo> active = HotReloadCompositionRoot.Services.Patcher.DescribeActivePatches();
             IReadOnlyList<HotReloadAddedMemberInfo> addedMembers =
                 HotReloadCompositionRoot.Services.Domain.DescribeAddedMembers();
             List<HotReloadMethodResult> methods =

--- a/Packages/src/Editor/FirstPartyTools/HotReload/IHotReloadHarmony.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/IHotReloadHarmony.cs
@@ -1,0 +1,34 @@
+using System.Reflection;
+
+using HarmonyLib;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// The patch engine operations the hot-reload patcher performs, behind a seam a test can
+    /// replace.
+    /// </summary>
+    /// <remarks>
+    /// Why an interface rather than the Harmony instance: a rebuild failure cannot be provoked
+    /// from outside Harmony, and the contained-failure contract of a revert has to be pinned by a
+    /// test that makes exactly that call fail.
+    /// </remarks>
+    internal interface IHotReloadHarmony
+    {
+        /// <summary>
+        /// Registers <paramref name="transpiler"/> on <paramref name="original"/>.
+        /// </summary>
+        void Patch(MethodBase original, HarmonyMethod transpiler);
+
+        /// <summary>
+        /// Removes the patch of one kind that <paramref name="harmonyId"/> owns from
+        /// <paramref name="original"/>, rebuilding the method.
+        /// </summary>
+        void Unpatch(MethodBase original, HarmonyPatchType patchType, string harmonyId);
+
+        /// <summary>
+        /// Removes every patch <paramref name="harmonyId"/> owns.
+        /// </summary>
+        void UnpatchAll(string harmonyId);
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/IHotReloadHarmony.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/IHotReloadHarmony.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3f4831fa5eaca4a7cab1f333551e1cd4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary
- Internal refactor of the hot-reload tool. No user-visible change: the same commands produce the same responses.
- The patch engine is now a dependency the composition root injects, instead of a static Harmony field with a test hook next to it.

## User Impact
- None. `uloop hot-reload` (`--status`, `--revert-all`, apply) behaves exactly as before.

## Changes
- Make `HotReloadPatcher`, `HotReloadFileEntryApplier` and `HotReloadEntryApplier` instances that take their domain and collaborators in the constructor, and build them in the composition root. The transpilers stay static because Harmony resolves them as static methods, and they keep reading the installed domain through the transpiler gateway.
- Add `IHotReloadHarmony` and `HotReloadHarmonyGateway`, and delete `HotReloadPatcher.UnpatchForTesting`. The two revert-failure tests inject a harmony that refuses one unpatch, so the contained-failure contract is pinned without a production seam.
- Move `CommitAddedFieldsForFile` into `HotReloadFileEntryApplier`, its only caller, so the two appliers depend on each other in one direction only.
- Resolve the production apply delegate at call time in `HotReloadGroupProcessorDependencies`. Its static field is built once per domain reload; a captured applier instance kept writing into the domain that was installed then, while the transpilers read whichever domain is installed now. That mismatch made a replacement-scope run patch a method whose shim the current domain had never registered.

## Verification
- `uloop compile`: `ErrorCount 0`, `Success true`.
- EditMode tests, run single-flight with class/regex filters:
  - patcher / file generations / tool / orchestrator / group processor / introduced type activation / cross-file E2E / introduced type response: 316 passed, 0 failed
  - `HotReloadOrchestratorTests` alone: 155 passed, 0 failed
- Red check on the two rewritten revert-failure tests: removing the refusal from the injected harmony makes both fail with `Expected: UnpatchFailed But was: Reverted`; restored and re-run green (19 passed, 0 failed).
- `uloop hot-reload --status` and `--revert-all` return the clean-state responses unchanged (`0 change(s) currently active.` / `No active hot-reload changes to revert.`).
- `git grep -n "static class HotReload\(Patcher\|FileEntryApplier\|EntryApplier\)\b"`: 0 hits.
- File length: no file this change touches crosses 400 SLOC except `HotReloadGroupProcessor.cs` at 401, which was already over before this change and whose line count is unchanged here. The repository's 500 SLOC gate passes.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2734?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

