### PR TITLE
chore: Give each hot-reload test its own domain

### DIFF
--- a/Assets/Tests/Editor/HotReload/HotReloadAutoRefreshHoldTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadAutoRefreshHoldTests.cs
@@ -15,6 +15,20 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
     /// </summary>
     public sealed class HotReloadAutoRefreshHoldTests
     {
+        private HotReloadDomainTestScope _scope;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _scope = new HotReloadDomainTestScope();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _scope.Dispose();
+        }
+
         private sealed class FakeEnvironment
         {
             internal bool Held;
@@ -330,7 +344,6 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         public void ReconcileForTesting_StaleFlagWithEmptyLedger_AllowsOnceAndClearsFlag()
         {
             FakeEnvironment environment = new FakeEnvironment { Held = true };
-            HotReloadCompositionRoot.Services.Patcher.RevertAll();
             HotReloadAutoRefreshHoldService previous = HotReloadAutoRefreshHold.OverrideServiceForTesting;
             try
             {
@@ -365,7 +378,6 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 Held = true,
                 AllowException = new InvalidOperationException("reload")
             };
-            HotReloadCompositionRoot.Services.Patcher.RevertAll();
             HotReloadAutoRefreshHoldService previous = HotReloadAutoRefreshHold.OverrideServiceForTesting;
             try
             {

--- a/Assets/Tests/Editor/HotReload/HotReloadCrossFileE2ETests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadCrossFileE2ETests.cs
@@ -56,20 +56,19 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         private const string IntroducedTypeDeclaration =
             "\n\nnamespace Example\n{\n    public class CrossFileIntroduced\n    {\n    }\n}\n";
 
+        private HotReloadDomainTestScope _scope;
+
         [SetUp]
         public void SetUp()
         {
-            // The production run captures these at its entry point; a direct call to the path
-            // normalizer in a test has to do the same.
-            HotReloadCompositionRoot.Services.PackageRootCapture.CaptureCurrent();
-            HotReloadCompositionRoot.Services.Patcher.RevertAll();
+            _scope = new HotReloadDomainTestScope();
             HotReloadAutoRefreshHold.SyncToActiveChanges();
         }
 
         [TearDown]
         public void TearDown()
         {
-            HotReloadCompositionRoot.Services.Patcher.RevertAll();
+            _scope.Dispose();
             HotReloadAutoRefreshHold.SyncToActiveChanges();
             VibeLogger.ClearMemoryLogs();
         }

--- a/Assets/Tests/Editor/HotReload/HotReloadDomainTestAccess.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadDomainTestAccess.cs
@@ -105,20 +105,5 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             return generation != null && generation.HasAddedMemberGeneration;
         }
 
-        /// <summary>Drops the added members and fields of every file, leaving live patches alone.</summary>
-        internal void ClearAddedMembersAndFields()
-        {
-            IReadOnlyList<HotReloadFileGeneration> generations = Domain.ListGenerations();
-            for (int index = 0; index < generations.Count; index++)
-            {
-                generations[index].BeginAddedMemberGeneration();
-            }
-        }
-
-        /// <summary>Empties every store the domain owns, as a revert-all would.</summary>
-        internal void ResetDomain()
-        {
-            Domain.RevertAll();
-        }
     }
 }

