### PR TITLE
fix: Pause point no longer answers from a hot-reload domain that was uninstalled

### DIFF
--- a/Assets/Tests/Editor/CoordinationPorts.meta
+++ b/Assets/Tests/Editor/CoordinationPorts.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c1146f100b0374ef1ab84f837ad50b77
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/CoordinationPorts/HotReloadPausePointPortScopes.cs
+++ b/Assets/Tests/Editor/CoordinationPorts/HotReloadPausePointPortScopes.cs
@@ -1,0 +1,55 @@
+using System;
+
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor
+{
+    /// <summary>
+    /// Substitutes the hot-reload side of the coordination point for the life of the scope and
+    /// puts the previously installed port back on dispose. Members the test does not override on
+    /// <see cref="Port"/> still answer from that previous port.
+    /// </summary>
+    public sealed class HotReloadSidePortScope : IDisposable
+    {
+        private readonly IHotReloadPausePointPort _previous;
+
+        public HotReloadSidePortScope()
+        {
+            _previous = HotReloadPausePointCoordination.HotReloadSide;
+            Port = new StubHotReloadPausePointPort { Inner = _previous };
+            HotReloadPausePointCoordination.HotReloadSide = Port;
+        }
+
+        /// <summary>The stub the test configures. Overriding a member replaces just that answer.</summary>
+        public StubHotReloadPausePointPort Port { get; }
+
+        public void Dispose()
+        {
+            HotReloadPausePointCoordination.HotReloadSide = _previous;
+        }
+    }
+
+    /// <summary>
+    /// Substitutes the pause-point side of the coordination point for the life of the scope and
+    /// puts the previously installed port back on dispose.
+    /// </summary>
+    public sealed class PausePointSidePortScope : IDisposable
+    {
+        private readonly IPausePointHotReloadPort _previous;
+
+        public PausePointSidePortScope()
+        {
+            _previous = HotReloadPausePointCoordination.PausePointSide;
+            Port = new StubPausePointHotReloadPort { Inner = _previous };
+            HotReloadPausePointCoordination.PausePointSide = Port;
+        }
+
+        /// <summary>The stub the test configures. Overriding a member replaces just that answer.</summary>
+        public StubPausePointHotReloadPort Port { get; }
+
+        public void Dispose()
+        {
+            HotReloadPausePointCoordination.PausePointSide = _previous;
+        }
+    }
+}

--- a/Assets/Tests/Editor/CoordinationPorts/HotReloadPausePointPortScopes.cs.meta
+++ b/Assets/Tests/Editor/CoordinationPorts/HotReloadPausePointPortScopes.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fcabb922bde9a4de98c2c1e6ea05fae5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/CoordinationPorts/StubHotReloadPausePointPort.cs
+++ b/Assets/Tests/Editor/CoordinationPorts/StubHotReloadPausePointPort.cs
@@ -1,0 +1,85 @@
+using System.Collections.Generic;
+using System.Reflection;
+using System.Reflection.Emit;
+
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor
+{
+    /// <summary>
+    /// Test double for the hot-reload side of the coordination point. Every member falls through
+    /// to <see cref="Inner"/> (the port that was installed when the test opened) unless the test
+    /// overrides that one member, so a test states only the answers it cares about.
+    /// </summary>
+    public sealed class StubHotReloadPausePointPort : IHotReloadPausePointPort
+    {
+        /// <summary>The port answers fall through to. Null answers "no domain installed".</summary>
+        public IHotReloadPausePointPort Inner { get; set; }
+
+        public System.Func<MethodBase, MethodBase> ActiveShimForMethod { get; set; }
+
+        public System.Func<string, HotReloadShimFileLookup> ShimLookupForFile { get; set; }
+
+        public System.Func<string, string> VerifiedSnapshotSourceForFile { get; set; }
+
+        public System.Func<string, string, string> VerifiedSnapshotSource { get; set; }
+
+        public System.Func<MethodBase, IReadOnlyList<LocalBuilder>> TransplantLocals { get; set; }
+
+        public System.Func<MethodBase, int> TransplantPreambleLength { get; set; }
+
+        public System.Func<string, IReadOnlyList<string>> AddedFieldsForType { get; set; }
+
+        public MethodBase GetActiveShimForMethod(MethodBase method)
+        {
+            return ActiveShimForMethod != null
+                ? ActiveShimForMethod(method)
+                : Inner?.GetActiveShimForMethod(method);
+        }
+
+        public HotReloadShimFileLookup GetShimLookupForFile(string file)
+        {
+            return ShimLookupForFile != null
+                ? ShimLookupForFile(file)
+                : Inner?.GetShimLookupForFile(file);
+        }
+
+        public string GetVerifiedSnapshotSourceForFile(string projectRelativeFile)
+        {
+            return VerifiedSnapshotSourceForFile != null
+                ? VerifiedSnapshotSourceForFile(projectRelativeFile)
+                : Inner?.GetVerifiedSnapshotSourceForFile(projectRelativeFile);
+        }
+
+        public string GetVerifiedSnapshotSource(string projectRelativeFile, string dllPath)
+        {
+            return VerifiedSnapshotSource != null
+                ? VerifiedSnapshotSource(projectRelativeFile, dllPath)
+                : Inner?.GetVerifiedSnapshotSource(projectRelativeFile, dllPath);
+        }
+
+        public IReadOnlyList<LocalBuilder> GetTransplantLocals(MethodBase method)
+        {
+            return TransplantLocals != null
+                ? TransplantLocals(method)
+                : Inner?.GetTransplantLocals(method);
+        }
+
+        public int GetTransplantPreambleLength(MethodBase method)
+        {
+            if (TransplantPreambleLength != null)
+            {
+                return TransplantPreambleLength(method);
+            }
+
+            return Inner?.GetTransplantPreambleLength(method) ?? 0;
+        }
+
+        public IReadOnlyList<string> GetAddedFieldsForType(string typeFullName)
+        {
+            return AddedFieldsForType != null
+                ? AddedFieldsForType(typeFullName)
+                : Inner?.GetAddedFieldsForType(typeFullName);
+        }
+    }
+}

--- a/Assets/Tests/Editor/CoordinationPorts/StubHotReloadPausePointPort.cs.meta
+++ b/Assets/Tests/Editor/CoordinationPorts/StubHotReloadPausePointPort.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 92a1980920d1e460c854e61e1a1577a9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/CoordinationPorts/StubPausePointHotReloadPort.cs
+++ b/Assets/Tests/Editor/CoordinationPorts/StubPausePointHotReloadPort.cs
@@ -1,0 +1,68 @@
+using System.Collections.Generic;
+using System.Reflection;
+
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor
+{
+    /// <summary>
+    /// Test double for the pause-point side of the coordination point. Every member falls through
+    /// to <see cref="Inner"/> (the port that was installed when the test opened) unless the test
+    /// overrides that one member.
+    /// </summary>
+    public sealed class StubPausePointHotReloadPort : IPausePointHotReloadPort
+    {
+        /// <summary>The port answers fall through to. Null answers "pause point not initialized".</summary>
+        public IPausePointHotReloadPort Inner { get; set; }
+
+        public System.Func<MethodBase, IReadOnlyList<string>> ArmedMarkerIdsOnMethod { get; set; }
+
+        public System.Func<MethodBase, IReadOnlyList<string>> SuppressedMarkerIdsOnMethod { get; set; }
+
+        public System.Func<IReadOnlyList<string>> ExpiredNotRetargetedMarkerIds { get; set; }
+
+        public System.Func<IReadOnlyList<(string Id, string OldText, string NewText)>>
+            RetargetLineDriftWarnings { get; set; }
+
+        public System.Action<MethodBase, bool> HotReloadPatchStateChanged { get; set; }
+
+        public IReadOnlyList<string> GetArmedMarkerIdsOnMethod(MethodBase method)
+        {
+            return ArmedMarkerIdsOnMethod != null
+                ? ArmedMarkerIdsOnMethod(method)
+                : Inner?.GetArmedMarkerIdsOnMethod(method);
+        }
+
+        public IReadOnlyList<string> GetSuppressedMarkerIdsOnMethod(MethodBase method)
+        {
+            return SuppressedMarkerIdsOnMethod != null
+                ? SuppressedMarkerIdsOnMethod(method)
+                : Inner?.GetSuppressedMarkerIdsOnMethod(method);
+        }
+
+        public IReadOnlyList<string> ConsumeExpiredNotRetargetedMarkerIds()
+        {
+            return ExpiredNotRetargetedMarkerIds != null
+                ? ExpiredNotRetargetedMarkerIds()
+                : Inner?.ConsumeExpiredNotRetargetedMarkerIds();
+        }
+
+        public IReadOnlyList<(string Id, string OldText, string NewText)> ConsumeRetargetLineDriftWarnings()
+        {
+            return RetargetLineDriftWarnings != null
+                ? RetargetLineDriftWarnings()
+                : Inner?.ConsumeRetargetLineDriftWarnings();
+        }
+
+        public void OnHotReloadPatchStateChanged(MethodBase method, bool patched)
+        {
+            if (HotReloadPatchStateChanged != null)
+            {
+                HotReloadPatchStateChanged(method, patched);
+                return;
+            }
+
+            Inner?.OnHotReloadPatchStateChanged(method, patched);
+        }
+    }
+}

--- a/Assets/Tests/Editor/CoordinationPorts/StubPausePointHotReloadPort.cs.meta
+++ b/Assets/Tests/Editor/CoordinationPorts/StubPausePointHotReloadPort.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4bdd7f3da2b374c93ac982454040dbd2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/CoordinationPorts/UnityCLILoop.Tests.Editor.CoordinationPorts.asmdef
+++ b/Assets/Tests/Editor/CoordinationPorts/UnityCLILoop.Tests.Editor.CoordinationPorts.asmdef
@@ -1,0 +1,18 @@
+{
+    "name": "UnityCLILoop.Tests.Editor.CoordinationPorts",
+    "rootNamespace": "io.github.hatayama.UnityCliLoop.Tests.Editor",
+    "references": [
+        "GUID:fc3fd32eddbee40e39c2d76dc184957b"
+    ],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": false,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Assets/Tests/Editor/CoordinationPorts/UnityCLILoop.Tests.Editor.CoordinationPorts.asmdef.meta
+++ b/Assets/Tests/Editor/CoordinationPorts/UnityCLILoop.Tests.Editor.CoordinationPorts.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: cec8bc9a73a34dd0a7f85035927e546f
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/HotReload/HotReloadCompositionRootTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadCompositionRootTests.cs
@@ -7,6 +7,7 @@ using HarmonyLib;
 using NUnit.Framework;
 
 using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+using io.github.hatayama.UnityCliLoop.ToolContracts;
 
 namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 {
@@ -67,6 +68,35 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
             Assert.That(HotReloadCompositionRoot.Services, Is.SameAs(previous));
             Assert.Throws<ObjectDisposedException>(() => ownedDomain.IntroducedTypeResolver.Suspend());
+        }
+
+        /// <summary>
+        /// Uninstalling clears the coordination point, so the pause point side reads the
+        /// documented "no domain installed" answer instead of a port that would keep answering
+        /// from the domain the uninstall just disposed.
+        /// </summary>
+        [Test]
+        public void UninstallInstalledServices_LeavesTheSiblingToolsReadingNoDomainInstalled()
+        {
+            IHotReloadPausePointPort installedPort = HotReloadPausePointCoordination.HotReloadSide;
+            Assert.That(installedPort, Is.Not.Null, "the production services must be installed here.");
+
+            try
+            {
+                HotReloadCompositionRoot.UninstallInstalledServices();
+
+                Assert.That(HotReloadPausePointCoordination.HotReloadSide, Is.Null);
+                Assert.That(HotReloadIntroducedTypeCoordination.DescribeActiveTypeNames, Is.Null);
+            }
+            finally
+            {
+                // The uninstall disposed the domain the rest of the suite runs on, so the next
+                // test needs the production services back.
+                HotReloadCompositionRoot.Initialize();
+            }
+
+            Assert.That(HotReloadPausePointCoordination.HotReloadSide, Is.Not.Null);
+            Assert.That(HotReloadPausePointCoordination.HotReloadSide, Is.Not.SameAs(installedPort));
         }
 
         private static HotReloadServices CreateServicesSharing(HotReloadDomain domain)

--- a/Assets/Tests/Editor/HotReload/HotReloadDomainTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadDomainTests.cs
@@ -295,10 +295,10 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
             Assert.That(_access.Domain.ActivePatchCount, Is.EqualTo(0));
             Assert.That(
-                HotReloadPausePointCoordination.GetShimLookupForFile?.Invoke(FileOne),
+                HotReloadPausePointCoordination.HotReloadSide?.GetShimLookupForFile(FileOne),
                 Is.Null);
             Assert.That(
-                HotReloadPausePointCoordination.GetShimLookupForFile?.Invoke(FileTwo),
+                HotReloadPausePointCoordination.HotReloadSide?.GetShimLookupForFile(FileTwo),
                 Is.Null);
         }
 

--- a/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
@@ -5964,7 +5964,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             string projectRelativePath =
                 "Assets/Tests/Editor/HotReload/HotReloadAddedMethodApplyFixture.cs";
             HotReloadShimFileLookup lookup =
-                HotReloadPausePointCoordination.GetShimLookupForFile?.Invoke(projectRelativePath);
+                HotReloadPausePointCoordination.HotReloadSide?.GetShimLookupForFile(projectRelativePath);
             Assert.That(
                 lookup,
                 Is.Not.Null,

--- a/Assets/Tests/Editor/HotReload/HotReloadPatcherTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadPatcherTests.cs
@@ -581,7 +581,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                         new HotReloadDomainTestAccess().ApplyPatch(failing, failingShim, HotReloadPatchShape.Transplant, "Assets/Tests/Fixture.cs").Success,
                         Is.True);
                     Assert.That(
-                        HotReloadPausePointCoordination.GetTransplantLocals(failing),
+                        HotReloadPausePointCoordination.HotReloadSide.GetTransplantLocals(failing),
                         Is.Not.Null,
                         "A transplant apply must record the shim locals the test then checks are retained.");
 
@@ -592,11 +592,11 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                     harmony.RefuseUnpatch = false;
 
                     Assert.That(
-                        HotReloadPausePointCoordination.GetTransplantLocals(failing),
+                        HotReloadPausePointCoordination.HotReloadSide.GetTransplantLocals(failing),
                         Is.Not.Null,
                         "The transpiler is still live, so pause-point must still find its transplant locals.");
                     Assert.That(
-                        HotReloadPausePointCoordination.GetTransplantPreambleLength(failing),
+                        HotReloadPausePointCoordination.HotReloadSide.GetTransplantPreambleLength(failing),
                         Is.GreaterThan(0),
                         "The retained entry must keep the preamble length pause-point offsets against.");
                 }

--- a/Assets/Tests/Editor/HotReload/HotReloadPausePointContractTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadPausePointContractTests.cs
@@ -170,7 +170,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
             await HotReloadFromEditedSourceAsync(editedSource, "ContractDelegationLambda.cs");
             HotReloadShimFileLookup lookup =