--- a/Assets/Tests/Editor/HotReload/HotReloadDomainTestScope.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadDomainTestScope.cs
@@ -1,0 +1,50 @@
+using System;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
+{
+    /// <summary>
+    /// Installs a hot-reload services graph of its own for the duration of one test and takes it
+    /// back out again, so a test arranges patches and generations without inheriting or leaving any.
+    /// </summary>
+    /// <remarks>
+    /// Why a scope rather than a revert in SetUp and TearDown: reverting empties the one production
+    /// domain but leaves every test sharing it, so a class that forgets a store leaks into the next
+    /// one. A scope that brings its own domain cannot leak, because the domain goes away with it.
+    /// Substituting a single collaborator on the installed graph is a different need, and
+    /// <see cref="HotReloadServicesTestScope"/> covers that one.
+    /// </remarks>
+    internal sealed class HotReloadDomainTestScope : IDisposable
+    {
+        private readonly HotReloadServices _services;
+        private readonly IDisposable _replacement;
+        private bool _disposed;
+
+        internal HotReloadDomainTestScope()
+        {
+            HotReloadServices services = HotReloadCompositionRoot.CreateProductionServices();
+
+            // The capture is main-thread only, and a run inside the scope normalizes script paths
+            // against these roots on the background threads it switches to.
+            services.PackageRootCapture.CaptureCurrent();
+            _services = services;
+            _replacement = HotReloadCompositionRoot.BeginReplacement(services);
+        }
+
+        public void Dispose()
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            _disposed = true;
+
+            // Harmony first: reverting after the domain is put back would unpatch against the
+            // generations the restored services own, not the ones this scope patched.
+            _services.Patcher.RevertAll();
+            _replacement.Dispose();
+        }
+    }
+}

--- a/Assets/Tests/Editor/HotReload/HotReloadDomainTestScope.cs.meta
+++ b/Assets/Tests/Editor/HotReload/HotReloadDomainTestScope.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ec742b1b4161f450995ab80f1182ceea
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/HotReload/HotReloadDomainTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadDomainTests.cs
@@ -28,17 +28,19 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
         private HotReloadDomainTestAccess _access;
 
+        private HotReloadDomainTestScope _scope;
+
         [SetUp]
         public void SetUp()
         {
+            _scope = new HotReloadDomainTestScope();
             _access = new HotReloadDomainTestAccess();
-            _access.ResetDomain();
         }
 
         [TearDown]
         public void TearDown()
         {
-            HotReloadCompositionRoot.Services.Patcher.RevertAll();
+            _scope.Dispose();
         }
 
         /// <summary>

--- a/Assets/Tests/Editor/HotReload/HotReloadGlobalNamespaceShimE2ETests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadGlobalNamespaceShimE2ETests.cs
@@ -24,17 +24,19 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         private const string HostValueAnchor = "    public int Value()";
         private const string CallerCallBodyAnchor = "return host.Value();";
 
+        private HotReloadDomainTestScope _scope;
+
         [SetUp]
         public void SetUp()
         {
-            HotReloadCompositionRoot.Services.Patcher.RevertAll();
+            _scope = new HotReloadDomainTestScope();
             HotReloadAutoRefreshHold.SyncToActiveChanges();
         }
 
         [TearDown]
         public void TearDown()
         {
-            HotReloadCompositionRoot.Services.Patcher.RevertAll();
+            _scope.Dispose();
             HotReloadAutoRefreshHold.SyncToActiveChanges();
             VibeLogger.ClearMemoryLogs();
         }

--- a/Assets/Tests/Editor/HotReload/HotReloadGroupProcessorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadGroupProcessorTests.cs
@@ -31,12 +31,18 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             "BrokenNoticeSource.cs(3,1): error CS1022: Type or namespace definition, or end-of-file expected";
 
 
+        private HotReloadDomainTestScope _scope;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _scope = new HotReloadDomainTestScope();
+        }
+
         [TearDown]
         public void TearDown()
         {
-            // Added members and fields live for the whole domain, so a committed name would
-            // outlive this class.
-            new HotReloadDomainTestAccess().ClearAddedMembersAndFields();
+            _scope.Dispose();
         }
 
         /// <summary>