-                HotReloadPausePointCoordination.GetShimLookupForFile?.Invoke(FixtureProjectRelativePath);
+                HotReloadPausePointCoordination.HotReloadSide?.GetShimLookupForFile(FixtureProjectRelativePath);
             Assert.That(lookup, Is.Not.Null);
             HotReloadShimMethodLookup lambdaEntry = lookup.Methods.FirstOrDefault(
                 m => m.OriginalMethod != null
@@ -551,7 +551,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             await HotReloadFromEditedSourceAsync(editedSource, "ContractAsyncMoveNext.cs");
 
             HotReloadShimFileLookup lookup =
-                HotReloadPausePointCoordination.GetShimLookupForFile?.Invoke(FixtureProjectRelativePath);
+                HotReloadPausePointCoordination.HotReloadSide?.GetShimLookupForFile(FixtureProjectRelativePath);
             Assert.That(lookup, Is.Not.Null);
             SourcePausePointShimResolution shimResolution =
                 SourcePausePointShimResolver.Resolve(lookup, FixtureProjectRelativePath, enableLine);

--- a/Assets/Tests/Editor/HotReload/HotReloadPausePointE2ETests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadPausePointE2ETests.cs
@@ -125,7 +125,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             await HotReloadFromEditedSourceAsync(editedSource, "E2E_f_LocalFunction.cs");
 
             HotReloadShimFileLookup lookup =
-                HotReloadPausePointCoordination.GetShimLookupForFile?.Invoke(FixtureProjectRelativePath);
+                HotReloadPausePointCoordination.HotReloadSide?.GetShimLookupForFile(FixtureProjectRelativePath);
             Assert.That(lookup, Is.Not.Null);
             SourcePausePointShimResolution shimResolution =
                 SourcePausePointShimResolver.Resolve(lookup, FixtureProjectRelativePath, enableLine);

--- a/Assets/Tests/Editor/HotReload/HotReloadPausePointLineDriftTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadPausePointLineDriftTests.cs
@@ -73,8 +73,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
             await HotReloadFromEditedSourceAsync(edited, "LineDriftUnpatched.cs");
 
-            Func<string, string> previousSnapshot = HotReloadPausePointCoordination.GetVerifiedSnapshotSourceForFile;
-            HotReloadPausePointCoordination.GetVerifiedSnapshotSourceForFile = _ => BuildSentinelSnapshot(
+            HotReloadSidePortScope snapshotScope = new HotReloadSidePortScope();
+            snapshotScope.Port.VerifiedSnapshotSourceForFile = _ => BuildSentinelSnapshot(
                 CompiledSnapshotSentinel,
                 80);
             PausePointResponse enable;
@@ -90,7 +90,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             }
             finally
             {
-                HotReloadPausePointCoordination.GetVerifiedSnapshotSourceForFile = previousSnapshot;
+                snapshotScope.Dispose();
             }
 
             Assert.That(enable.Success, Is.True, enable.Message + " / " + enable.RecommendedNextAction);
@@ -229,8 +229,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             int editedUnpatchedLine = FindLineNumber(edited, "return 22;");
             await HotReloadFromEditedSourceAsync(edited, "LineDriftNoSnapshot.cs");
 
-            Func<string, string> previous = HotReloadPausePointCoordination.GetVerifiedSnapshotSourceForFile;
-            HotReloadPausePointCoordination.GetVerifiedSnapshotSourceForFile = _ => null;
+            HotReloadSidePortScope snapshotScope = new HotReloadSidePortScope();
+            snapshotScope.Port.VerifiedSnapshotSourceForFile = _ => null;
             PausePointResponse enable;
             try
             {
@@ -244,7 +244,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             }
             finally
             {
-                HotReloadPausePointCoordination.GetVerifiedSnapshotSourceForFile = previous;
+                snapshotScope.Dispose();
             }
 
             Assert.That(enable.Success, Is.True, enable.Message + " / " + enable.RecommendedNextAction);
@@ -261,9 +261,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         {
             PausePointResponse enable = await EnablePatchedLineThenPrepareRestoreAsync(
                 "LineDriftRestoreSentinel.cs");
-            Func<string, string, string> previous =
-                HotReloadPausePointCoordination.GetVerifiedSnapshotSource;
-            HotReloadPausePointCoordination.GetVerifiedSnapshotSource =
+            HotReloadSidePortScope snapshotScope = new HotReloadSidePortScope();
+            snapshotScope.Port.VerifiedSnapshotSource =
                 (string file, string dllPath) =>
                 {
                     Assert.That(file, Does.Contain("HotReloadPausePointLineDriftFixture.cs"));
@@ -276,7 +275,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             }
             finally
             {
-                HotReloadPausePointCoordination.GetVerifiedSnapshotSource = previous;
+                snapshotScope.Dispose();
             }
 
             UloopPausePointSnapshot afterRevert = UloopPausePointRegistry.GetStatus(enable.Id);
@@ -285,24 +284,23 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
-        /// What: restore-after-revert leaves ResolvedLineText empty when the (file, dll)
-        /// snapshot Func is unset, and does not fall back to disk.
+        /// What: restore-after-revert leaves ResolvedLineText empty when hot reload has no
+        /// (file, dll) snapshot to give, and does not fall back to disk.
         /// </summary>
         [Test]
-        public async Task RevertAll_RestoreWithoutSnapshotFunc_LeavesResolvedLineTextEmpty()
+        public async Task RevertAll_RestoreWithoutSnapshot_LeavesResolvedLineTextEmpty()
         {
             PausePointResponse enable = await EnablePatchedLineThenPrepareRestoreAsync(
                 "LineDriftRestoreNoSnapshot.cs");
-            Func<string, string, string> previous =
-                HotReloadPausePointCoordination.GetVerifiedSnapshotSource;
-            HotReloadPausePointCoordination.GetVerifiedSnapshotSource = null;
+            HotReloadSidePortScope snapshotScope = new HotReloadSidePortScope();
+            snapshotScope.Port.VerifiedSnapshotSource = (string file, string dllPath) => null;
             try
             {
                 HotReloadCompositionRoot.Services.Patcher.RevertAll();
             }
             finally
             {
-                HotReloadPausePointCoordination.GetVerifiedSnapshotSource = previous;
+                snapshotScope.Dispose();
             }
 
             UloopPausePointSnapshot afterRevert = UloopPausePointRegistry.GetStatus(enable.Id);
@@ -348,10 +346,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
         private static HotReloadShimMethodLookup FindPatchedShimEntry()
         {
-            Func<string, HotReloadShimFileLookup> getLookup =
-                HotReloadPausePointCoordination.GetShimLookupForFile;
-            Assert.That(getLookup, Is.Not.Null);
-            HotReloadShimFileLookup lookup = getLookup(FixtureProjectRelativePath);
+            IHotReloadPausePointPort hotReloadSide = HotReloadPausePointCoordination.HotReloadSide;
+            Assert.That(hotReloadSide, Is.Not.Null);
+            HotReloadShimFileLookup lookup = hotReloadSide.GetShimLookupForFile(FixtureProjectRelativePath);
             Assert.That(lookup, Is.Not.Null);
             Assert.That(lookup.Methods, Is.Not.Null);
 

--- a/Assets/Tests/Editor/HotReload/HotReloadShimLookupTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadShimLookupTests.cs
@@ -41,7 +41,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             await PatchComputeWithPrivateAsync();
 
             HotReloadShimFileLookup lookup =
-                HotReloadPausePointCoordination.GetShimLookupForFile?.Invoke(FixtureProjectRelativePath);
+                HotReloadPausePointCoordination.HotReloadSide?.GetShimLookupForFile(FixtureProjectRelativePath);
             Assert.That(lookup, Is.Not.Null);
             Assert.That(lookup.AssemblyBytes, Is.Not.Null.And.Not.Empty);
             Assert.That(lookup.PdbBytes, Is.Not.Null.And.Not.Empty);
@@ -52,7 +52,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             string absoluteFixturePath = Path.GetFullPath(
                 Path.Combine(projectRoot, FixtureProjectRelativePath));
             HotReloadShimFileLookup absoluteLookup =
-                HotReloadPausePointCoordination.GetShimLookupForFile?.Invoke(absoluteFixturePath);
+                HotReloadPausePointCoordination.HotReloadSide?.GetShimLookupForFile(absoluteFixturePath);
             Assert.That(
                 absoluteLookup,
                 Is.Not.Null,
@@ -89,7 +89,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             Assert.That(computeMethod, Is.Not.Null);
 
             HotReloadShimFileLookup beforeLookup =
-                HotReloadPausePointCoordination.GetShimLookupForFile?.Invoke(FixtureProjectRelativePath);
+                HotReloadPausePointCoordination.HotReloadSide?.GetShimLookupForFile(FixtureProjectRelativePath);
             Assert.That(beforeLookup, Is.Not.Null);
             Assert.That(
                 beforeLookup.Methods.Count,
@@ -101,7 +101,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             Assert.That(reverted, Is.EqualTo(HotReloadRevertOutcome.Reverted));
 
             HotReloadShimFileLookup lookup =
-                HotReloadPausePointCoordination.GetShimLookupForFile?.Invoke(FixtureProjectRelativePath);
+                HotReloadPausePointCoordination.HotReloadSide?.GetShimLookupForFile(FixtureProjectRelativePath);
             Assert.That(lookup, Is.Not.Null);
             Assert.That(lookup.Methods, Is.Not.Empty);
 
@@ -123,7 +123,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             HotReloadCompositionRoot.Services.Patcher.RevertAll();
 
             HotReloadShimFileLookup lookup =
-                HotReloadPausePointCoordination.GetShimLookupForFile?.Invoke(FixtureProjectRelativePath);
+                HotReloadPausePointCoordination.HotReloadSide?.GetShimLookupForFile(FixtureProjectRelativePath);
             Assert.That(lookup, Is.Null);
         }
 
@@ -135,13 +135,13 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         {
             await PatchComputeWithPrivateAsync(extraDelta: 100);
             HotReloadShimFileLookup firstLookup =
-                HotReloadPausePointCoordination.GetShimLookupForFile?.Invoke(FixtureProjectRelativePath);
+                HotReloadPausePointCoordination.HotReloadSide?.GetShimLookupForFile(FixtureProjectRelativePath);
             Assert.That(firstLookup, Is.Not.Null);
             Assembly firstAssembly = firstLookup.LoadedAssembly;
 
             await PatchComputeWithPrivateAsync(extraDelta: 200);
             HotReloadShimFileLookup secondLookup =
-                HotReloadPausePointCoordination.GetShimLookupForFile?.Invoke(FixtureProjectRelativePath);
+                HotReloadPausePointCoordination.HotReloadSide?.GetShimLookupForFile(FixtureProjectRelativePath);
             Assert.That(secondLookup, Is.Not.Null);
             Assert.That(
                 ReferenceEquals(secondLookup.LoadedAssembly, firstAssembly),
@@ -163,7 +163,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             Assert.That(computeMethod, Is.Not.Null);
 
             HotReloadShimFileLookup lookup =
-                HotReloadPausePointCoordination.GetShimLookupForFile?.Invoke(FixtureProjectRelativePath);
+                HotReloadPausePointCoordination.HotReloadSide?.GetShimLookupForFile(FixtureProjectRelativePath);
             Assert.That(lookup, Is.Not.Null);
 
             MethodBase shimMethod = null;
@@ -182,7 +182,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             Assert.That(shimBody, Is.Not.Null);
 
             IReadOnlyList<LocalBuilder> locals =
-                HotReloadPausePointCoordination.GetTransplantLocals?.Invoke(computeMethod);
+                HotReloadPausePointCoordination.HotReloadSide?.GetTransplantLocals(computeMethod);
             Assert.That(locals, Is.Not.Null);
             Assert.That(locals.Count, Is.EqualTo(shimBody.LocalVariables.Count));
         }

--- a/Assets/Tests/Editor/HotReload/HotReloadToolTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadToolTests.cs
@@ -837,9 +837,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         [Test]
         public void BuildApplyResponse_WithRetargetLineDrift_AddsDriftWarning()
         {
-            Func<IReadOnlyList<(string Id, string OldText, string NewText)>> previous =
-                HotReloadPausePointCoordination.ConsumeRetargetLineDriftWarnings;
-            HotReloadPausePointCoordination.ConsumeRetargetLineDriftWarnings = () =>
+            PausePointSidePortScope pausePointScope = new PausePointSidePortScope();
+            pausePointScope.Port.RetargetLineDriftWarnings = () =>
                 new List<(string, string, string)>
                 {
                     ("Assets/Scripts/A.cs:10", "return a;", "return a + 1;")
@@ -866,7 +865,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             }
             finally
             {
-                HotReloadPausePointCoordination.ConsumeRetargetLineDriftWarnings = previous;
+                pausePointScope.Dispose();
             }
         }
 
@@ -876,9 +875,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         [Test]
         public void BuildApplyResponse_WithExpiredNotRetargetedIds_AddsAggregatedWarning()
         {
-            Func<IReadOnlyList<string>> previous =
-                HotReloadPausePointCoordination.ConsumeExpiredNotRetargetedMarkerIds;
-            HotReloadPausePointCoordination.ConsumeExpiredNotRetargetedMarkerIds = () =>
+            PausePointSidePortScope pausePointScope = new PausePointSidePortScope();
+            pausePointScope.Port.ExpiredNotRetargetedMarkerIds = () =>
                 new List<string> { "Assets/Scripts/A.cs:10" };
             try
             {
@@ -900,7 +898,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             }
             finally
             {
-                HotReloadPausePointCoordination.ConsumeExpiredNotRetargetedMarkerIds = previous;
+                pausePointScope.Dispose();
             }
         }
 

--- a/Assets/Tests/Editor/HotReload/HotReloadUnpatchedMethodLineShiftWarningBuilderTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadUnpatchedMethodLineShiftWarningBuilderTests.cs
@@ -407,9 +407,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             Directory.CreateDirectory(Path.GetDirectoryName(absolutePath));
             File.WriteAllText(absolutePath, "line1\nline2\nline3");
 
-            Func<string, string> previousLoader =
-                HotReloadPausePointCoordination.GetVerifiedSnapshotSourceForFile;
-            HotReloadPausePointCoordination.GetVerifiedSnapshotSourceForFile = _ => "line1\nline2";
+            HotReloadSidePortScope snapshotScope = new HotReloadSidePortScope();
+            snapshotScope.Port.VerifiedSnapshotSourceForFile = _ => "line1\nline2";
             try
             {
                 HotReloadResponse response = HotReloadTool.BuildApplyResponse(
@@ -437,7 +436,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             }
             finally
             {
-                HotReloadPausePointCoordination.GetVerifiedSnapshotSourceForFile = previousLoader;
+                snapshotScope.Dispose();
                 if (File.Exists(absolutePath))
                 {
                     File.Delete(absolutePath);
@@ -460,9 +459,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             Directory.CreateDirectory(Path.GetDirectoryName(absolutePath));
             File.WriteAllText(absolutePath, "line1\nline2\nline3");
 
-            Func<string, string> previousLoader =
-                HotReloadPausePointCoordination.GetVerifiedSnapshotSourceForFile;
-            HotReloadPausePointCoordination.GetVerifiedSnapshotSourceForFile = _ => "line1\nline2";
+            HotReloadSidePortScope snapshotScope = new HotReloadSidePortScope();
+            snapshotScope.Port.VerifiedSnapshotSourceForFile = _ => "line1\nline2";
             try
             {
                 HotReloadResponse response = HotReloadTool.BuildApplyResponse(
@@ -485,7 +483,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             }
             finally
             {
-                HotReloadPausePointCoordination.GetVerifiedSnapshotSourceForFile = previousLoader;
+                snapshotScope.Dispose();
                 if (File.Exists(absolutePath))
                 {
                     File.Delete(absolutePath);

--- a/Assets/Tests/Editor/HotReload/UnityCLILoop.Tests.Editor.HotReload.asmdef
+++ b/Assets/Tests/Editor/HotReload/UnityCLILoop.Tests.Editor.HotReload.asmdef
@@ -2,6 +2,7 @@
     "name": "UnityCLILoop.Tests.Editor.HotReload",
     "rootNamespace": "io.github.hatayama.UnityCliLoop.Tests.Editor",
     "references": [
+        "GUID:cec8bc9a73a34dd0a7f85035927e546f",
         "GUID:0acc523941302664db1f4e527237feb3",
         "GUID:27619889b8ba8c24980f49ee34dbb44a",
         "GUID:afe86dd49995e46baa33e099a4d2ee1d",

--- a/Assets/Tests/Editor/PausePointAddedFieldWarningTests.cs
+++ b/Assets/Tests/Editor/PausePointAddedFieldWarningTests.cs
@@ -19,7 +19,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         private const string FixtureFilePath = "Assets/Tests/Editor/PausePointToolsFixture.cs";
         private const int FixtureLine = 12;
 
-        private Func<string, IReadOnlyList<string>> _originalAddedFieldsLookup;
+        private HotReloadSidePortScope _hotReloadSideScope;
 
         [SetUp]
         public void SetUp()
@@ -27,8 +27,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             UloopPausePointRegistry.ConfigureForTests(new FakePausePointPauseController(), () => DateTime.UtcNow);
 
             // This assembly must not reference the hot-reload tool, so the added fields are
-            // published through the same coordination delegate the hot-reload side sets.
-            _originalAddedFieldsLookup = HotReloadPausePointCoordination.GetAddedFieldsForType;
+            // published through the same coordination port the hot-reload side installs.
+            _hotReloadSideScope = new HotReloadSidePortScope();
         }
 
         [TearDown]
@@ -36,7 +36,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         {
             SourcePausePointPatcher.UnpatchAll();
             UloopPausePointRegistry.ResetForTests();
-            HotReloadPausePointCoordination.GetAddedFieldsForType = _originalAddedFieldsLookup;
+            _hotReloadSideScope.Dispose();
         }
 
         /// <summary>
@@ -45,7 +45,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         /// </summary>
         private void PublishAddedFields(string typeName, IReadOnlyList<string> simpleFieldNames)
         {
-            HotReloadPausePointCoordination.GetAddedFieldsForType = queriedTypeName =>
+            _hotReloadSideScope.Port.AddedFieldsForType = queriedTypeName =>
                 string.Equals(queriedTypeName, typeName, StringComparison.Ordinal)
                     ? simpleFieldNames
                     : Array.Empty<string>();

--- a/Assets/Tests/Editor/PausePointCompiledLineMapWarningTests.cs
+++ b/Assets/Tests/Editor/PausePointCompiledLineMapWarningTests.cs
@@ -557,10 +557,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         [Test]
         public void Enable_WhenCompiledLineDriftsFromEditedFile_AddsDriftWarningAndNextAction()
         {
-            Func<string, HotReloadShimFileLookup> previousLookup =
-                HotReloadPausePointCoordination.GetShimLookupForFile;
-            Func<string, string> previousSnapshot =
-                HotReloadPausePointCoordination.GetVerifiedSnapshotSourceForFile;
+            HotReloadSidePortScope hotReloadSideScope = new HotReloadSidePortScope();
             HotReloadShimFileLookup stubLookup = new HotReloadShimFileLookup(
                 Array.Empty<byte>(),
                 Array.Empty<byte>(),
@@ -584,8 +581,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
 
             try
             {
-                HotReloadPausePointCoordination.GetShimLookupForFile = _ => stubLookup;
-                HotReloadPausePointCoordination.GetVerifiedSnapshotSourceForFile = _ => snapshotSource;
+                hotReloadSideScope.Port.ShimLookupForFile = _ => stubLookup;
+                hotReloadSideScope.Port.VerifiedSnapshotSourceForFile = _ => snapshotSource;
 
                 PausePointResponse response = new PausePointUseCase().Enable(new EnablePausePointSchema
                 {
@@ -646,8 +643,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             }
             finally
             {
-                HotReloadPausePointCoordination.GetShimLookupForFile = previousLookup;
-                HotReloadPausePointCoordination.GetVerifiedSnapshotSourceForFile = previousSnapshot;
+                hotReloadSideScope.Dispose();
             }
         }
 
@@ -658,10 +654,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         [Test]
         public void Enable_WhenCompiledLineMatchesEditedFile_UsesMatchedCompiledLineMapWarning()
         {
-            Func<string, HotReloadShimFileLookup> previousLookup =
-                HotReloadPausePointCoordination.GetShimLookupForFile;
-            Func<string, string> previousSnapshot =
-                HotReloadPausePointCoordination.GetVerifiedSnapshotSourceForFile;
+            HotReloadSidePortScope hotReloadSideScope = new HotReloadSidePortScope();
             HotReloadShimFileLookup stubLookup = new HotReloadShimFileLookup(
                 Array.Empty<byte>(),
                 Array.Empty<byte>(),
@@ -680,8 +673,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
 
             try
             {
-                HotReloadPausePointCoordination.GetShimLookupForFile = _ => stubLookup;
-                HotReloadPausePointCoordination.GetVerifiedSnapshotSourceForFile = _ => diskSource;
+                hotReloadSideScope.Port.ShimLookupForFile = _ => stubLookup;
+                hotReloadSideScope.Port.VerifiedSnapshotSourceForFile = _ => diskSource;
 
                 PausePointResponse response = new PausePointUseCase().Enable(new EnablePausePointSchema
                 {
@@ -724,8 +717,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             }
             finally
             {
-                HotReloadPausePointCoordination.GetShimLookupForFile = previousLookup;
-                HotReloadPausePointCoordination.GetVerifiedSnapshotSourceForFile = previousSnapshot;
+                hotReloadSideScope.Dispose();
             }
         }
 
@@ -736,10 +728,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         [Test]
         public void Enable_WhenRequestedLineSnapsForward_DisclosesSnapAndSetsNextAction()
         {
-            Func<string, HotReloadShimFileLookup> previousLookup =
-                HotReloadPausePointCoordination.GetShimLookupForFile;
-            Func<string, string> previousSnapshot =
-                HotReloadPausePointCoordination.GetVerifiedSnapshotSourceForFile;
+            HotReloadSidePortScope hotReloadSideScope = new HotReloadSidePortScope();
             HotReloadShimFileLookup stubLookup = new HotReloadShimFileLookup(
                 Array.Empty<byte>(),
                 Array.Empty<byte>(),
@@ -758,8 +747,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
 
             try
             {
-                HotReloadPausePointCoordination.GetShimLookupForFile = _ => stubLookup;
-                HotReloadPausePointCoordination.GetVerifiedSnapshotSourceForFile = _ => diskSource;
+                hotReloadSideScope.Port.ShimLookupForFile = _ => stubLookup;
+                hotReloadSideScope.Port.VerifiedSnapshotSourceForFile = _ => diskSource;
 
                 PausePointResponse response = new PausePointUseCase().Enable(new EnablePausePointSchema
                 {
@@ -811,8 +800,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             }
             finally
             {
-                HotReloadPausePointCoordination.GetShimLookupForFile = previousLookup;
-                HotReloadPausePointCoordination.GetVerifiedSnapshotSourceForFile = previousSnapshot;
+                hotReloadSideScope.Dispose();
             }
         }
 
@@ -1748,8 +1736,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         [Test]
         public void Enable_WhenResolveFailsAndFileHasActivePatches_UsesResolveFailureWarningAndNextAction()
         {
-            Func<string, HotReloadShimFileLookup> previous =
-                HotReloadPausePointCoordination.GetShimLookupForFile;
+            HotReloadSidePortScope hotReloadSideScope = new HotReloadSidePortScope();
             HotReloadShimFileLookup stubLookup = new HotReloadShimFileLookup(
                 Array.Empty<byte>(),
                 Array.Empty<byte>(),
@@ -1758,7 +1745,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
 
             try
             {
-                HotReloadPausePointCoordination.GetShimLookupForFile = _ => stubLookup;
+                hotReloadSideScope.Port.ShimLookupForFile = _ => stubLookup;
                 PausePointResponse withPatches = EnableUnresolvableLine();
 
                 Assert.That(withPatches.Success, Is.False);
@@ -1768,7 +1755,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                     withPatches.RecommendedNextAction,
                     Is.EqualTo(SourcePausePointConstants.HotReloadCompiledLineMapResolveFailureNextAction));
 
-                HotReloadPausePointCoordination.GetShimLookupForFile = _ => null;
+                hotReloadSideScope.Port.ShimLookupForFile = _ => null;
                 PausePointResponse withoutPatches = EnableUnresolvableLine();
 
                 Assert.That(withoutPatches.Success, Is.False);
@@ -1780,7 +1767,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             }
             finally
             {
-                HotReloadPausePointCoordination.GetShimLookupForFile = previous;
+                hotReloadSideScope.Dispose();
             }
         }
 
@@ -1820,11 +1807,10 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 "compiled-line-drift" + "-probe-unique") + 1;
             Assert.That(requestedLine, Is.GreaterThan(1));
 
-            Func<string, HotReloadShimFileLookup> previous =
-                HotReloadPausePointCoordination.GetShimLookupForFile;
+            HotReloadSidePortScope hotReloadSideScope = new HotReloadSidePortScope();
             try
             {
-                HotReloadPausePointCoordination.GetShimLookupForFile =
+                hotReloadSideScope.Port.ShimLookupForFile =
                     _ => CreatePdbUnavailableLookup(CompiledLineDriftProbeMethod(), requestedLine);
                 PausePointResponse response = new PausePointUseCase().Enable(new EnablePausePointSchema
                 {
@@ -1854,7 +1840,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             }
             finally
             {
-                HotReloadPausePointCoordination.GetShimLookupForFile = previous;
+                hotReloadSideScope.Dispose();
             }
         }
 
@@ -1865,11 +1851,10 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         [Test]
         public void Enable_WhenPatchedMethodHasNoPdbBytes_EmitsDedicatedWarningOnResolveFailure()
         {
-            Func<string, HotReloadShimFileLookup> previous =
-                HotReloadPausePointCoordination.GetShimLookupForFile;
+            HotReloadSidePortScope hotReloadSideScope = new HotReloadSidePortScope();
             try
             {
-                HotReloadPausePointCoordination.GetShimLookupForFile =
+                hotReloadSideScope.Port.ShimLookupForFile =
                     _ => CreatePdbUnavailableLookup(CompiledLineDriftProbeMethod(), UnresolvableLine);
                 PausePointResponse response = EnableUnresolvableLine();
 
@@ -1886,7 +1871,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             }
             finally
             {
-                HotReloadPausePointCoordination.GetShimLookupForFile = previous;
+                hotReloadSideScope.Dispose();
             }
         }
 

--- a/Assets/Tests/Editor/PausePointEditedLineRemapTests.cs
+++ b/Assets/Tests/Editor/PausePointEditedLineRemapTests.cs
@@ -47,20 +47,20 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         private const string ExpectedNoSnapshotFailureMessage =
             "No method named 'UniqueTarget' with a sequence point on or after line 16 was found. Nearby methods in the last compiled source: 'EditedLineRemapFixture.UniqueOther' spans lines 15-18.";
 
-        private Func<string, string> _previousSnapshotLoader;
+        private HotReloadSidePortScope _hotReloadSideScope;
 
         [SetUp]
         public void SetUp()
         {
             UloopPausePointRegistry.ConfigureForTests(new FakePausePointPauseController(), () => DateTime.UtcNow);
-            _previousSnapshotLoader = HotReloadPausePointCoordination.GetVerifiedSnapshotSourceForFile;
-            HotReloadPausePointCoordination.GetVerifiedSnapshotSourceForFile = null;
+            _hotReloadSideScope = new HotReloadSidePortScope();
+            _hotReloadSideScope.Port.VerifiedSnapshotSourceForFile = _ => null;
         }
 
         [TearDown]
         public void TearDown()
         {
-            HotReloadPausePointCoordination.GetVerifiedSnapshotSourceForFile = _previousSnapshotLoader;
+            _hotReloadSideScope.Dispose();
             SourcePausePointPatcher.UnpatchAll();
             UloopPausePointRegistry.ResetForTests();
         }
@@ -331,13 +331,13 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(response.Message, Is.EqualTo(ExpectedRoundForwardFailureMessage));
         }
 
-        private static void InstallSnapshotFromFile(string projectRelativeFile)
+        private void InstallSnapshotFromFile(string projectRelativeFile)
         {
             string absoluteFilePath = Path.Combine(
                 UnityCliLoopPathResolver.GetProjectRoot(),
                 projectRelativeFile);
             string snapshotSource = File.ReadAllText(absoluteFilePath);
-            HotReloadPausePointCoordination.GetVerifiedSnapshotSourceForFile = _ => snapshotSource;
+            _hotReloadSideScope.Port.VerifiedSnapshotSourceForFile = _ => snapshotSource;
         }
 
         private sealed class FakePausePointPauseController : IUloopPausePointPauseController

--- a/Assets/Tests/Editor/SourcePausePointPatcher/SourcePausePointPatcherTests.cs
+++ b/Assets/Tests/Editor/SourcePausePointPatcher/SourcePausePointPatcherTests.cs
@@ -25,20 +25,20 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         private const string FixturesDirectory = "Assets/Tests/Editor/SourcePausePointPatcher/Fixtures/";
 
         private FakePausePointPauseController _pauseController;
-        private Func<MethodBase, MethodBase> _previousGetActiveShim;
+        private HotReloadSidePortScope _hotReloadSideScope;
 
         [SetUp]
         public void SetUp()
         {
             _pauseController = new FakePausePointPauseController();
             UloopPausePointRegistry.ConfigureForTests(_pauseController, () => DateTime.UtcNow);
-            _previousGetActiveShim = HotReloadPausePointCoordination.GetActiveShimForMethod;
+            _hotReloadSideScope = new HotReloadSidePortScope();
         }
 
         [TearDown]
         public void TearDown()
         {
-            HotReloadPausePointCoordination.GetActiveShimForMethod = _previousGetActiveShim;
+            _hotReloadSideScope.Dispose();
             SourcePausePointPatcher.UnpatchAll();
             UloopPausePointRegistry.ResetForTests();
         }
@@ -732,7 +732,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         public void Patch_OnHotReloadedMethod_WithoutCompiledSpan_KeepsExistingMessage()
         {
             MethodBase method = typeof(PatcherStaticMethodFixture).GetMethod(nameof(PatcherStaticMethodFixture.Add));
-            HotReloadPausePointCoordination.GetActiveShimForMethod = _ => method;
+            _hotReloadSideScope.Port.ActiveShimForMethod = _ => method;
             const int requestedLine = 42;
             SourcePausePointPatchResult result = SourcePausePointPatcher.Patch(
                 "patcher-hot-reload-no-span",
@@ -761,7 +761,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         public void Patch_OnHotReloadedMethod_WithCompiledSpan_AppendsSpanSentence()
         {
             MethodBase method = typeof(PatcherStaticMethodFixture).GetMethod(nameof(PatcherStaticMethodFixture.Add));
-            HotReloadPausePointCoordination.GetActiveShimForMethod = _ => method;
+            _hotReloadSideScope.Port.ActiveShimForMethod = _ => method;
             const int requestedLine = 42;
             const int compiledStart = 10;
             const int compiledEnd = 20;

--- a/Assets/Tests/Editor/SourcePausePointPatcher/SourcePausePointPostLineCaptureTests.cs
+++ b/Assets/Tests/Editor/SourcePausePointPatcher/SourcePausePointPostLineCaptureTests.cs
@@ -25,20 +25,20 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         private const int ThrowLine = 29;
 
         private FakePausePointPauseController _pauseController;
-        private Func<MethodBase, MethodBase> _previousGetActiveShim;
+        private HotReloadSidePortScope _hotReloadSideScope;
 
         [SetUp]
         public void SetUp()
         {
             _pauseController = new FakePausePointPauseController();
             UloopPausePointRegistry.ConfigureForTests(_pauseController, () => DateTime.UtcNow);
-            _previousGetActiveShim = HotReloadPausePointCoordination.GetActiveShimForMethod;
+            _hotReloadSideScope = new HotReloadSidePortScope();
         }
 
         [TearDown]
         public void TearDown()
         {
-            HotReloadPausePointCoordination.GetActiveShimForMethod = _previousGetActiveShim;
+            _hotReloadSideScope.Dispose();
             SourcePausePointPatcher.UnpatchAll();
             UloopPausePointRegistry.ResetForTests();
         }

--- a/Assets/Tests/Editor/SourcePausePointPatcher/UnityCLILoop.Tests.Editor.SourcePausePointPatcher.asmdef
+++ b/Assets/Tests/Editor/SourcePausePointPatcher/UnityCLILoop.Tests.Editor.SourcePausePointPatcher.asmdef
@@ -2,6 +2,7 @@
     "name": "UnityCLILoop.Tests.Editor.SourcePausePointPatcher",
     "rootNamespace": "io.github.hatayama.UnityCliLoop.Tests.Editor",
     "references": [
+        "GUID:cec8bc9a73a34dd0a7f85035927e546f",
         "GUID:0acc523941302664db1f4e527237feb3",
         "GUID:27619889b8ba8c24980f49ee34dbb44a",
         "GUID:94d8abc693f543a691a4645a5ff42e5c",

--- a/Assets/Tests/Editor/UnityCLILoop.Tests.Editor.asmdef
+++ b/Assets/Tests/Editor/UnityCLILoop.Tests.Editor.asmdef
@@ -2,6 +2,7 @@
     "name": "UnityCLILoop.Tests.Editor",
     "rootNamespace": "io.github.hatayama.UnityCliLoop.Tests.Editor",
     "references": [
+        "GUID:cec8bc9a73a34dd0a7f85035927e546f",
         "GUID:214998e563c124e8a88199b2dd1f522d",
         "GUID:5079a8d3a72924a81aa1cbc25f65ed1b",
         "GUID:5c4588558a3624eacbce0f50007cf1eb",

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadApplyResponseBuilder.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadApplyResponseBuilder.cs
@@ -143,7 +143,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         private static void AppendRetargetLineDriftWarnings(List<string> warnings)
         {
             IReadOnlyList<(string Id, string OldText, string NewText)> driftWarnings =
-                HotReloadPausePointCoordination.ConsumeRetargetLineDriftWarnings?.Invoke();
+                HotReloadPausePointCoordination.PausePointSide?.ConsumeRetargetLineDriftWarnings();
             if (driftWarnings == null || driftWarnings.Count == 0)
             {
                 return;
@@ -164,7 +164,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         private static void AppendExpiredNotRetargetedWarnings(List<string> warnings)
         {
             IReadOnlyList<string> expiredIds =
-                HotReloadPausePointCoordination.ConsumeExpiredNotRetargetedMarkerIds?.Invoke();
+                HotReloadPausePointCoordination.PausePointSide?.ConsumeExpiredNotRetargetedMarkerIds();
             if (expiredIds == null || expiredIds.Count == 0)
             {
                 return;

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadCompositionRoot.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadCompositionRoot.cs
@@ -39,7 +39,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         {
             // Uninstalling first because a second Initialize would otherwise leave the previous
             // domain's resolver attached to AppDomain.AssemblyResolve with nothing owning it.
-            Uninstall(_services);
+            UninstallServices(_services);
             Install(CreateProductionServices());
         }
 
@@ -168,17 +168,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             HotReloadTranspilerDomainGateway.Current = domain;
             HotReloadIntroducedTypeCoordination.DescribeActiveTypeNames =
                 () => DescribeActiveTypeNames(domain);
-            HotReloadPausePointCoordination.GetShimLookupForFile = domain.LookupShimsForFile;
-            HotReloadPausePointCoordination.GetVerifiedSnapshotSourceForFile =
-                domain.LoadVerifiedSnapshotSourceForFile;
-            HotReloadPausePointCoordination.GetVerifiedSnapshotSource = LoadVerifiedSnapshotSource;
-            HotReloadPausePointCoordination.GetAddedFieldsForType = domain.GetAddedFieldsForType;
-            HotReloadPausePointCoordination.GetActiveShimForMethod =
-                method => domain.FindGenerationForMethod(method)?.FindPatchShim(method);
-            HotReloadPausePointCoordination.GetTransplantLocals =
-                method => domain.FindGenerationForMethod(method)?.FindTransplantLocals(method);
-            HotReloadPausePointCoordination.GetTransplantPreambleLength =
-                method => domain.FindGenerationForMethod(method)?.FindTransplantPreambleLength(method) ?? 0;
+            HotReloadPausePointCoordination.HotReloadSide = new HotReloadPausePointPort(domain);
             // Attaching last keeps the invariant across the gap: the resolver only starts
             // answering binds once every gateway already points at the domain behind it.
             domain.IntroducedTypeResolver.Resume();
@@ -192,9 +182,26 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             HotReloadAddedFieldStore.Current = null;
             HotReloadInvocationRegistry.Current = null;
             HotReloadTranspilerDomainGateway.Current = null;
+            // The sibling tools are told "no domain installed" here too: leaving the port behind
+            // would keep answering pause point from the domain the uninstall is about to dispose.
+            HotReloadIntroducedTypeCoordination.DescribeActiveTypeNames = null;
+            HotReloadPausePointCoordination.HotReloadSide = null;
         }
 
-        private static void Uninstall(HotReloadServices services)
+        /// <summary>
+        /// Drops the installed services and their wiring, leaving the sibling tools reading the
+        /// documented "no domain installed" answer. Production reaches this state only through
+        /// <see cref="Initialize"/>; a test calls it to observe that state and restores with
+        /// <see cref="Initialize"/>.
+        /// </summary>
+        internal static void UninstallInstalledServices()
+        {
+            HotReloadServices installed = _services;
+            _services = null;
+            UninstallServices(installed);
+        }
+
+        private static void UninstallServices(HotReloadServices services)
         {
             ClearWiring();
             // Why the domain is disposed after the wiring is dropped: disposing unsubscribes its
@@ -212,16 +219,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             return names;
-        }
-
-        private static string LoadVerifiedSnapshotSource(string projectRelativeFile, string dllPath)
-        {
-            if (string.IsNullOrEmpty(projectRelativeFile) || string.IsNullOrEmpty(dllPath))
-            {
-                return null;
-            }
-
-            return HotReloadSourceBaseline.LoadVerifiedSnapshotSource(projectRelativeFile, dllPath);
         }
 
         private sealed class ReplacementScope : IDisposable
@@ -257,9 +254,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     return;
                 }
 
-                Uninstall(_installed);
+                UninstallServices(_installed);
                 // Install reattaches the resolver that came back, so the replacement's has to be
-                // gone by now: Uninstall disposed it, which leaves it detached for good.
+                // gone by now: UninstallServices disposed it, which leaves it detached for good.
                 Install(_previous);
             }
         }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadFileEntryApplier.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadFileEntryApplier.cs
@@ -351,16 +351,15 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             List<string> suppressedPausePointIds,
             List<string> retargetedPausePointIds)
         {
-            IReadOnlyList<string> armedIds =
-                HotReloadPausePointCoordination.GetArmedMarkerIdsOnMethod?.Invoke(method);
+            IPausePointHotReloadPort pausePointSide = HotReloadPausePointCoordination.PausePointSide;
+            IReadOnlyList<string> armedIds = pausePointSide?.GetArmedMarkerIdsOnMethod(method);
             if (armedIds == null || armedIds.Count == 0)
             {
                 return;
             }
 
             IReadOnlyList<string> suppressedIds =
-                HotReloadPausePointCoordination.GetSuppressedMarkerIdsOnMethod?.Invoke(method)
-                ?? Array.Empty<string>();
+                pausePointSide.GetSuppressedMarkerIdsOnMethod(method) ?? Array.Empty<string>();
 
             // The same method can be patched twice in one run (duplicate file inputs,
             // re-applied edits); the aggregated warning must list each marker id once.

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadPatcher.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadPatcher.cs
@@ -110,7 +110,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 // Mirror the removal: if the re-Patch below fails, its contained Unpatch rebuilds
                 // with markers restored (no live patch), and RevertAll can never reach this method
                 // again — leaving suppress stuck true would make status lie forever.
-                HotReloadPausePointCoordination.OnHotReloadPatchStateChanged?.Invoke(method, false);
+                HotReloadPausePointCoordination.PausePointSide?.OnHotReloadPatchStateChanged(method, false);
             }
 
             MethodInfo transpilerMethodInfo = patchShape == HotReloadPatchShape.Delegation
@@ -132,7 +132,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                         priority = Priority.First
                     });
                 generation.CommitPatch(method);
-                HotReloadPausePointCoordination.OnHotReloadPatchStateChanged?.Invoke(method, true);
+                HotReloadPausePointCoordination.PausePointSide?.OnHotReloadPatchStateChanged(method, true);
             }
             catch (Exception exception)
             {
@@ -156,7 +156,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 _harmony.Unpatch(method, HarmonyPatchType.Transpiler, HotReloadConstants.HarmonyId);
                 // Why after Unpatch: retarget may have already replaced markers onto the shim;
                 // restore them onto the original body now that GetActiveShim is null.
-                HotReloadPausePointCoordination.OnHotReloadPatchStateChanged?.Invoke(method, false);
+                HotReloadPausePointCoordination.PausePointSide?.OnHotReloadPatchStateChanged(method, false);
                 Exception rootCause = exception;
                 while (rootCause.InnerException != null)
                 {
@@ -190,7 +190,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             _harmony.UnpatchAll(HotReloadConstants.HarmonyId);
             foreach (MethodBase revertedMethod in revertedMethods)
             {
-                HotReloadPausePointCoordination.OnHotReloadPatchStateChanged?.Invoke(revertedMethod, false);
+                HotReloadPausePointCoordination.PausePointSide?.OnHotReloadPatchStateChanged(revertedMethod, false);
             }
         }
 
@@ -243,11 +243,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     return HotReloadRevertOutcome.UnpatchFailed;
                 }
 
-                HotReloadPausePointCoordination.OnHotReloadPatchStateChanged?.Invoke(method, false);
+                HotReloadPausePointCoordination.PausePointSide?.OnHotReloadPatchStateChanged(method, false);
                 return HotReloadRevertOutcome.UnpatchFailed;
             }
 
-            HotReloadPausePointCoordination.OnHotReloadPatchStateChanged?.Invoke(method, false);
+            HotReloadPausePointCoordination.PausePointSide?.OnHotReloadPatchStateChanged(method, false);
             return HotReloadRevertOutcome.Reverted;
         }
 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadPausePointPort.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadPausePointPort.cs
@@ -1,0 +1,63 @@
+using System.Collections.Generic;
+using System.Reflection;
+using System.Reflection.Emit;
+
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Answers the pause-point tool's questions about one hot-reload domain. The composition root
+    /// publishes an instance of this for the domain it installs, so an answer can never come from
+    /// a domain that is no longer installed.
+    /// </summary>
+    internal sealed class HotReloadPausePointPort : IHotReloadPausePointPort
+    {
+        private readonly HotReloadDomain _domain;
+
+        public HotReloadPausePointPort(HotReloadDomain domain)
+        {
+            _domain = domain;
+        }
+
+        public MethodBase GetActiveShimForMethod(MethodBase method)
+        {
+            return _domain.FindGenerationForMethod(method)?.FindPatchShim(method);
+        }
+
+        public HotReloadShimFileLookup GetShimLookupForFile(string file)
+        {
+            return _domain.LookupShimsForFile(file);
+        }
+
+        public string GetVerifiedSnapshotSourceForFile(string projectRelativeFile)
+        {
+            return _domain.LoadVerifiedSnapshotSourceForFile(projectRelativeFile);
+        }
+
+        public string GetVerifiedSnapshotSource(string projectRelativeFile, string dllPath)
+        {
+            if (string.IsNullOrEmpty(projectRelativeFile) || string.IsNullOrEmpty(dllPath))
+            {
+                return null;
+            }
+
+            return HotReloadSourceBaseline.LoadVerifiedSnapshotSource(projectRelativeFile, dllPath);
+        }
+
+        public IReadOnlyList<LocalBuilder> GetTransplantLocals(MethodBase method)
+        {
+            return _domain.FindGenerationForMethod(method)?.FindTransplantLocals(method);
+        }
+
+        public int GetTransplantPreambleLength(MethodBase method)
+        {
+            return _domain.FindGenerationForMethod(method)?.FindTransplantPreambleLength(method) ?? 0;
+        }
+
+        public IReadOnlyList<string> GetAddedFieldsForType(string typeFullName)
+        {
+            return _domain.GetAddedFieldsForType(typeFullName);
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadPausePointPort.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadPausePointPort.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7c6d2e76db93c4e7e8aa9cc3eb98f1b4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadUnpatchedMethodLineShiftWarningBuilder.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadUnpatchedMethodLineShiftWarningBuilder.cs
@@ -184,6 +184,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return File.ReadAllText(absolutePath);
         }
 
+        // Why hot reload reads its own snapshot through the port it publishes for pause point:
+        // this reader is handed to Append as a Func by the response builder, and the builder still
+        // reaches the domain through the installed services. Passing the domain in belongs with
+        // that call site, not here.
         internal static string ReadCompiledSnapshot(string projectRelativePath)
         {
             if (string.IsNullOrEmpty(projectRelativePath))
@@ -191,13 +195,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 return null;
             }
 
-            Func<string, string> loader = HotReloadPausePointCoordination.GetVerifiedSnapshotSourceForFile;
-            if (loader == null)
-            {
-                return null;
-            }
-
-            return loader(HotReloadSourcePathNormalizer.ToForwardSlashes(projectRelativePath));
+            return HotReloadPausePointCoordination.HotReloadSide?.GetVerifiedSnapshotSourceForFile(
+                HotReloadSourcePathNormalizer.ToForwardSlashes(projectRelativePath));
         }
 
         // Why the same split as pause-point compiled-line reads: --line is 1-based against that split,

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/PausePointCompiledSourceReader.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/PausePointCompiledSourceReader.cs
@@ -11,7 +11,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         {
             string normalizedFile = SourcePausePointPathNormalizer.ToForwardSlashes(requestedFile);
             string snapshotSource =
-                HotReloadPausePointCoordination.GetVerifiedSnapshotSourceForFile?.Invoke(normalizedFile);
+                HotReloadPausePointCoordination.HotReloadSide?.GetVerifiedSnapshotSourceForFile(
+                    normalizedFile);
             return snapshotSource ?? string.Empty;
         }
     }

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/PausePointEnableWarnings.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/PausePointEnableWarnings.cs
@@ -23,9 +23,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 return string.Empty;
             }
 
-            Func<string, IReadOnlyList<string>> getter =
-                HotReloadPausePointCoordination.GetAddedFieldsForType;
-            if (getter == null)
+            IHotReloadPausePointPort hotReloadSide = HotReloadPausePointCoordination.HotReloadSide;
+            if (hotReloadSide == null)
             {
                 return string.Empty;
             }
@@ -36,7 +35,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 return string.Empty;
             }
 
-            IReadOnlyList<string> addedFields = getter(typeName);
+            IReadOnlyList<string> addedFields = hotReloadSide.GetAddedFieldsForType(typeName);
             if (addedFields == null || addedFields.Count == 0)
             {
                 return string.Empty;

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/PausePointHotReloadPort.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/PausePointHotReloadPort.cs
@@ -1,0 +1,39 @@
+using System.Collections.Generic;
+using System.Reflection;
+
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Answers the hot-reload tool's questions about the markers pause point has injected in this
+    /// domain. Published by <see cref="SourcePausePointPatcher"/> when it initializes.
+    /// </summary>
+    internal sealed class PausePointHotReloadPort : IPausePointHotReloadPort
+    {
+        public IReadOnlyList<string> GetArmedMarkerIdsOnMethod(MethodBase method)
+        {
+            return SourcePausePointHotReloadRetarget.GetArmedMarkerIds(method);
+        }
+
+        public IReadOnlyList<string> GetSuppressedMarkerIdsOnMethod(MethodBase method)
+        {
+            return SourcePausePointHotReloadRetarget.GetSuppressedMarkerIds(method);
+        }
+
+        public IReadOnlyList<string> ConsumeExpiredNotRetargetedMarkerIds()
+        {
+            return SourcePausePointHotReloadRetarget.ConsumeExpiredNotRetargetedMarkerIds();
+        }
+
+        public IReadOnlyList<(string Id, string OldText, string NewText)> ConsumeRetargetLineDriftWarnings()
+        {
+            return SourcePausePointHotReloadRetarget.ConsumeRetargetLineDriftWarnings();
+        }
+
+        public void OnHotReloadPatchStateChanged(MethodBase method, bool patched)
+        {
+            SourcePausePointHotReloadRetarget.HandleHotReloadPatchStateChanged(method, patched);
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/PausePointHotReloadPort.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/PausePointHotReloadPort.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b1707f315e10042d58aea9bc305c4bb8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/PausePointLineTextReader.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/PausePointLineTextReader.cs
@@ -29,7 +29,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             string dllPath,
             int resolvedLine)
         {
-            string snapshot = HotReloadPausePointCoordination.GetVerifiedSnapshotSource?.Invoke(
+            string snapshot = HotReloadPausePointCoordination.HotReloadSide?.GetVerifiedSnapshotSource(
                 projectRelativeFile,
                 dllPath);
             return SourcePausePointSourceLineReader.ReadLineTextFromSource(snapshot, resolvedLine);

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/PausePointUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/PausePointUseCase.cs
@@ -220,7 +220,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             SourcePausePointSnapshotTiming snapshotTiming = ParseSnapshotTiming(parameters.SnapshotTiming);
 
             HotReloadShimFileLookup shimLookup =
-                HotReloadPausePointCoordination.GetShimLookupForFile?.Invoke(normalizedFile);
+                HotReloadPausePointCoordination.HotReloadSide?.GetShimLookupForFile(normalizedFile);
             if (shimLookup != null)
             {
                 SourcePausePointShimResolution shimResolution =

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointHotReloadRetarget.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointHotReloadRetarget.cs
@@ -184,7 +184,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 }
 
                 HotReloadShimFileLookup lookup =
-                    HotReloadPausePointCoordination.GetShimLookupForFile?.Invoke(request.NormalizedFile);
+                    HotReloadPausePointCoordination.HotReloadSide?.GetShimLookupForFile(
+                        request.NormalizedFile);
                 if (lookup == null)
                 {
                     SuppressMarkerRetargetFailed(id);

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointInjectionEmitter.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointInjectionEmitter.cs
@@ -49,7 +49,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             MethodBase activeShim =
-                HotReloadPausePointCoordination.GetActiveShimForMethod?.Invoke(original);
+                HotReloadPausePointCoordination.HotReloadSide?.GetActiveShimForMethod(original);
 
             foreach (SourcePausePointPatchInjection injection in injections.OrderByDescending(i => i.InstructionIndex))
             {
@@ -188,7 +188,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             if (injection.TargetKind == SourcePausePointPatchInjectionTargetKind.TransplantChainJoin)
             {
                 IReadOnlyList<LocalBuilder> transplantLocals =
-                    HotReloadPausePointCoordination.GetTransplantLocals?.Invoke(method);
+                    HotReloadPausePointCoordination.HotReloadSide?.GetTransplantLocals(method);
                 MethodBody donorBody = injection.DonorShim != null
                     ? injection.DonorShim.GetMethodBody()
                     : null;

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointPatcher.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointPatcher.cs
@@ -42,16 +42,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         {
             UloopPausePointRegistry.OnCleared = Unpatch;
             UloopPausePointRegistry.OnClearedAll = UnpatchAll;
-            HotReloadPausePointCoordination.GetArmedMarkerIdsOnMethod =
-                SourcePausePointHotReloadRetarget.GetArmedMarkerIds;
-            HotReloadPausePointCoordination.GetSuppressedMarkerIdsOnMethod =
-                SourcePausePointHotReloadRetarget.GetSuppressedMarkerIds;
-            HotReloadPausePointCoordination.ConsumeExpiredNotRetargetedMarkerIds =
-                SourcePausePointHotReloadRetarget.ConsumeExpiredNotRetargetedMarkerIds;
-            HotReloadPausePointCoordination.OnHotReloadPatchStateChanged =
-                SourcePausePointHotReloadRetarget.HandleHotReloadPatchStateChanged;
-            HotReloadPausePointCoordination.ConsumeRetargetLineDriftWarnings =
-                SourcePausePointHotReloadRetarget.ConsumeRetargetLineDriftWarnings;
+            HotReloadPausePointCoordination.PausePointSide = new PausePointHotReloadPort();
         }
 
         public static SourcePausePointPatchResult Patch(
@@ -77,7 +68,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             bool patchedByHotReload =
-                HotReloadPausePointCoordination.GetActiveShimForMethod?.Invoke(method) != null;
+                HotReloadPausePointCoordination.HotReloadSide?.GetActiveShimForMethod(method) != null;
             if (patchedByHotReload)
             {
                 string typeName = method.DeclaringType != null ? method.DeclaringType.Name : "?";
@@ -215,14 +206,13 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 return instructionIndex;
             }
 
-            Func<MethodBase, int> getPreambleLength =
-                HotReloadPausePointCoordination.GetTransplantPreambleLength;
-            if (getPreambleLength == null)
+            IHotReloadPausePointPort hotReloadSide = HotReloadPausePointCoordination.HotReloadSide;
+            if (hotReloadSide == null)
             {
                 return instructionIndex;
             }
 
-            return instructionIndex + getPreambleLength(method);
+            return instructionIndex + hotReloadSide.GetTransplantPreambleLength(method);
         }
 
         // Why compare the injection site too: the same file:line id re-enabled with the other

--- a/Packages/src/Editor/ToolContracts/HotReloadPausePointCoordination.cs
+++ b/Packages/src/Editor/ToolContracts/HotReloadPausePointCoordination.cs
@@ -1,94 +1,29 @@
-using System;
 using System.Collections.Generic;
 using System.Reflection;
-using System.Reflection.Emit;
 
 namespace io.github.hatayama.UnityCliLoop.ToolContracts
 {
     /// <summary>
     /// Editor-domain coordination point between the hot-reload tool and the source
     /// pause-point tool. The two tools live in sibling assemblies that must not
-    /// reference each other, so each side publishes its state through delegates
-    /// wired in its own static constructor (the same pattern as
-    /// UloopPausePointRegistry's OnCleared wiring). A null delegate means the owning
-    /// side has not initialized in this domain, which also means it has no state
-    /// worth querying; callers treat null as "no patches" / "no markers" /
-    /// "no shim lookup".
+    /// reference each other, so each side publishes one port implementation, wired by the
+    /// side that owns it (the same pattern as UloopPausePointRegistry's OnCleared wiring).
+    /// A null port means the owning side has not initialized in this domain, which also
+    /// means it has no state worth querying; callers treat null as "no patches" /
+    /// "no markers" / "no shim lookup".
     /// </summary>
     public static class HotReloadPausePointCoordination
     {
-        // Set by the hot-reload side. Returns the active shim MethodBase for a patched
-        // original method, or null when the method is not hot-reload patched.
-        public static Func<MethodBase, MethodBase> GetActiveShimForMethod { get; set; }
+        /// <summary>
+        /// Set by the hot-reload composition root when it installs a domain, and cleared when it
+        /// uninstalls one. Never points at a domain that is no longer installed.
+        /// </summary>
+        public static IHotReloadPausePointPort HotReloadSide { get; set; }
 
         /// <summary>
-        /// Set by the hot-reload side. Argument is a forward-slash path (absolute or
-        /// project-relative); returns null when that file has no active shim generation.
-        /// A method may still report an active shim via <see cref="GetActiveShimForMethod"/>
-        /// while missing from this file lookup (a newer generation replaced the file and
-        /// the method was skipped, bind-failed, or isolation-excluded). Consumers must treat
-        /// that combination as retarget-impossible (suppress the marker).
+        /// Set by the pause-point patcher when it initializes in this domain.
         /// </summary>
-        public static Func<string, HotReloadShimFileLookup> GetShimLookupForFile { get; set; }
-
-        /// <summary>
-        /// Set by HotReload. Returns the PDB-checksum-verified compiled snapshot text for a
-        /// project-relative source file, or null when no snapshot is available.
-        /// </summary>
-        public static Func<string, string> GetVerifiedSnapshotSourceForFile { get; set; }
-
-        /// <summary>
-        /// Set by HotReload. Arguments are the project-relative source path and the compiled
-        /// assembly path; returns the PDB-checksum-verified snapshot text, or null when none.
-        /// Use this after the shim registry is cleared (revert/restore) when file lookup
-        /// can no longer find a generation.
-        /// </summary>
-        public static Func<string, string, string> GetVerifiedSnapshotSource { get; set; }
-
-        /// <summary>
-        /// Set by the hot-reload side. Returns the LocalBuilder array (shim slot order) from
-        /// the latest transplant rebuild of the original method, or null when none.
-        /// Returned LocalBuilders are tied to the ILGenerator of that rebuild and are valid
-        /// only inside the same rebuild (the pause-point transpiler that runs after the
-        /// hot-reload transpiler). Do not retain or use them outside that rebuild.
-        /// </summary>
-        public static Func<MethodBase, IReadOnlyList<LocalBuilder>> GetTransplantLocals { get; set; }
-
-        /// <summary>
-        /// Set by the hot-reload side. Returns how many instructions the latest rebuild prepended
-        /// before the patched body (0 when none). Pause-point must add this only to
-        /// TransplantChainJoin indexes; ShimDirect and OriginalBody have no transplant preamble.
-        /// </summary>
-        public static Func<MethodBase, int> GetTransplantPreambleLength { get; set; }
-
-        /// <summary>
-        /// Set by the hot-reload side. Argument is a type full name (reflection
-        /// <c>Outer+Inner</c> or Cecil <c>Outer/Inner</c>); returns the simple names of fields
-        /// hot reload added to that type across every file, or empty when none.
-        /// </summary>
-        public static Func<string, IReadOnlyList<string>> GetAddedFieldsForType { get; set; }
-
-        // Set by SourcePausePointPatcher. Returns the marker ids currently injected
-        // into the method (empty when none).
-        public static Func<MethodBase, IReadOnlyList<string>> GetArmedMarkerIdsOnMethod { get; set; }
-
-        // Set by SourcePausePointPatcher. Returns marker ids whose logical owner is the
-        // method and whose registry entry is currently SuppressedByHotReload.
-        public static Func<MethodBase, IReadOnlyList<string>> GetSuppressedMarkerIdsOnMethod { get; set; }
-
-        // Set by SourcePausePointPatcher. Drains marker ids recorded during the latest
-        // hot-reload patch transition that were skipped for retarget because they were
-        // already Expired (not a scan of residual expired ledger state).
-        public static Func<IReadOnlyList<string>> ConsumeExpiredNotRetargetedMarkerIds { get; set; }
-
-        // Set by SourcePausePointPatcher. Drains (id, oldText, newText) triples recorded when
-        // retarget changed the resolved line text of an armed marker.
-        public static Func<IReadOnlyList<(string Id, string OldText, string NewText)>>
-            ConsumeRetargetLineDriftWarnings { get; set; }
-
-        // Set by SourcePausePointPatcher. Invoked by HotReloadPatcher after a
-        // method's patch state changes (true = patched, false = reverted).
-        public static Action<MethodBase, bool> OnHotReloadPatchStateChanged { get; set; }
+        public static IPausePointHotReloadPort PausePointSide { get; set; }
     }
 
     /// <summary>

--- a/Packages/src/Editor/ToolContracts/IHotReloadPausePointPort.cs
+++ b/Packages/src/Editor/ToolContracts/IHotReloadPausePointPort.cs
@@ -1,0 +1,66 @@
+using System.Collections.Generic;
+using System.Reflection;
+using System.Reflection.Emit;
+
+namespace io.github.hatayama.UnityCliLoop.ToolContracts
+{
+    /// <summary>
+    /// What the pause-point tool may ask the hot-reload tool about the domain hot reload
+    /// currently has installed. Implemented by hot reload, read through
+    /// <see cref="HotReloadPausePointCoordination.HotReloadSide"/>.
+    /// </summary>
+    public interface IHotReloadPausePointPort
+    {
+        /// <summary>
+        /// Returns the active shim MethodBase for a patched original method, or null when the
+        /// method is not hot-reload patched.
+        /// </summary>
+        MethodBase GetActiveShimForMethod(MethodBase method);
+
+        /// <summary>
+        /// Argument is a forward-slash path (absolute or project-relative); returns null when
+        /// that file has no active shim generation. A method may still report an active shim via
+        /// <see cref="GetActiveShimForMethod"/> while missing from this file lookup (a newer
+        /// generation replaced the file and the method was skipped, bind-failed, or
+        /// isolation-excluded). Consumers must treat that combination as retarget-impossible
+        /// (suppress the marker).
+        /// </summary>
+        HotReloadShimFileLookup GetShimLookupForFile(string file);
+
+        /// <summary>
+        /// Returns the PDB-checksum-verified compiled snapshot text for a project-relative source
+        /// file, or null when no snapshot is available.
+        /// </summary>
+        string GetVerifiedSnapshotSourceForFile(string projectRelativeFile);
+
+        /// <summary>
+        /// Returns the PDB-checksum-verified snapshot text for a project-relative source path and
+        /// the compiled assembly path, or null when none. Use this after the shim registry is
+        /// cleared (revert/restore) when file lookup can no longer find a generation.
+        /// </summary>
+        string GetVerifiedSnapshotSource(string projectRelativeFile, string dllPath);
+
+        /// <summary>
+        /// Returns the LocalBuilder array (shim slot order) from the latest transplant rebuild of
+        /// the original method, or null when none. Returned LocalBuilders are tied to the
+        /// ILGenerator of that rebuild and are valid only inside the same rebuild (the pause-point
+        /// transpiler that runs after the hot-reload transpiler). Do not retain or use them
+        /// outside that rebuild.
+        /// </summary>
+        IReadOnlyList<LocalBuilder> GetTransplantLocals(MethodBase method);
+
+        /// <summary>
+        /// Returns how many instructions the latest rebuild prepended before the patched body
+        /// (0 when none). Pause-point must add this only to TransplantChainJoin indexes;
+        /// ShimDirect and OriginalBody have no transplant preamble.
+        /// </summary>
+        int GetTransplantPreambleLength(MethodBase method);
+
+        /// <summary>
+        /// Argument is a type full name (reflection <c>Outer+Inner</c> or Cecil
+        /// <c>Outer/Inner</c>); returns the simple names of fields hot reload added to that type
+        /// across every file, or empty when none.
+        /// </summary>
+        IReadOnlyList<string> GetAddedFieldsForType(string typeFullName);
+    }
+}

--- a/Packages/src/Editor/ToolContracts/IHotReloadPausePointPort.cs.meta
+++ b/Packages/src/Editor/ToolContracts/IHotReloadPausePointPort.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fcbe4974288fa4c229868372071bf3b8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/ToolContracts/IPausePointHotReloadPort.cs
+++ b/Packages/src/Editor/ToolContracts/IPausePointHotReloadPort.cs
@@ -1,0 +1,43 @@
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace io.github.hatayama.UnityCliLoop.ToolContracts
+{
+    /// <summary>
+    /// What the hot-reload tool may ask the pause-point tool about the markers it currently has
+    /// injected. Implemented by pause point, read through
+    /// <see cref="HotReloadPausePointCoordination.PausePointSide"/>.
+    /// </summary>
+    public interface IPausePointHotReloadPort
+    {
+        /// <summary>
+        /// Returns the marker ids currently injected into the method (empty when none).
+        /// </summary>
+        IReadOnlyList<string> GetArmedMarkerIdsOnMethod(MethodBase method);
+
+        /// <summary>
+        /// Returns marker ids whose logical owner is the method and whose registry entry is
+        /// currently SuppressedByHotReload.
+        /// </summary>
+        IReadOnlyList<string> GetSuppressedMarkerIdsOnMethod(MethodBase method);
+
+        /// <summary>
+        /// Drains marker ids recorded during the latest hot-reload patch transition that were
+        /// skipped for retarget because they were already Expired (not a scan of residual expired
+        /// ledger state).
+        /// </summary>
+        IReadOnlyList<string> ConsumeExpiredNotRetargetedMarkerIds();
+
+        /// <summary>
+        /// Drains (id, oldText, newText) triples recorded when retarget changed the resolved line
+        /// text of an armed marker.
+        /// </summary>
+        IReadOnlyList<(string Id, string OldText, string NewText)> ConsumeRetargetLineDriftWarnings();
+
+        /// <summary>
+        /// Called by the hot-reload patcher after a method's patch state changes
+        /// (true = patched, false = reverted).
+        /// </summary>
+        void OnHotReloadPatchStateChanged(MethodBase method, bool patched);
+    }
+}

--- a/Packages/src/Editor/ToolContracts/IPausePointHotReloadPort.cs.meta
+++ b/Packages/src/Editor/ToolContracts/IPausePointHotReloadPort.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 10bd9fe58742b4d969da22fd77c63ff2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary
- Uninstalling the hot-reload services no longer leaves pause point reading from a disposed domain.
- The hot-reload and pause-point tools now coordinate through one port object per side instead of twelve loose static delegates.

## User Impact
- Before: after the hot-reload services were uninstalled (a second `Initialize` in one Editor session), the coordination point still held delegates closed over the disposed domain. Pause point kept answering shim lookups, transplant locals, preamble lengths and added-field warnings from a domain that could no longer serve them.
- After: an uninstall clears both sides of the coordination point in one assignment each, so pause point observes the documented "no domain installed" answer and falls back to its own source reading. No behavior changes while a domain is installed.

## Changes
- Added `IHotReloadPausePointPort` (7 members) and `IPausePointHotReloadPort` (5 members) to `ToolContracts`, replacing the 12 delegate slots on `HotReloadPausePointCoordination` with `HotReloadSide` / `PausePointSide`.
- `HotReloadPausePointPort` is built and installed by `HotReloadCompositionRoot` beside the gateways; `PausePointHotReloadPort` is installed by `SourcePausePointPatcher`'s static initializer.
- `ClearWiring` now also clears `HotReloadPausePointCoordination.HotReloadSide` and `HotReloadIntroducedTypeCoordination.DescribeActiveTypeNames`, which is the actual defect fix.
- Added `HotReloadCompositionRoot.UninstallInstalledServices` so a test can observe the terminal uninstall state; production still reaches it only through `Initialize`.
- The composition root's private `LoadVerifiedSnapshotSource` helper moved into the hot-reload port.
- New `UnityCLILoop.Tests.Editor.CoordinationPorts` test assembly (references `ToolContracts` only) holds the two port stubs and the `HotReloadSidePortScope` / `PausePointSidePortScope` helpers, shared by the three test assemblies that stub the coordination point.

## Verification
- `uloop compile` — 0 errors.
- `uloop run-tests --filter-type regex --filter-value "HotReloadCompositionRootTests|HotReloadPausePointContractTests|HotReloadPausePointE2ETests|HotReloadPausePointLineDriftTests|HotReloadShimLookupTests"` — 39/39 passed.
- `uloop run-tests --filter-type regex --filter-value "PausePoint"` — 722/722 passed.
- `uloop run-tests --filter-type regex --filter-value "HotReloadToolTests|HotReloadUnpatchedMethodLineShiftWarningBuilderTests|HotReloadDomainTests|HotReloadOrchestratorTests|HotReloadPatcherTests|HotReloadFileGenerationsTests"` — 266/266 passed.
- `check-asmdef-policy` — no violations.
- `check-file-length.sh` with the repository threshold — exit 0.
- `git grep -n "HotReloadPausePointCoordination\.\(Get\|Consume\|On\)" Packages Assets` — 0 matches.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2736?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