--- a/Assets/Tests/Editor/HotReload/HotReloadIntroducedTypeActivationTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadIntroducedTypeActivationTests.cs
@@ -20,13 +20,12 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
     public class HotReloadIntroducedTypeActivationTests
     {
 
+        private HotReloadDomainTestScope _scope;
+
         [SetUp]
         public void SetUp()
         {
-            // The production run captures these at its entry point; a direct call to the path
-            // normalizer in a test has to do the same.
-            HotReloadCompositionRoot.Services.PackageRootCapture.CaptureCurrent();
-            HotReloadCompositionRoot.Services.Patcher.RevertAll();
+            _scope = new HotReloadDomainTestScope();
             HotReloadAutoRefreshHold.SyncToActiveChanges();
         }
 
@@ -36,7 +35,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         [TearDown]
         public void TearDown()
         {
-            HotReloadCompositionRoot.Services.Patcher.RevertAll();
+            _scope.Dispose();
             HotReloadAutoRefreshHold.SyncToActiveChanges();
         }
 

--- a/Assets/Tests/Editor/HotReload/HotReloadIntroducedTypeHoldTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadIntroducedTypeHoldTests.cs
@@ -20,10 +20,12 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
     /// </summary>
     public class HotReloadIntroducedTypeHoldTests
     {
+        private HotReloadDomainTestScope _scope;
+
         [SetUp]
         public void SetUp()
         {
-            HotReloadCompositionRoot.Services.Patcher.RevertAll();
+            _scope = new HotReloadDomainTestScope();
             ReleaseTheHold();
         }
 
@@ -32,7 +34,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         [TearDown]
         public void TearDown()
         {
-            HotReloadCompositionRoot.Services.Patcher.RevertAll();
+            _scope.Dispose();
             ReleaseTheHold();
         }
 

--- a/Assets/Tests/Editor/HotReload/HotReloadIntroducedTypeResponseTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadIntroducedTypeResponseTests.cs
@@ -16,10 +16,12 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
     /// </summary>
     public class HotReloadIntroducedTypeResponseTests
     {
+        private HotReloadDomainTestScope _scope;
+
         [SetUp]
         public void SetUp()
         {
-            HotReloadCompositionRoot.Services.Patcher.RevertAll();
+            _scope = new HotReloadDomainTestScope();
             HotReloadAutoRefreshHold.SyncToActiveChanges();
         }
 
@@ -29,7 +31,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         [TearDown]
         public void TearDown()
         {
-            HotReloadCompositionRoot.Services.Patcher.RevertAll();
+            _scope.Dispose();
             HotReloadAutoRefreshHold.SyncToActiveChanges();
         }
 

--- a/Assets/Tests/Editor/HotReload/HotReloadIntroducedTypeStatusTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadIntroducedTypeStatusTests.cs
@@ -22,17 +22,19 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         private const string FirstMetadataName = "Fixture.IntroducedOne";
         private const string SecondMetadataName = "Fixture.IntroducedTwo";
 
+        private HotReloadDomainTestScope _scope;
+
         [SetUp]
         public void SetUp()
         {
-            HotReloadCompositionRoot.Services.Patcher.RevertAll();
+            _scope = new HotReloadDomainTestScope();
             HotReloadAutoRefreshHold.SyncToActiveChanges();
         }
 
         [TearDown]
         public void TearDown()
         {
-            HotReloadCompositionRoot.Services.Patcher.RevertAll();
+            _scope.Dispose();
             HotReloadAutoRefreshHold.SyncToActiveChanges();
         }
 

--- a/Assets/Tests/Editor/HotReload/HotReloadJitInliningInvestigationTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadJitInliningInvestigationTests.cs
@@ -19,10 +19,18 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
     /// </summary>
     public class HotReloadJitInliningInvestigationTests
     {
+        private HotReloadDomainTestScope _scope;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _scope = new HotReloadDomainTestScope();
+        }
+
         [TearDown]
         public void TearDown()
         {
-            HotReloadCompositionRoot.Services.Patcher.RevertAll();
+            _scope.Dispose();
         }
 
         /// <summary>

--- a/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
@@ -29,20 +29,19 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
     /// </summary>
     public class HotReloadOrchestratorTests
     {
+        private HotReloadDomainTestScope _scope;
+
         [SetUp]
         public void SetUp()
         {
-            // The production run captures these at its entry point; a direct call to the path
-            // normalizer in a test has to do the same.
-            HotReloadCompositionRoot.Services.PackageRootCapture.CaptureCurrent();
-            HotReloadCompositionRoot.Services.Patcher.RevertAll();
+            _scope = new HotReloadDomainTestScope();
             HotReloadAutoRefreshHold.SyncToActiveChanges();
         }
 
         [TearDown]
         public void TearDown()
         {
-            HotReloadCompositionRoot.Services.Patcher.RevertAll();
+            _scope.Dispose();
             HotReloadAutoRefreshHold.SyncToActiveChanges();
             VibeLogger.ClearMemoryLogs();
         }
@@ -3044,7 +3043,6 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 workerOutput,
                 entries,
                 Array.Empty<string>());
-            new HotReloadDomainTestAccess().ResetDomain();
 
             try
             {

--- a/Assets/Tests/Editor/HotReload/HotReloadPatcherTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadPatcherTests.cs
@@ -21,10 +21,18 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
     /// </summary>
     public class HotReloadPatcherTests
     {
+        private HotReloadDomainTestScope _scope;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _scope = new HotReloadDomainTestScope();
+        }
+
         [TearDown]
         public void TearDown()
         {
-            HotReloadCompositionRoot.Services.Patcher.RevertAll();
+            _scope.Dispose();
         }
 
         /// <summary>

--- a/Assets/Tests/Editor/HotReload/HotReloadPausePointContractTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadPausePointContractTests.cs
@@ -28,16 +28,19 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         private const string FixtureProjectRelativePath =
             "Assets/Tests/Editor/HotReload/HotReloadE2EFixtures.cs";
 
+        private HotReloadDomainTestScope _scope;
+
         [SetUp]
         public void SetUp()
         {
+            _scope = new HotReloadDomainTestScope();
             UloopPausePointRegistry.ConfigureForTests(new FakePausePointPauseController(), () => DateTime.UtcNow);
         }
 
         [TearDown]
         public void TearDown()
         {
-            HotReloadCompositionRoot.Services.Patcher.RevertAll();
+            _scope.Dispose();
             SourcePausePointPatcher.UnpatchAll();
             UloopPausePointRegistry.ResetForTests();
         }

--- a/Assets/Tests/Editor/HotReload/HotReloadPausePointE2ETests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadPausePointE2ETests.cs
@@ -29,16 +29,19 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         private const string FixtureProjectRelativePath =
             "Assets/Tests/Editor/HotReload/HotReloadE2EFixtures.cs";
 
+        private HotReloadDomainTestScope _scope;
+
         [SetUp]
         public void SetUp()
         {
+            _scope = new HotReloadDomainTestScope();
             UloopPausePointRegistry.ConfigureForTests(new FakePausePointPauseController(), () => DateTime.UtcNow);
         }
 
         [TearDown]
         public void TearDown()
         {
-            HotReloadCompositionRoot.Services.Patcher.RevertAll();
+            _scope.Dispose();
             SourcePausePointPatcher.UnpatchAll();
             UloopPausePointRegistry.ResetForTests();
         }

--- a/Assets/Tests/Editor/HotReload/HotReloadPausePointLineDriftTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadPausePointLineDriftTests.cs
@@ -37,16 +37,19 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
         private const string RestoreSnapshotSentinel = "SENTINEL_RESTORE_LINE_TEXT";
 
+        private HotReloadDomainTestScope _scope;
+
         [SetUp]
         public void SetUp()
         {
+            _scope = new HotReloadDomainTestScope();
             UloopPausePointRegistry.ConfigureForTests(new FakePausePointPauseController(), () => DateTime.UtcNow);
         }
 
         [TearDown]
         public void TearDown()
         {
-            HotReloadCompositionRoot.Services.Patcher.RevertAll();
+            _scope.Dispose();
             SourcePausePointPatcher.UnpatchAll();
             UloopPausePointRegistry.ResetForTests();
         }

--- a/Assets/Tests/Editor/HotReload/HotReloadPlayModeEntryDropRecorderTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadPlayModeEntryDropRecorderTests.cs
@@ -25,11 +25,13 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
     {
         private HotReloadPlayModeEntryDropLedgerSessionScope _ledgerSessionScope;
 
+        private HotReloadDomainTestScope _scope;
+
         [SetUp]
         public void SetUp()
         {
             _ledgerSessionScope = new HotReloadPlayModeEntryDropLedgerSessionScope();
-            HotReloadCompositionRoot.Services.Patcher.RevertAll();
+            _scope = new HotReloadDomainTestScope();
             HotReloadAutoRefreshHold.SyncToActiveChanges();
         }
 
@@ -39,7 +41,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         [TearDown]
         public void TearDown()
         {
-            HotReloadCompositionRoot.Services.Patcher.RevertAll();
+            _scope.Dispose();
             HotReloadAutoRefreshHold.SyncToActiveChanges();
             _ledgerSessionScope.Restore();
         }

--- a/Assets/Tests/Editor/HotReload/HotReloadPlayModeEntryDropStatusTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadPlayModeEntryDropStatusTests.cs
@@ -20,17 +20,19 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
     {
         private HotReloadPlayModeEntryDropLedgerSessionScope _ledgerSessionScope;
 
+        private HotReloadDomainTestScope _scope;
+
         [SetUp]
         public void SetUp()
         {
             _ledgerSessionScope = new HotReloadPlayModeEntryDropLedgerSessionScope();
-            HotReloadCompositionRoot.Services.Patcher.RevertAll();
+            _scope = new HotReloadDomainTestScope();
         }
 
         [TearDown]
         public void TearDown()
         {
-            HotReloadCompositionRoot.Services.Patcher.RevertAll();
+            _scope.Dispose();
             _ledgerSessionScope.Restore();
         }
 

--- a/Assets/Tests/Editor/HotReload/HotReloadServicesTestScope.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadServicesTestScope.cs
@@ -12,8 +12,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
     /// </summary>
     /// <remarks>
     /// Why one place: the collaborators a test replaces are constructor arguments now, so every
-    /// substitution builds a whole services graph. PR-8 replaces the body of these helpers with
-    /// the domain test scope without touching the tests that call them.
+    /// substitution builds a whole services graph. These helpers stay separate from
+    /// <see cref="HotReloadDomainTestScope"/>: they substitute one collaborator on the installed
+    /// graph, while the domain scope brings a whole graph of its own.
     /// </remarks>
     internal static class HotReloadServicesTestScope
     {

--- a/Assets/Tests/Editor/HotReload/HotReloadShimLookupTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadShimLookupTests.cs
@@ -24,10 +24,18 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         private const string FixtureProjectRelativePath =
             "Assets/Tests/Editor/HotReload/HotReloadE2EFixtures.cs";
 
+        private HotReloadDomainTestScope _scope;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _scope = new HotReloadDomainTestScope();
+        }
+
         [TearDown]
         public void TearDown()
         {
-            HotReloadCompositionRoot.Services.Patcher.RevertAll();
+            _scope.Dispose();
         }
 
         /// <summary>

--- a/Assets/Tests/Editor/HotReload/HotReloadSupersededSignatureRecorderTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadSupersededSignatureRecorderTests.cs
@@ -18,20 +18,21 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         private const string RemovedMethodLabel = "Sample.Host.Scaled(System.Int32)";
         private const string DecoyMethodLabel = "Sample.Host.Other(System.Int32)";
 
+        private HotReloadDomainTestScope _scope;
+
         [SetUp]
         public void SetUp()
         {
-            HotReloadDomainTestAccess access = new HotReloadDomainTestAccess();
-            access.ResetDomain();
+            _scope = new HotReloadDomainTestScope();
 
             // The recorder writes into the file's generation, so the generation must exist first.
-            access.GetOrBeginAddedMemberGeneration(FixtureProjectRelativePath);
+            new HotReloadDomainTestAccess().GetOrBeginAddedMemberGeneration(FixtureProjectRelativePath);
         }
 
         [TearDown]
         public void TearDown()
         {
-            new HotReloadDomainTestAccess().ResetDomain();
+            _scope.Dispose();
         }
 
         /// <summary>

--- a/Assets/Tests/Editor/HotReload/HotReloadToolTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadToolTests.cs
@@ -26,18 +26,20 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
         private HotReloadPlayModeEntryDropLedgerSessionScope _ledgerSessionScope;
 
+        private HotReloadDomainTestScope _scope;
+
         [SetUp]
         public void SetUp()
         {
             _ledgerSessionScope = new HotReloadPlayModeEntryDropLedgerSessionScope();
-            HotReloadCompositionRoot.Services.Patcher.RevertAll();
+            _scope = new HotReloadDomainTestScope();
             HotReloadAutoRefreshHold.SyncToActiveChanges();
         }
 
         [TearDown]
         public void TearDown()
         {
-            HotReloadCompositionRoot.Services.Patcher.RevertAll();
+            _scope.Dispose();
             HotReloadAutoRefreshHold.SyncToActiveChanges();
             _ledgerSessionScope.Restore();
         }
@@ -194,24 +196,17 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             const string filePath = "Assets/Tests/Editor/HotReload/StatusAddedReason.cs";
             const string methodKey = "Host.NewHelper(System.Int32)";
             RegisterAddedMemberForStatus(filePath, methodKey);
-            try
-            {
-                HotReloadResponse response = await ExecuteStatusAsync(CancellationToken.None);
-                HotReloadMethodResult addedRow = FindStatusRow(
-                    response,
-                    HotReloadConstants.AddedMemberStatusKind,
-                    methodKey);
+            HotReloadResponse response = await ExecuteStatusAsync(CancellationToken.None);
+            HotReloadMethodResult addedRow = FindStatusRow(
+                response,
+                HotReloadConstants.AddedMemberStatusKind,
+                methodKey);
 
-                Assert.That(
-                    addedRow.Reason,
-                    Is.EqualTo(
-                        "Added-member calls are not instrumented, so InvocationCount is always 0 for this row."));
-                Assert.That(addedRow.InvocationCount, Is.EqualTo(0L));
-            }
-            finally
-            {
-                new HotReloadDomainTestAccess().ClearAddedMembersAndFields();
-            }
+            Assert.That(
+                addedRow.Reason,
+                Is.EqualTo(
+                    "Added-member calls are not instrumented, so InvocationCount is always 0 for this row."));
+            Assert.That(addedRow.InvocationCount, Is.EqualTo(0L));
         }
 
         /// <summary>
@@ -433,7 +428,6 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             const string filePath = "Assets/Tests/Editor/HotReload/StatusAddedField.cs";
             const string methodKey = "Host.NewHelper(System.Int32)";
             HotReloadCompositionRoot.Services.Patcher.RevertAll();
-            new HotReloadDomainTestAccess().ClearAddedMembersAndFields();
             try
             {
                 ApplyCoreFixtureTransplant(
@@ -467,7 +461,6 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             finally
             {
                 HotReloadCompositionRoot.Services.Patcher.RevertAll();
-                new HotReloadDomainTestAccess().ClearAddedMembersAndFields();
             }
         }
 
@@ -1592,29 +1585,21 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         [Test]
         public void BuildApplyResponse_CopiesAddedFieldTotalFromLiveRegistry()
         {
-            new HotReloadDomainTestAccess().ClearAddedMembersAndFields();
-            try
-            {
-                new HotReloadDomainTestAccess().ReplaceAddedFields(
-                    "Assets/Tests/Editor/HotReload/ApplyAddedFieldTotal.cs",
-                    new[] { "Ns.Host.score" });
-                HotReloadResponse response = HotReloadTool.BuildApplyResponse(
-                    new HotReloadOrchestratorResult(
-                        new List<HotReloadMethodOutcome>
-                        {
-                            HotReloadMethodOutcome.Patched("Type.Method", "Assets/A.cs")
-                        },
-                        new List<string>(),
-                        patchedTotal: 1,
-                        activePatchTotal: 1));
+            new HotReloadDomainTestAccess().ReplaceAddedFields(
+                "Assets/Tests/Editor/HotReload/ApplyAddedFieldTotal.cs",
+                new[] { "Ns.Host.score" });
+            HotReloadResponse response = HotReloadTool.BuildApplyResponse(
+                new HotReloadOrchestratorResult(
+                    new List<HotReloadMethodOutcome>
+                    {
+                        HotReloadMethodOutcome.Patched("Type.Method", "Assets/A.cs")
+                    },
+                    new List<string>(),
+                    patchedTotal: 1,
+                    activePatchTotal: 1));
 
-                Assert.That(response.AddedFieldTotal, Is.EqualTo(1));
-                Assert.That(response.ActivePatchTotal, Is.EqualTo(1));
-            }
-            finally
-            {
-                new HotReloadDomainTestAccess().ClearAddedMembersAndFields();
-            }
+            Assert.That(response.AddedFieldTotal, Is.EqualTo(1));
+            Assert.That(response.ActivePatchTotal, Is.EqualTo(1));
         }
 
         /// <summary>

--- a/Assets/Tests/Editor/HotReload/HotReloadTransplantControlFlowTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadTransplantControlFlowTests.cs
@@ -17,10 +17,18 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
     /// </summary>
     public class HotReloadTransplantControlFlowTests
     {
+        private HotReloadDomainTestScope _scope;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _scope = new HotReloadDomainTestScope();
+        }
+
         [TearDown]
         public void TearDown()
         {
-            HotReloadCompositionRoot.Services.Patcher.RevertAll();
+            _scope.Dispose();
         }
 
         // Why NoInlining: repo convention for patch-target fixtures — without it the


### PR DESCRIPTION
## Summary
- No user-visible change: this is test-side isolation work in the hot-reload suite.
- Each hot-reload test now runs on a services graph of its own instead of sharing the one installed domain.

## User Impact
- None at runtime. The hot-reload tool, the CLI and the Unity package behave exactly as before.

## Changes
- New `HotReloadDomainTestScope`: installs a production services graph for one test (fresh domain), captures package roots, and on dispose reverts Harmony before putting the previous services back.
- The 21 classes that reverted the installed patcher in `SetUp` / `TearDown`, and the classes that cleared individual stores instead, now open the scope in `SetUp` and dispose it in `TearDown`.
- `HotReloadDomainTestAccess` loses `ResetDomain` and `ClearAddedMembersAndFields`; the scope owns that lifetime now, and the intra-test calls that stood in for a fixture are gone.
- `HotReloadServicesTestScope` is deliberately left on the installed graph: it substitutes one collaborator, and building a fresh graph there would put an enclosing substitution back to production. Its `remarks` now says so.

## Verification
- `uloop compile` — 0 errors.
- `uloop run-tests --filter-type regex --filter-value "HotReload"` — 1194/1194 passed.
- `uloop run-tests --filter-type regex --filter-value "PausePoint"` — 722/722 passed.
- Order dependence: `--filter-type class --filter-value HotReloadPatcherTests` alone — 19/19 passed; `HotReloadShimLookupTests` alone — 5/5 passed.
- `git grep -n "ForTesting\|ForTests" Packages/src/Editor/FirstPartyTools/HotReload` — only the three out-of-scope members (`OverrideServiceForTesting`, `ReconcileForTesting`, `ResetPendingForTesting`).
- `check-asmdef-policy` — no violations.
- `check-file-length.sh` at the repository threshold — exit 0; no touched file reaches 400 SLOC.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2737?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

