### PR TITLE
chore: Bind a hot-reload run to one set of collaborators

### DIFF
--- a/Assets/Tests/Editor/HotReload/HotReloadAssemblyResolutionDiagnosticsTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadAssemblyResolutionDiagnosticsTests.cs
@@ -180,6 +180,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             List<string> warnings = new List<string>();
 
             HotReloadPatchTargetResolution resolution = HotReloadPatchTargetSupport.ResolvePatchTarget(
+                HotReloadCompositionRoot.Services.Domain,
+                HotReloadCompositionRoot.Services.PackageRootCapture,
+                HotReloadCompositionRoot.Services.EditorStateSnapshotCapture,
                 MissingHotReloadScriptPath,
                 MissingHotReloadScriptPath,
                 outcomes,

--- a/Assets/Tests/Editor/HotReload/HotReloadCrossFileE2ETests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadCrossFileE2ETests.cs
@@ -944,7 +944,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         // can produce, so the reload reports the host's declaration as changed and stops.
         private static void ActivateStaleIntroducedTypeFor(string hostPath)
         {
-            string projectRelativePath = HotReloadPatchTargetSupport.ToProjectRelativeScriptPath(hostPath);
+            string projectRelativePath = HotReloadPatchTargetSupport.ToProjectRelativeScriptPath(
+                HotReloadCompositionRoot.Services.PackageRootCapture,
+                hostPath);
             string assemblyName = Path.GetFileNameWithoutExtension(
                 UnityEditor.Compilation.CompilationPipeline.GetAssemblyNameFromScriptPath(projectRelativePath));
             string artifactPath = WriteIntroducedTypeArtifact();

--- a/Assets/Tests/Editor/HotReload/HotReloadGroupProcessorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadGroupProcessorTests.cs
@@ -314,12 +314,18 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             // The resolver normalizes a package path, which the run entry point captures for.
             // This test calls the resolver directly, so it captures here instead.
             HotReloadCompositionRoot.Services.PackageRootCapture.CaptureCurrent();
-            HotReloadRunAccumulator run = new HotReloadRunAccumulator(autoRefreshHeldAtStart: false);
+            HotReloadRunAccumulator run = new HotReloadRunAccumulator(
+                HotReloadCompositionRoot.Services.Domain,
+                HotReloadCompositionRoot.Services.Patcher,
+                autoRefreshHeldAtStart: false);
             HotReloadInputResolutionSlot slot = new HotReloadInputResolutionSlot();
             List<(int InputIndex, string AssemblyName, string ProjectRelativePath)> plannerInput =
                 new List<(int InputIndex, string AssemblyName, string ProjectRelativePath)>();
 
-            new HotReloadInputFileResolver().ResolveInputFile(
+            new HotReloadInputFileResolver(
+                HotReloadCompositionRoot.Services.Domain,
+                HotReloadCompositionRoot.Services.PackageRootCapture,
+                HotReloadCompositionRoot.Services.EditorStateSnapshotCapture).ResolveInputFile(
                 MissingNewSourcePath,
                 0,
                 null,
@@ -360,6 +366,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 new HotReloadStubEditorStateSnapshotCapture(() => new HotReloadEditorStateSnapshot(false, false, true)));
 
             HotReloadGroupCompileResult result = await HotReloadShimFirstCompile.ResolveEntriesToPatchAsync(
+                HotReloadCompositionRoot.Services.GroupStageCollaborators,
                 context,
                 CreateEmptyGateResult(),
                 CancellationToken.None);
@@ -382,6 +389,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             SeedActiveAddedMember(file.ProjectRelativePath);
 
             HotReloadGroupCompileResult result = await HotReloadShimFirstCompile.ResolveEntriesToPatchAsync(
+                HotReloadCompositionRoot.Services.GroupStageCollaborators,
                 context,
                 CreateEmptyGateResult(),
                 CancellationToken.None);
@@ -501,6 +509,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             file.AddedFieldNames = null;
 
             HotReloadGroupCompileResult result = await HotReloadShimFirstCompile.ResolveEntriesToPatchAsync(
+                HotReloadCompositionRoot.Services.GroupStageCollaborators,
                 context,
                 CreateEmptyGateResult(),
                 CancellationToken.None);
@@ -523,6 +532,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             file.AddedFieldNames = new[] { "Sample.Host.retryField" };
 
             HotReloadGroupCompileResult result = await HotReloadShimFirstCompile.ResolveEntriesToPatchAsync(
+                HotReloadCompositionRoot.Services.GroupStageCollaborators,
                 context,
                 CreateEmptyGateResult(),
                 CancellationToken.None);
@@ -547,16 +557,17 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             file.FileOutput = null;
 
             IReadOnlyList<HotReloadFileProcessResult> results;
-            using (HotReloadServicesTestScope.BeginWithDependencies((transformWorkerClient, entryApplier) =>
+            using (HotReloadServicesTestScope.BeginWithDependencies(collaborators =>
                 HotReloadGroupProcessorDependencies.Create(
                     files => true,
                     (files, input, ct) => Task.FromResult(
                         HotReloadIntroducedTypePreparationResult.NoIntroducedTypes()),
                     (input, ct) => Task.FromResult(
                         TransformWorkerClientResult.Failure("transform worker failed")),
-                    HotReloadGroupProcessor.GateAndCompileAsync,
-                    HotReloadGroupEntryPreparation.PrepareGroup,
-                    entryApplier.ApplyPreparedEntries)))
+                    (context, ct) => HotReloadGroupProcessor.GateAndCompileAsync(collaborators, context, ct),
+                    (context, compileResult, entriesToPatch) => HotReloadGroupEntryPreparation.PrepareGroup(
+                        collaborators, context, compileResult, entriesToPatch),
+                    collaborators.EntryApplier.ApplyPreparedEntries)))
             {
                 results = await HotReloadCompositionRoot.Services.GroupProcessor.ProcessGroupAsync(
                     new[] { file },
@@ -620,6 +631,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             file.SkipApply = true;
 
             HotReloadGroupCompileResult result = await HotReloadShimFirstCompile.ResolveEntriesToPatchAsync(
+                HotReloadCompositionRoot.Services.GroupStageCollaborators,
                 context,
                 CreateEmptyGateResult(),
                 CancellationToken.None);
@@ -692,12 +704,13 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
             internal IDisposable Install()
             {
-                return HotReloadServicesTestScope.BeginWithDependencies((transformWorkerClient, entryApplier) =>
+                return HotReloadServicesTestScope.BeginWithDependencies(collaborators =>
                     HotReloadGroupProcessorDependencies.Create(
-                        HotReloadGroupProcessor.TryAppendNewSourceMembershipFailure,
-                        HotReloadIntroducedTypePreparation.PrepareAsync,
-                        transformWorkerClient.RunAsync,
-                        HotReloadGroupProcessor.GateAndCompileAsync,
+                        files => HotReloadGroupProcessor.TryAppendNewSourceMembershipFailure(collaborators, files),
+                        (files, input, ct) =>
+                            HotReloadIntroducedTypePreparation.PrepareAsync(collaborators, files, input, ct),
+                        collaborators.TransformWorkerClient.RunAsync,
+                        (context, ct) => HotReloadGroupProcessor.GateAndCompileAsync(collaborators, context, ct),
                         (context, compileResult, entriesToPatch) =>
                             Array.Empty<HotReloadPreparedGroupFile>(),
                         (context, compileResult, preparedFiles) =>
@@ -894,6 +907,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 "ScriptAssemblies",
                 AssemblyName + ".dll");
             string failure = HotReloadNewSourceMembershipValidator.TryCapture(
+                HotReloadCompositionRoot.Services.EditorStateSnapshotCapture,
                 projectRoot,
                 MissingNewSourcePath,
                 AssemblyName,

--- a/Assets/Tests/Editor/HotReload/HotReloadIntroducedTypeActivationTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadIntroducedTypeActivationTests.cs
@@ -159,7 +159,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         {
             string hostPath = FixturePath("HotReloadCrossFileAddedMemberHost.cs");
             string callerPath = FixturePath("HotReloadCrossFileAddedMemberCaller.cs");
-            string hostProjectRelativePath = HotReloadPatchTargetSupport.ToProjectRelativeScriptPath(hostPath);
+            string hostProjectRelativePath = HotReloadPatchTargetSupport.ToProjectRelativeScriptPath(
+                HotReloadCompositionRoot.Services.PackageRootCapture,
+                hostPath);
             TransformWorkerInputDto transformInput = null;
             TransformWorkerOutputDto transformOutput = null;
             HotReloadIntroducedTypeArtifact preparedArtifact = null;
@@ -167,27 +169,28 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
             using (HotReloadCompositionRoot.BeginReplacement(HotReloadCompositionRoot.CreateProductionServices()))
             {
-                using (HotReloadServicesTestScope.BeginWithDependencies((transformWorkerClient, entryApplier) =>
+                using (HotReloadServicesTestScope.BeginWithDependencies(collaborators =>
                     HotReloadGroupProcessorDependencies.Create(
-                        HotReloadGroupProcessor.TryAppendNewSourceMembershipFailure,
+                        files => HotReloadGroupProcessor.TryAppendNewSourceMembershipFailure(collaborators, files),
                         async (files, input, ct) =>
                         {
                             ownerAssemblyName = files[0].AssemblyName;
                             HotReloadIntroducedTypePreparationResult preparation =
-                                await HotReloadIntroducedTypePreparation.PrepareAsync(files, input, ct);
+                                await HotReloadIntroducedTypePreparation.PrepareAsync(collaborators, files, input, ct);
                             preparedArtifact = preparation.Prepared?.Artifact;
                             return preparation;
                         },
                         async (input, ct) =>
                         {
                             transformInput = input;
-                            TransformWorkerClientResult result = await transformWorkerClient.RunAsync(input, ct);
+                            TransformWorkerClientResult result = await collaborators.TransformWorkerClient.RunAsync(input, ct);
                             transformOutput = result.Output;
                             return result;
                         },
-                        HotReloadGroupProcessor.GateAndCompileAsync,
-                        HotReloadGroupEntryPreparation.PrepareGroup,
-                        entryApplier.ApplyPreparedEntries)))
+                        (context, ct) => HotReloadGroupProcessor.GateAndCompileAsync(collaborators, context, ct),
+                        (context, compileResult, entriesToPatch) => HotReloadGroupEntryPreparation.PrepareGroup(
+                            collaborators, context, compileResult, entriesToPatch),
+                        collaborators.EntryApplier.ApplyPreparedEntries)))
                 {
                     HotReloadOrchestratorResult result = await HotReloadCompositionRoot.Services.Orchestrator.RunAsync(
                         new[] { hostPath, callerPath },
@@ -238,18 +241,20 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                     "0000000000000000000000000000000000000000");
                 HotReloadCompositionRoot.Services.Domain.IntroducedTypes.RegisterPrepared(staleArtifact);
                 HotReloadCompositionRoot.Services.Domain.IntroducedTypes.Activate(staleArtifact);
-                using (HotReloadServicesTestScope.BeginWithDependencies((transformWorkerClient, entryApplier) =>
+                using (HotReloadServicesTestScope.BeginWithDependencies(collaborators =>
                     HotReloadGroupProcessorDependencies.Create(
-                        HotReloadGroupProcessor.TryAppendNewSourceMembershipFailure,
-                        HotReloadIntroducedTypePreparation.PrepareAsync,
+                        files => HotReloadGroupProcessor.TryAppendNewSourceMembershipFailure(collaborators, files),
+                        (files, input, ct) =>
+                            HotReloadIntroducedTypePreparation.PrepareAsync(collaborators, files, input, ct),
                         (input, ct) =>
                         {
                             transformInput = input;
-                            return transformWorkerClient.RunAsync(input, ct);
+                            return collaborators.TransformWorkerClient.RunAsync(input, ct);
                         },
-                        HotReloadGroupProcessor.GateAndCompileAsync,
-                        HotReloadGroupEntryPreparation.PrepareGroup,
-                        entryApplier.ApplyPreparedEntries)))
+                        (context, ct) => HotReloadGroupProcessor.GateAndCompileAsync(collaborators, context, ct),
+                        (context, compileResult, entriesToPatch) => HotReloadGroupEntryPreparation.PrepareGroup(
+                            collaborators, context, compileResult, entriesToPatch),
+                        collaborators.EntryApplier.ApplyPreparedEntries)))
                 {
                     await HotReloadCompositionRoot.Services.Orchestrator.RunAsync(
                         new[] { callerPath },
@@ -284,8 +289,10 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
             using (HotReloadCompositionRoot.BeginReplacement(HotReloadCompositionRoot.CreateProductionServices()))
             {
-                using (HotReloadServicesTestScope.BeginWithDependencies((transformWorkerClient, entryApplier) =>
-                    CreateArtifactCapturingDependencies(artifact => preparedArtifact = artifact)))
+                using (HotReloadServicesTestScope.BeginWithDependencies(collaborators =>
+                    CreateArtifactCapturingDependencies(
+                        collaborators,
+                        artifact => preparedArtifact = artifact)))
                 {
                     HotReloadOrchestratorResult result = await HotReloadCompositionRoot.Services.Orchestrator.RunAsync(
                         new[] { hostPath, callerPath },
@@ -331,8 +338,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
             using (HotReloadCompositionRoot.BeginReplacement(HotReloadCompositionRoot.CreateProductionServices()))
             {
-                using (HotReloadServicesTestScope.BeginWithDependencies((transformWorkerClient, entryApplier) =>
+                using (HotReloadServicesTestScope.BeginWithDependencies(collaborators =>
                     CreatePreparationCountingDependencies(
+                        collaborators,
                         preparedDescriptorCounts,
                         artifact =>
                         {
@@ -363,7 +371,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                         "A reload that declares an already introduced type must not fail.");
                     AssertCallerIsPatched(second);
 
-                    HotReloadResponse response = HotReloadApplyResponseBuilder.Build(second, null);
+                    HotReloadResponse response = HotReloadApplyResponseBuilder.Build(HotReloadCompositionRoot.Services, second, null);
                     Assert.That(
                         response.IntroducedTypes.Count,
                         Is.EqualTo(1),
@@ -412,8 +420,10 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
             using (HotReloadCompositionRoot.BeginReplacement(HotReloadCompositionRoot.CreateProductionServices()))
             {
-                using (HotReloadServicesTestScope.BeginWithDependencies((transformWorkerClient, entryApplier) =>
-                    CreateArtifactCapturingDependencies(artifact =>
+                using (HotReloadServicesTestScope.BeginWithDependencies(collaborators =>
+                    CreateArtifactCapturingDependencies(
+                        collaborators,
+                        artifact =>
                     {
                         if (artifact != null)
                         {
@@ -481,8 +491,10 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
             using (HotReloadCompositionRoot.BeginReplacement(HotReloadCompositionRoot.CreateProductionServices()))
             {
-                using (HotReloadServicesTestScope.BeginWithDependencies((transformWorkerClient, entryApplier) =>
-                    CreateDependenciesWithFailedResolutionFor(Path.GetFileName(callerPath))))
+                using (HotReloadServicesTestScope.BeginWithDependencies(collaborators =>
+                    CreateDependenciesWithFailedResolutionFor(
+                        collaborators,
+                        Path.GetFileName(callerPath))))
                 {
                     HotReloadOrchestratorResult result = await HotReloadCompositionRoot.Services.Orchestrator.RunAsync(
                         new[] { hostPath, callerPath },
@@ -509,8 +521,10 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
             using (HotReloadCompositionRoot.BeginReplacement(HotReloadCompositionRoot.CreateProductionServices()))
             {
-                using (HotReloadServicesTestScope.BeginWithDependencies((transformWorkerClient, entryApplier) =>
-                    CreateArtifactCapturingDependencies(artifact => preparedArtifact = artifact)))
+                using (HotReloadServicesTestScope.BeginWithDependencies(collaborators =>
+                    CreateArtifactCapturingDependencies(
+                        collaborators,
+                        artifact => preparedArtifact = artifact)))
                 {
                     result = await HotReloadCompositionRoot.Services.Orchestrator.RunAsync(
                         new[] { hostPath },
@@ -560,9 +574,11 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                     CancellationToken.None);
             }
 
-            HotReloadResponse response = HotReloadApplyResponseBuilder.Build(result, null);
+            HotReloadResponse response = HotReloadApplyResponseBuilder.Build(HotReloadCompositionRoot.Services, result, null);
             Assert.That(response.Success, Is.False, "A refused declaration must fail the run.");
-            string ownerProjectRelativePath = HotReloadPatchTargetSupport.ToProjectRelativeScriptPath(hostPath);
+            string ownerProjectRelativePath = HotReloadPatchTargetSupport.ToProjectRelativeScriptPath(
+                HotReloadCompositionRoot.Services.PackageRootCapture,
+                hostPath);
             List<HotReloadIntroducedTypeResult> failedRows = new List<HotReloadIntroducedTypeResult>();
             foreach (HotReloadIntroducedTypeResult row in response.IntroducedTypes)
             {
@@ -755,8 +771,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 using (HotReloadServicesTestScope.BeginWith(
                     editorState,
                     TransformWorkerHost.Shared,
-                    (transformWorkerClient, entryApplier) =>
+                    collaborators =>
                         CreateDependenciesWithAfterGateAction(
+                            collaborators,
                             () => editorState.Capture =
                                 () => new HotReloadEditorStateSnapshot(true, false, false))))
                 {
@@ -784,8 +801,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
             using (HotReloadCompositionRoot.BeginReplacement(HotReloadCompositionRoot.CreateProductionServices()))
             {
-                using (HotReloadServicesTestScope.BeginWithDependencies((transformWorkerClient, entryApplier) =>
-                    CreateDependenciesWithRebuiltTargetAfterWorker()))
+                using (HotReloadServicesTestScope.BeginWithDependencies(collaborators =>
+                    CreateDependenciesWithRebuiltTargetAfterWorker(collaborators)))
                 {
                     HotReloadOrchestratorResult result = await HotReloadCompositionRoot.Services.Orchestrator.RunAsync(
                         new[] { hostPath, callerPath },
@@ -813,8 +830,10 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
             using (HotReloadCompositionRoot.BeginReplacement(HotReloadCompositionRoot.CreateProductionServices()))
             {
-                using (HotReloadServicesTestScope.BeginWithDependencies((transformWorkerClient, entryApplier) =>
-                    CreateDependenciesWithBeforeWorkerAction(() => AppendMarkerComment(edits[hostPath]))))
+                using (HotReloadServicesTestScope.BeginWithDependencies(collaborators =>
+                    CreateDependenciesWithBeforeWorkerAction(
+                        collaborators,
+                        () => AppendMarkerComment(edits[hostPath]))))
                 {
                     result = await HotReloadCompositionRoot.Services.Orchestrator.RunAsync(
                         new[] { hostPath, callerPath },
@@ -840,8 +859,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
             using (HotReloadCompositionRoot.BeginReplacement(HotReloadCompositionRoot.CreateProductionServices()))
             {
-                using (HotReloadServicesTestScope.BeginWithDependencies((transformWorkerClient, entryApplier) =>
-                    CreateDependenciesWithUnverifiableOwner()))
+                using (HotReloadServicesTestScope.BeginWithDependencies(collaborators =>
+                    CreateDependenciesWithUnverifiableOwner(collaborators)))
                 {
                     HotReloadOrchestratorResult result = await HotReloadCompositionRoot.Services.Orchestrator.RunAsync(
                         new[] { hostPath, callerPath },
@@ -867,8 +886,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
             using (HotReloadCompositionRoot.BeginReplacement(HotReloadCompositionRoot.CreateProductionServices()))
             {
-                using (HotReloadServicesTestScope.BeginWithDependencies((transformWorkerClient, entryApplier) =>
-                    CreateDependenciesWithBlankedHashFor(Path.GetFileName(callerPath))))
+                using (HotReloadServicesTestScope.BeginWithDependencies(collaborators =>
+                    CreateDependenciesWithBlankedHashFor(collaborators, Path.GetFileName(callerPath))))
                 {
                     HotReloadOrchestratorResult result = await HotReloadCompositionRoot.Services.Orchestrator.RunAsync(
                         new[] { hostPath, callerPath },
@@ -895,8 +914,10 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
             using (HotReloadCompositionRoot.BeginReplacement(HotReloadCompositionRoot.CreateProductionServices()))
             {
-                using (HotReloadServicesTestScope.BeginWithDependencies((transformWorkerClient, entryApplier) =>
-                    CreateDependenciesWithAfterGateAction(() => AppendMarkerComment(edits[callerPath]))))
+                using (HotReloadServicesTestScope.BeginWithDependencies(collaborators =>
+                    CreateDependenciesWithAfterGateAction(
+                        collaborators,
+                        () => AppendMarkerComment(edits[callerPath]))))
                 {
                     result = await HotReloadCompositionRoot.Services.Orchestrator.RunAsync(
                         new[] { hostPath, callerPath },
@@ -1012,15 +1033,16 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         // Records how many introduced-type descriptors each run of a scope prepared, which is how
         // a run that reuses an already active type is told from one that introduces it again.
         private static HotReloadGroupProcessorDependencies CreatePreparationCountingDependencies(
+            HotReloadGroupStageCollaborators collaborators,
             List<int> preparedDescriptorCounts,
             Action<HotReloadIntroducedTypeArtifact> captureArtifact)
         {
             return HotReloadGroupProcessorDependencies.Create(
-                HotReloadGroupProcessor.TryAppendNewSourceMembershipFailure,
+                files => HotReloadGroupProcessor.TryAppendNewSourceMembershipFailure(collaborators, files),
                 async (files, input, ct) =>
                 {
                     HotReloadIntroducedTypePreparationResult preparation =
-                        await HotReloadIntroducedTypePreparation.PrepareAsync(files, input, ct);
+                        await HotReloadIntroducedTypePreparation.PrepareAsync(collaborators, files, input, ct);
                     HotReloadIntroducedTypeArtifact artifact = preparation.Prepared?.Artifact;
                     preparedDescriptorCounts.Add(artifact == null ? 0 : artifact.Descriptors.Count);
                     if (artifact != null)
@@ -1031,64 +1053,73 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                     return preparation;
                 },
                 HotReloadCompositionRoot.Services.TransformWorkerClient.RunAsync,
-                HotReloadGroupProcessor.GateAndCompileAsync,
-                HotReloadGroupEntryPreparation.PrepareGroup,
+                (context, ct) => HotReloadGroupProcessor.GateAndCompileAsync(collaborators, context, ct),
+                (context, compileResult, entriesToPatch) => HotReloadGroupEntryPreparation.PrepareGroup(
+                    collaborators, context, compileResult, entriesToPatch),
                 HotReloadCompositionRoot.Services.EntryApplier.ApplyPreparedEntries);
         }
 
         private static HotReloadGroupProcessorDependencies CreateArtifactCapturingDependencies(
+            HotReloadGroupStageCollaborators collaborators,
             Action<HotReloadIntroducedTypeArtifact> captureArtifact)
         {
             return HotReloadGroupProcessorDependencies.Create(
-                HotReloadGroupProcessor.TryAppendNewSourceMembershipFailure,
+                files => HotReloadGroupProcessor.TryAppendNewSourceMembershipFailure(collaborators, files),
                 async (files, input, ct) =>
                 {
                     HotReloadIntroducedTypePreparationResult preparation =
-                        await HotReloadIntroducedTypePreparation.PrepareAsync(files, input, ct);
+                        await HotReloadIntroducedTypePreparation.PrepareAsync(collaborators, files, input, ct);
                     captureArtifact(preparation.Prepared?.Artifact);
                     return preparation;
                 },
                 HotReloadCompositionRoot.Services.TransformWorkerClient.RunAsync,
-                HotReloadGroupProcessor.GateAndCompileAsync,
-                HotReloadGroupEntryPreparation.PrepareGroup,
+                (context, ct) => HotReloadGroupProcessor.GateAndCompileAsync(collaborators, context, ct),
+                (context, compileResult, entriesToPatch) => HotReloadGroupEntryPreparation.PrepareGroup(
+                    collaborators, context, compileResult, entriesToPatch),
                 HotReloadCompositionRoot.Services.EntryApplier.ApplyPreparedEntries);
         }
 
         // The window between the preparation run and the transform run, which is where an owner
         // rewrite makes the prepared artifact stale.
         private static HotReloadGroupProcessorDependencies CreateDependenciesWithBeforeWorkerAction(
+            HotReloadGroupStageCollaborators collaborators,
             Action beforeWorker)
         {
             return HotReloadGroupProcessorDependencies.Create(
-                HotReloadGroupProcessor.TryAppendNewSourceMembershipFailure,
-                HotReloadIntroducedTypePreparation.PrepareAsync,
+                files => HotReloadGroupProcessor.TryAppendNewSourceMembershipFailure(collaborators, files),
+                (files, input, ct) =>
+                    HotReloadIntroducedTypePreparation.PrepareAsync(collaborators, files, input, ct),
                 (input, ct) =>
                 {
                     beforeWorker();
                     return HotReloadCompositionRoot.Services.TransformWorkerClient.RunAsync(input, ct);
                 },
-                HotReloadGroupProcessor.GateAndCompileAsync,
-                HotReloadGroupEntryPreparation.PrepareGroup,
+                (context, ct) => HotReloadGroupProcessor.GateAndCompileAsync(collaborators, context, ct),
+                (context, compileResult, entriesToPatch) => HotReloadGroupEntryPreparation.PrepareGroup(
+                    collaborators, context, compileResult, entriesToPatch),
                 HotReloadCompositionRoot.Services.EntryApplier.ApplyPreparedEntries);
         }
 
         // The window between the shim compile and the commit boundary, which is the last instant
         // an external change can invalidate a run that has mutated nothing yet.
         private static HotReloadGroupProcessorDependencies CreateDependenciesWithAfterGateAction(
+            HotReloadGroupStageCollaborators collaborators,
             Action afterGate)
         {
             return HotReloadGroupProcessorDependencies.Create(
-                HotReloadGroupProcessor.TryAppendNewSourceMembershipFailure,
-                HotReloadIntroducedTypePreparation.PrepareAsync,
+                files => HotReloadGroupProcessor.TryAppendNewSourceMembershipFailure(collaborators, files),
+                (files, input, ct) =>
+                    HotReloadIntroducedTypePreparation.PrepareAsync(collaborators, files, input, ct),
                 HotReloadCompositionRoot.Services.TransformWorkerClient.RunAsync,
                 async (context, ct) =>
                 {
                     HotReloadGroupGateAndCompileResult gateAndCompile =
-                        await HotReloadGroupProcessor.GateAndCompileAsync(context, ct);
+                        await HotReloadGroupProcessor.GateAndCompileAsync(collaborators, context, ct);
                     afterGate();
                     return gateAndCompile;
                 },
-                HotReloadGroupEntryPreparation.PrepareGroup,
+                (context, compileResult, entriesToPatch) => HotReloadGroupEntryPreparation.PrepareGroup(
+                    collaborators, context, compileResult, entriesToPatch),
                 HotReloadCompositionRoot.Services.EntryApplier.ApplyPreparedEntries);
         }
 
@@ -1100,17 +1131,20 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         // and what is under test is that the commit point is not reached, not how resolution
         // decides a file has failed.
         private static HotReloadGroupProcessorDependencies CreateDependenciesWithFailedResolutionFor(
+            HotReloadGroupStageCollaborators collaborators,
             string failingFileName)
         {
             return HotReloadGroupProcessorDependencies.Create(
-                HotReloadGroupProcessor.TryAppendNewSourceMembershipFailure,
-                HotReloadIntroducedTypePreparation.PrepareAsync,
+                files => HotReloadGroupProcessor.TryAppendNewSourceMembershipFailure(collaborators, files),
+                (files, input, ct) =>
+                    HotReloadIntroducedTypePreparation.PrepareAsync(collaborators, files, input, ct),
                 HotReloadCompositionRoot.Services.TransformWorkerClient.RunAsync,
-                HotReloadGroupProcessor.GateAndCompileAsync,
+                (context, ct) => HotReloadGroupProcessor.GateAndCompileAsync(collaborators, context, ct),
                 (context, compileResult, entriesToPatch) =>
                 {
                     IReadOnlyList<HotReloadPreparedGroupFile> prepared =
-                        HotReloadGroupEntryPreparation.PrepareGroup(context, compileResult, entriesToPatch);
+                        HotReloadGroupEntryPreparation.PrepareGroup(
+                            collaborators, context, compileResult, entriesToPatch);
                     List<HotReloadPreparedGroupFile> replaced =
                         new List<HotReloadPreparedGroupFile>(prepared.Count);
                     bool failedOne = false;
@@ -1162,11 +1196,13 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         // could take the Editor down. The check under test compares the two, so making them
         // differ from this side observes the same condition. The change is made after the worker
         // has run, so nothing the worker decided is affected by it.
-        private static HotReloadGroupProcessorDependencies CreateDependenciesWithRebuiltTargetAfterWorker()
+        private static HotReloadGroupProcessorDependencies CreateDependenciesWithRebuiltTargetAfterWorker(
+            HotReloadGroupStageCollaborators collaborators)
         {
             return HotReloadGroupProcessorDependencies.Create(
-                HotReloadGroupProcessor.TryAppendNewSourceMembershipFailure,
-                HotReloadIntroducedTypePreparation.PrepareAsync,
+                files => HotReloadGroupProcessor.TryAppendNewSourceMembershipFailure(collaborators, files),
+                (files, input, ct) =>
+                    HotReloadIntroducedTypePreparation.PrepareAsync(collaborators, files, input, ct),
                 async (input, ct) =>
                 {
                     TransformWorkerClientResult workerResult =
@@ -1174,21 +1210,23 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                     input.targetAssemblyMvid = Guid.NewGuid().ToString("N");
                     return workerResult;
                 },
-                HotReloadGroupProcessor.GateAndCompileAsync,
-                HotReloadGroupEntryPreparation.PrepareGroup,
+                (context, ct) => HotReloadGroupProcessor.GateAndCompileAsync(collaborators, context, ct),
+                (context, compileResult, entriesToPatch) => HotReloadGroupEntryPreparation.PrepareGroup(
+                    collaborators, context, compileResult, entriesToPatch),
                 HotReloadCompositionRoot.Services.EntryApplier.ApplyPreparedEntries);
         }
 
         // An artifact whose owner hash is keyed by a path the transform run reported no row for,
         // which is the shape the boundary cannot compare its two windows across.
-        private static HotReloadGroupProcessorDependencies CreateDependenciesWithUnverifiableOwner()
+        private static HotReloadGroupProcessorDependencies CreateDependenciesWithUnverifiableOwner(
+            HotReloadGroupStageCollaborators collaborators)
         {
             return HotReloadGroupProcessorDependencies.Create(
-                HotReloadGroupProcessor.TryAppendNewSourceMembershipFailure,
+                files => HotReloadGroupProcessor.TryAppendNewSourceMembershipFailure(collaborators, files),
                 async (files, input, ct) =>
                 {
                     HotReloadIntroducedTypePreparationResult preparation =
-                        await HotReloadIntroducedTypePreparation.PrepareAsync(files, input, ct);
+                        await HotReloadIntroducedTypePreparation.PrepareAsync(collaborators, files, input, ct);
                     if (preparation.Prepared == null)
                     {
                         return preparation;
@@ -1200,8 +1238,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                             RekeyOwnerHashesToUnreportedPaths(preparation.Prepared.OwnerSourceHashes)));
                 },
                 HotReloadCompositionRoot.Services.TransformWorkerClient.RunAsync,
-                HotReloadGroupProcessor.GateAndCompileAsync,
-                HotReloadGroupEntryPreparation.PrepareGroup,
+                (context, ct) => HotReloadGroupProcessor.GateAndCompileAsync(collaborators, context, ct),
+                (context, compileResult, entriesToPatch) => HotReloadGroupEntryPreparation.PrepareGroup(
+                    collaborators, context, compileResult, entriesToPatch),
                 HotReloadCompositionRoot.Services.EntryApplier.ApplyPreparedEntries);
         }
 
@@ -1220,11 +1259,13 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         // A worker output row that carries no source hash, which is what the transform client's
         // own coalescing leaves behind when the worker omits the field.
         private static HotReloadGroupProcessorDependencies CreateDependenciesWithBlankedHashFor(
+            HotReloadGroupStageCollaborators collaborators,
             string fileName)
         {
             return HotReloadGroupProcessorDependencies.Create(
-                HotReloadGroupProcessor.TryAppendNewSourceMembershipFailure,
-                HotReloadIntroducedTypePreparation.PrepareAsync,
+                files => HotReloadGroupProcessor.TryAppendNewSourceMembershipFailure(collaborators, files),
+                (files, input, ct) =>
+                    HotReloadIntroducedTypePreparation.PrepareAsync(collaborators, files, input, ct),
                 async (input, ct) =>
                 {
                     TransformWorkerClientResult workerResult =
@@ -1232,8 +1273,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                     BlankSourceHashOf(workerResult.Output, fileName);
                     return workerResult;
                 },
-                HotReloadGroupProcessor.GateAndCompileAsync,
-                HotReloadGroupEntryPreparation.PrepareGroup,
+                (context, ct) => HotReloadGroupProcessor.GateAndCompileAsync(collaborators, context, ct),
+                (context, compileResult, entriesToPatch) => HotReloadGroupEntryPreparation.PrepareGroup(
+                    collaborators, context, compileResult, entriesToPatch),
                 HotReloadCompositionRoot.Services.EntryApplier.ApplyPreparedEntries);
         }
 
@@ -1293,8 +1335,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
             using (HotReloadCompositionRoot.BeginReplacement(HotReloadCompositionRoot.CreateProductionServices()))
             {
-                using (HotReloadServicesTestScope.BeginWithDependencies((transformWorkerClient, entryApplier) =>
-                    CreateRecordingDependencies(stages)))
+                using (HotReloadServicesTestScope.BeginWithDependencies(collaborators =>
+                    CreateRecordingDependencies(collaborators, stages)))
                 {
                     HotReloadOrchestratorResult result = await HotReloadCompositionRoot.Services.Orchestrator.RunAsync(
                         new[] { hostPath, callerPath },
@@ -1340,8 +1382,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
             using (HotReloadCompositionRoot.BeginReplacement(HotReloadCompositionRoot.CreateProductionServices()))
             {
-                using (HotReloadServicesTestScope.BeginWithDependencies((transformWorkerClient, entryApplier) =>
-                    CreateFailingMembershipDependencies(stages)))
+                using (HotReloadServicesTestScope.BeginWithDependencies(collaborators =>
+                    CreateFailingMembershipDependencies(collaborators, stages)))
                 {
                     await HotReloadCompositionRoot.Services.Orchestrator.RunAsync(
                         new[] { hostPath, callerPath },
@@ -1380,8 +1422,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
             using (HotReloadCompositionRoot.BeginReplacement(HotReloadCompositionRoot.CreateProductionServices()))
             {
-                using (HotReloadServicesTestScope.BeginWithDependencies((transformWorkerClient, entryApplier) =>
-                    CreateFailingPreparationDependencies(stages)))
+                using (HotReloadServicesTestScope.BeginWithDependencies(collaborators =>
+                    CreateFailingPreparationDependencies(collaborators, stages)))
                 {
                     await HotReloadCompositionRoot.Services.Orchestrator.RunAsync(
                         new[] { hostPath, callerPath },
@@ -1428,18 +1470,20 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
         // Why every stage delegates to production: the order under test is the production order,
         // so a recording decorator must not stand in for any stage of it.
-        private static HotReloadGroupProcessorDependencies CreateRecordingDependencies(List<string> stages)
+        private static HotReloadGroupProcessorDependencies CreateRecordingDependencies(
+            HotReloadGroupStageCollaborators collaborators,
+            List<string> stages)
         {
             return HotReloadGroupProcessorDependencies.Create(
                 files =>
                 {
                     stages.Add(ValidateStage);
-                    return HotReloadGroupProcessor.TryAppendNewSourceMembershipFailure(files);
+                    return HotReloadGroupProcessor.TryAppendNewSourceMembershipFailure(collaborators, files);
                 },
                 (files, input, ct) =>
                 {
                     stages.Add(PrepareStage);
-                    return HotReloadIntroducedTypePreparation.PrepareAsync(files, input, ct);
+                    return HotReloadIntroducedTypePreparation.PrepareAsync(collaborators, files, input, ct);
                 },
                 (input, ct) =>
                 {
@@ -1449,12 +1493,13 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 (context, ct) =>
                 {
                     stages.Add(GateStage);
-                    return HotReloadGroupProcessor.GateAndCompileAsync(context, ct);
+                    return HotReloadGroupProcessor.GateAndCompileAsync(collaborators, context, ct);
                 },
                 (context, compileResult, entriesToPatch) =>
                 {
                     stages.Add(PreflightStage);
-                    return HotReloadGroupEntryPreparation.PrepareGroup(context, compileResult, entriesToPatch);
+                    return HotReloadGroupEntryPreparation.PrepareGroup(
+                            collaborators, context, compileResult, entriesToPatch);
                 },
                 (context, compileResult, preparedFiles) =>
                 {
@@ -1466,7 +1511,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         // Why the failure is injected instead of provoked: a group whose sources left their
         // assembly cannot be produced from a compiled fixture, and the stage under test is
         // "nothing runs after the refusal", not how the refusal is decided.
-        private static HotReloadGroupProcessorDependencies CreateFailingMembershipDependencies(List<string> stages)
+        private static HotReloadGroupProcessorDependencies CreateFailingMembershipDependencies(
+            HotReloadGroupStageCollaborators collaborators,
+            List<string> stages)
         {
             return HotReloadGroupProcessorDependencies.Create(
                 files =>
@@ -1481,28 +1528,31 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 (files, input, ct) =>
                 {
                     stages.Add(PrepareStage);
-                    return HotReloadIntroducedTypePreparation.PrepareAsync(files, input, ct);
+                    return HotReloadIntroducedTypePreparation.PrepareAsync(collaborators, files, input, ct);
                 },
                 (input, ct) =>
                 {
                     stages.Add(WorkerStage);
                     return HotReloadCompositionRoot.Services.TransformWorkerClient.RunAsync(input, ct);
                 },
-                HotReloadGroupProcessor.GateAndCompileAsync,
-                HotReloadGroupEntryPreparation.PrepareGroup,
+                (context, ct) => HotReloadGroupProcessor.GateAndCompileAsync(collaborators, context, ct),
+                (context, compileResult, entriesToPatch) => HotReloadGroupEntryPreparation.PrepareGroup(
+                    collaborators, context, compileResult, entriesToPatch),
                 HotReloadCompositionRoot.Services.EntryApplier.ApplyPreparedEntries);
         }
 
         // Why the failure is injected: an artifact compile failure cannot be provoked from a
         // fixture the repository keeps compiling, and the stage under test is that the run stops
         // before the worker with every ledger untouched.
-        private static HotReloadGroupProcessorDependencies CreateFailingPreparationDependencies(List<string> stages)
+        private static HotReloadGroupProcessorDependencies CreateFailingPreparationDependencies(
+            HotReloadGroupStageCollaborators collaborators,
+            List<string> stages)
         {
             return HotReloadGroupProcessorDependencies.Create(
                 files =>
                 {
                     stages.Add(ValidateStage);
-                    return HotReloadGroupProcessor.TryAppendNewSourceMembershipFailure(files);
+                    return HotReloadGroupProcessor.TryAppendNewSourceMembershipFailure(collaborators, files);
                 },
                 (files, input, ct) =>
                 {
@@ -1523,8 +1573,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                     stages.Add(WorkerStage);
                     return HotReloadCompositionRoot.Services.TransformWorkerClient.RunAsync(input, ct);
                 },
-                HotReloadGroupProcessor.GateAndCompileAsync,
-                HotReloadGroupEntryPreparation.PrepareGroup,
+                (context, ct) => HotReloadGroupProcessor.GateAndCompileAsync(collaborators, context, ct),
+                (context, compileResult, entriesToPatch) => HotReloadGroupEntryPreparation.PrepareGroup(
+                    collaborators, context, compileResult, entriesToPatch),
                 HotReloadCompositionRoot.Services.EntryApplier.ApplyPreparedEntries);
         }
 
@@ -1553,7 +1604,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
         private static string ResolveAssemblyName(string scriptPath)
         {
-            string projectRelativePath = HotReloadPatchTargetSupport.ToProjectRelativeScriptPath(scriptPath);
+            string projectRelativePath = HotReloadPatchTargetSupport.ToProjectRelativeScriptPath(
+                HotReloadCompositionRoot.Services.PackageRootCapture,
+                scriptPath);
             return Path.GetFileNameWithoutExtension(
                 UnityEditor.Compilation.CompilationPipeline.GetAssemblyNameFromScriptPath(projectRelativePath));
         }

--- a/Assets/Tests/Editor/HotReload/HotReloadIntroducedTypeHoldTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadIntroducedTypeHoldTests.cs
@@ -144,6 +144,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             using (HotReloadCompositionRoot.BeginReplacement(HotReloadCompositionRoot.CreateProductionServices()))
             {
                 HotReloadRunAccumulator run = new HotReloadRunAccumulator(
+                    HotReloadCompositionRoot.Services.Domain,
+                    HotReloadCompositionRoot.Services.Patcher,
                     autoRefreshHeldAtStart: HotReloadAutoRefreshHold.IsHeld);
 
                 Assert.That(
@@ -184,6 +186,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                     "Arrange: the hold must already be armed when the run starts.");
 
                 HotReloadRunAccumulator run = new HotReloadRunAccumulator(
+                    HotReloadCompositionRoot.Services.Domain,
+                    HotReloadCompositionRoot.Services.Patcher,
                     autoRefreshHeldAtStart: HotReloadAutoRefreshHold.IsHeld);
 
                 HotReloadOrchestratorResult result = run.BuildResult("correlation-already-armed");

--- a/Assets/Tests/Editor/HotReload/HotReloadIntroducedTypeResponseTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadIntroducedTypeResponseTests.cs
@@ -151,8 +151,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         {
             using (HotReloadCompositionRoot.BeginReplacement(HotReloadCompositionRoot.CreateProductionServices()))
             {
-                using (HotReloadServicesTestScope.BeginWithDependencies((transformWorkerClient, entryApplier) =>
-                    CreateFailingApplyDependencies()))
+                using (HotReloadServicesTestScope.BeginWithDependencies(collaborators =>
+                    CreateFailingApplyDependencies(collaborators)))
                 {
                     HotReloadResponse response = await RunIntroducingATypeAndEditingABodyAsync();
 
@@ -183,8 +183,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         {
             using (HotReloadCompositionRoot.BeginReplacement(HotReloadCompositionRoot.CreateProductionServices()))
             {
-                using (HotReloadServicesTestScope.BeginWithDependencies((transformWorkerClient, entryApplier) =>
-                    CreateAlreadyActiveWithFailingApplyDependencies()))
+                using (HotReloadServicesTestScope.BeginWithDependencies(collaborators =>
+                    CreateAlreadyActiveWithFailingApplyDependencies(collaborators)))
                 {
                     HotReloadResponse response = await RunEditingOnlyABodyAsync();
 
@@ -214,8 +214,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         {
             using (HotReloadCompositionRoot.BeginReplacement(HotReloadCompositionRoot.CreateProductionServices()))
             {
-                using (HotReloadServicesTestScope.BeginWithDependencies((transformWorkerClient, entryApplier) =>
+                using (HotReloadServicesTestScope.BeginWithDependencies(collaborators =>
                     CreatePreparationDependencies(
+                        collaborators,
                         HotReloadIntroducedTypePreparationResult.TypeFailures(
                             new[] { CreateInjectedTypeFailure() }))))
                 {
@@ -238,8 +239,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         {
             using (HotReloadCompositionRoot.BeginReplacement(HotReloadCompositionRoot.CreateProductionServices()))
             {
-                using (HotReloadServicesTestScope.BeginWithDependencies((transformWorkerClient, entryApplier) =>
-                    CreateTypeFailingApplyDependencies(failTheMethod: true)))
+                using (HotReloadServicesTestScope.BeginWithDependencies(collaborators =>
+                    CreateTypeFailingApplyDependencies(collaborators, failTheMethod: true)))
                 {
                     HotReloadResponse response = await RunEditingOnlyABodyAsync();
 
@@ -260,8 +261,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         {
             using (HotReloadCompositionRoot.BeginReplacement(HotReloadCompositionRoot.CreateProductionServices()))
             {
-                using (HotReloadServicesTestScope.BeginWithDependencies((transformWorkerClient, entryApplier) =>
-                    CreateTypeFailingApplyDependencies(failTheMethod: false)))
+                using (HotReloadServicesTestScope.BeginWithDependencies(collaborators =>
+                    CreateTypeFailingApplyDependencies(collaborators, failTheMethod: false)))
                 {
                     HotReloadResponse response = await RunEditingOnlyABodyAsync();
 
@@ -320,7 +321,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                         "IntroducedTypeAbsentCaller.cs",
                         EditTheCallerBody(File.ReadAllText(callerPath))),
                     CancellationToken.None);
-                HotReloadResponse response = HotReloadApplyResponseBuilder.Build(result, null);
+                HotReloadResponse response = HotReloadApplyResponseBuilder.Build(HotReloadCompositionRoot.Services, result, null);
 
                 Assert.That(
                     response.ShouldSerializeIntroducedTypes(),
@@ -344,7 +345,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                     "IntroducedTypeAndBodyHost.cs",
                     EditTheScaledBody(InsertIntroducedType(File.ReadAllText(hostPath)))),
                 CancellationToken.None);
-            return HotReloadApplyResponseBuilder.Build(result, null);
+            return HotReloadApplyResponseBuilder.Build(HotReloadCompositionRoot.Services, result, null);
         }
 
         private static HotReloadIntroducedTypeOutcome CreateInjectedTypeFailure()
@@ -360,14 +361,17 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         // own buffer, which is the carrier the response is built from, so the refusal reaches the
         // response beside whatever the methods did.
         private static HotReloadGroupProcessorDependencies CreateTypeFailingApplyDependencies(
+            HotReloadGroupStageCollaborators collaborators,
             bool failTheMethod)
         {
             return HotReloadGroupProcessorDependencies.Create(
-                HotReloadGroupProcessor.TryAppendNewSourceMembershipFailure,
-                HotReloadIntroducedTypePreparation.PrepareAsync,
+                files => HotReloadGroupProcessor.TryAppendNewSourceMembershipFailure(collaborators, files),
+                (files, input, ct) =>
+                    HotReloadIntroducedTypePreparation.PrepareAsync(collaborators, files, input, ct),
                 HotReloadCompositionRoot.Services.TransformWorkerClient.RunAsync,
-                HotReloadGroupProcessor.GateAndCompileAsync,
-                HotReloadGroupEntryPreparation.PrepareGroup,
+                (context, ct) => HotReloadGroupProcessor.GateAndCompileAsync(collaborators, context, ct),
+                (context, compileResult, entriesToPatch) => HotReloadGroupEntryPreparation.PrepareGroup(
+                    collaborators, context, compileResult, entriesToPatch),
                 (context, compile, preparedFiles) =>
                 {
                     foreach (HotReloadGroupFile file in context.Files)
@@ -401,15 +405,16 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                     "RetainedTypeOnlyCaller.cs",
                     EditTheCallerBody(File.ReadAllText(callerPath))),
                 CancellationToken.None);
-            return HotReloadApplyResponseBuilder.Build(result, null);
+            return HotReloadApplyResponseBuilder.Build(HotReloadCompositionRoot.Services, result, null);
         }
 
         // The production pipeline with the preparation reporting one retained declaration and the
         // apply stage failing, so the run carries a type row it did not activate itself.
-        private static HotReloadGroupProcessorDependencies CreateAlreadyActiveWithFailingApplyDependencies()
+        private static HotReloadGroupProcessorDependencies CreateAlreadyActiveWithFailingApplyDependencies(
+            HotReloadGroupStageCollaborators collaborators)
         {
             return HotReloadGroupProcessorDependencies.Create(
-                HotReloadGroupProcessor.TryAppendNewSourceMembershipFailure,
+                files => HotReloadGroupProcessor.TryAppendNewSourceMembershipFailure(collaborators, files),
                 (files, input, ct) => Task.FromResult(
                     HotReloadIntroducedTypePreparationResult.NoIntroducedTypes(
                         new[]
@@ -420,8 +425,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                                 files[0].ProjectRelativePath)
                         })),
                 HotReloadCompositionRoot.Services.TransformWorkerClient.RunAsync,
-                HotReloadGroupProcessor.GateAndCompileAsync,
-                HotReloadGroupEntryPreparation.PrepareGroup,
+                (context, ct) => HotReloadGroupProcessor.GateAndCompileAsync(collaborators, context, ct),
+                (context, compileResult, entriesToPatch) => HotReloadGroupEntryPreparation.PrepareGroup(
+                    collaborators, context, compileResult, entriesToPatch),
                 (context, compile, preparedFiles) =>
                 {
                     foreach (HotReloadGroupFile file in context.Files)
@@ -445,14 +451,17 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
         // The production pipeline with only the apply stage replaced, so the commit boundary runs
         // for real and the failure lands after the types became active.
-        private static HotReloadGroupProcessorDependencies CreateFailingApplyDependencies()
+        private static HotReloadGroupProcessorDependencies CreateFailingApplyDependencies(
+            HotReloadGroupStageCollaborators collaborators)
         {
             return HotReloadGroupProcessorDependencies.Create(
-                HotReloadGroupProcessor.TryAppendNewSourceMembershipFailure,
-                HotReloadIntroducedTypePreparation.PrepareAsync,
+                files => HotReloadGroupProcessor.TryAppendNewSourceMembershipFailure(collaborators, files),
+                (files, input, ct) =>
+                    HotReloadIntroducedTypePreparation.PrepareAsync(collaborators, files, input, ct),
                 HotReloadCompositionRoot.Services.TransformWorkerClient.RunAsync,
-                HotReloadGroupProcessor.GateAndCompileAsync,
-                HotReloadGroupEntryPreparation.PrepareGroup,
+                (context, ct) => HotReloadGroupProcessor.GateAndCompileAsync(collaborators, context, ct),
+                (context, compileResult, entriesToPatch) => HotReloadGroupEntryPreparation.PrepareGroup(
+                    collaborators, context, compileResult, entriesToPatch),
                 (context, compile, preparedFiles) =>
                 {
                     foreach (HotReloadGroupFile file in context.Files)
@@ -500,7 +509,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                         "IntroducedTypeNoticeHost.cs",
                         InsertUnintroducibleDeclaration(File.ReadAllText(hostPath))),
                     CancellationToken.None);
-                HotReloadResponse response = HotReloadApplyResponseBuilder.Build(result, null);
+                HotReloadResponse response = HotReloadApplyResponseBuilder.Build(HotReloadCompositionRoot.Services, result, null);
 
                 Assert.That(
                     response.Success,
@@ -555,8 +564,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         {
             using (HotReloadCompositionRoot.BeginReplacement(HotReloadCompositionRoot.CreateProductionServices()))
             {
-                using (HotReloadServicesTestScope.BeginWithDependencies((transformWorkerClient, entryApplier) =>
+                using (HotReloadServicesTestScope.BeginWithDependencies(collaborators =>
                     CreatePreparationDependencies(
+                        collaborators,
                         HotReloadIntroducedTypePreparationResult.TypeFailures(
                             new[]
                             {
@@ -598,8 +608,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         {
             using (HotReloadCompositionRoot.BeginReplacement(HotReloadCompositionRoot.CreateProductionServices()))
             {
-                using (HotReloadServicesTestScope.BeginWithDependencies((transformWorkerClient, entryApplier) =>
+                using (HotReloadServicesTestScope.BeginWithDependencies(collaborators =>
                     CreatePreparationDependencies(
+                        collaborators,
                         HotReloadIntroducedTypePreparationResult.TypeFailures(
                             new[]
                             {
@@ -648,8 +659,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         {
             using (HotReloadCompositionRoot.BeginReplacement(HotReloadCompositionRoot.CreateProductionServices()))
             {
-                using (HotReloadServicesTestScope.BeginWithDependencies((transformWorkerClient, entryApplier) =>
+                using (HotReloadServicesTestScope.BeginWithDependencies(collaborators =>
                     CreatePreparationDependencies(
+                        collaborators,
                         HotReloadIntroducedTypePreparationResult.WorkerFailure(InjectedWorkerFailureReason))))
                 {
                     HotReloadResponse response = await RunAgainstTheHostAsync();
@@ -670,14 +682,16 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         // The production pipeline with only the preparation stage replaced, which is the one stage
         // whose two failure kinds cannot both be provoked from a fixture the repository compiles.
         private static HotReloadGroupProcessorDependencies CreatePreparationDependencies(
+            HotReloadGroupStageCollaborators collaborators,
             HotReloadIntroducedTypePreparationResult preparationResult)
         {
             return HotReloadGroupProcessorDependencies.Create(
-                HotReloadGroupProcessor.TryAppendNewSourceMembershipFailure,
+                files => HotReloadGroupProcessor.TryAppendNewSourceMembershipFailure(collaborators, files),
                 (files, input, ct) => Task.FromResult(preparationResult),
                 HotReloadCompositionRoot.Services.TransformWorkerClient.RunAsync,
-                HotReloadGroupProcessor.GateAndCompileAsync,
-                HotReloadGroupEntryPreparation.PrepareGroup,
+                (context, ct) => HotReloadGroupProcessor.GateAndCompileAsync(collaborators, context, ct),
+                (context, compileResult, entriesToPatch) => HotReloadGroupEntryPreparation.PrepareGroup(
+                    collaborators, context, compileResult, entriesToPatch),
                 HotReloadCompositionRoot.Services.EntryApplier.ApplyPreparedEntries);
         }
 
@@ -690,7 +704,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                     "IntroducedTypeFailureHost.cs",
                     InsertIntroducedType(File.ReadAllText(hostPath))),
                 CancellationToken.None);
-            return HotReloadApplyResponseBuilder.Build(result, null);
+            return HotReloadApplyResponseBuilder.Build(HotReloadCompositionRoot.Services, result, null);
         }
 
         private static int CountTypeRows(HotReloadResponse response, string kind)
@@ -747,7 +761,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 FindFailureReason(result),
                 Is.Null,
                 "Precondition: a reload that only introduces a type must not fail a method.");
-            return HotReloadApplyResponseBuilder.Build(result, null);
+            return HotReloadApplyResponseBuilder.Build(HotReloadCompositionRoot.Services, result, null);
         }
 
         private static string FindFailureReason(HotReloadOrchestratorResult result)

--- a/Assets/Tests/Editor/HotReload/HotReloadNewSourceMembershipTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadNewSourceMembershipTests.cs
@@ -48,6 +48,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             List<string> warnings = new List<string>();
 
             HotReloadPatchTargetResolution resolution = HotReloadPatchTargetSupport.ResolvePatchTarget(
+                HotReloadCompositionRoot.Services.Domain,
+                HotReloadCompositionRoot.Services.PackageRootCapture,
+                HotReloadCompositionRoot.Services.EditorStateSnapshotCapture,
                 MissingHotReloadScriptPath,
                 MissingHotReloadScriptPath,
                 outcomes,
@@ -80,6 +83,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             List<string> warnings = new List<string>();
 
             HotReloadPatchTargetResolution resolution = HotReloadPatchTargetSupport.ResolvePatchTarget(
+                HotReloadCompositionRoot.Services.Domain,
+                HotReloadCompositionRoot.Services.PackageRootCapture,
+                HotReloadCompositionRoot.Services.EditorStateSnapshotCapture,
                 MissingHotReloadScriptPath,
                 MissingHotReloadScriptPath,
                 outcomes,
@@ -147,6 +153,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             using IDisposable editorStateScope = HotReloadServicesTestScope.BeginWithEditorState(
                 new HotReloadStubEditorStateSnapshotCapture(() => new HotReloadEditorStateSnapshot(false, false, false)));
             HotReloadPatchTargetSupport.ResolvePatchTarget(
+                HotReloadCompositionRoot.Services.Domain,
+                HotReloadCompositionRoot.Services.PackageRootCapture,
+                HotReloadCompositionRoot.Services.EditorStateSnapshotCapture,
                 ExistingScriptPath,
                 ExistingScriptPath,
                 new List<HotReloadMethodOutcome>(),
@@ -209,6 +218,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             List<string> warnings = new List<string>();
 
             HotReloadPatchTargetResolution resolution = HotReloadPatchTargetSupport.ResolvePatchTarget(
+                HotReloadCompositionRoot.Services.Domain,
+                HotReloadCompositionRoot.Services.PackageRootCapture,
+                HotReloadCompositionRoot.Services.EditorStateSnapshotCapture,
                 MissingPredefinedScriptPath,
                 MissingPredefinedScriptPath,
                 outcomes,

--- a/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
@@ -1988,18 +1988,20 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                     AssertHasPatched(first, nameof(HotReloadE2EFixture.ComputeWithPrivate));
 
                     ActivateIntroducedTypeForFixtureAssembly(fixturePath);
-                    using (HotReloadServicesTestScope.BeginWithDependencies((transformWorkerClient, entryApplier) =>
+                    using (HotReloadServicesTestScope.BeginWithDependencies(collaborators =>
                         HotReloadGroupProcessorDependencies.Create(
                             files =>
                             {
                                 membershipValidations++;
-                                return HotReloadGroupProcessor.TryAppendNewSourceMembershipFailure(files);
+                                return HotReloadGroupProcessor.TryAppendNewSourceMembershipFailure(collaborators, files);
                             },
-                            HotReloadIntroducedTypePreparation.PrepareAsync,
-                            transformWorkerClient.RunAsync,
-                            HotReloadGroupProcessor.GateAndCompileAsync,
-                            HotReloadGroupEntryPreparation.PrepareGroup,
-                            entryApplier.ApplyPreparedEntries)))
+                            (files, input, ct) =>
+                                HotReloadIntroducedTypePreparation.PrepareAsync(collaborators, files, input, ct),
+                            collaborators.TransformWorkerClient.RunAsync,
+                            (context, ct) => HotReloadGroupProcessor.GateAndCompileAsync(collaborators, context, ct),
+                            (context, compileResult, entriesToPatch) => HotReloadGroupEntryPreparation.PrepareGroup(
+                                collaborators, context, compileResult, entriesToPatch),
+                            collaborators.EntryApplier.ApplyPreparedEntries)))
                     {
                         await HotReloadCompositionRoot.Services.Orchestrator.RunAsync(
                             new[] { fixturePath },
@@ -2024,7 +2026,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
         private static void ActivateIntroducedTypeForFixtureAssembly(string fixturePath)
         {
-            string projectRelativePath = HotReloadPatchTargetSupport.ToProjectRelativeScriptPath(fixturePath);
+            string projectRelativePath = HotReloadPatchTargetSupport.ToProjectRelativeScriptPath(
+                HotReloadCompositionRoot.Services.PackageRootCapture,
+                fixturePath);
             string assemblyName = Path.GetFileNameWithoutExtension(
                 UnityEditor.Compilation.CompilationPipeline.GetAssemblyNameFromScriptPath(projectRelativePath));
             HotReloadIntroducedTypeDescriptor descriptor = new HotReloadIntroducedTypeDescriptor(
@@ -3060,6 +3064,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 Assert.That(context.Files[0].Sinks.AppliedEntries, Is.EqualTo(new[] { patchedEntry }));
 
                 HotReloadSupersededSignatureRecorder.RecordFromAppliedEntries(
+                HotReloadCompositionRoot.Services.Domain,
                     projectRelativePath,
                     context.Files[0].Sinks.AppliedEntries,
                     context.Files[0].FileOutput.removedMethodSignatures,
@@ -3160,7 +3165,11 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             return HotReloadCompositionRoot.Services.EntryApplier.ApplyPreparedEntries(
                 context,
                 compileResult,
-                HotReloadGroupEntryPreparation.PrepareGroup(context, compileResult, entriesToPatch));
+                HotReloadGroupEntryPreparation.PrepareGroup(
+                    HotReloadCompositionRoot.Services.GroupStageCollaborators,
+                    context,
+                    compileResult,
+                    entriesToPatch));
         }
 
         private static HotReloadApplyContext CreateApplyContext(

--- a/Assets/Tests/Editor/HotReload/HotReloadPatchTargetSupportPathTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadPatchTargetSupportPathTests.cs
@@ -40,7 +40,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         public void ToProjectRelativeScriptPath_WhenEmbeddedPackagePhysicalPath_ReturnsLogicalPackagePath()
         {
             // Verifies the physical folder of an embedded package is mapped back to its virtual package path.
-            string relative = HotReloadPatchTargetSupport.ToProjectRelativeScriptPath(EmbeddedPhysicalPath);
+            string relative = HotReloadPatchTargetSupport.ToProjectRelativeScriptPath(
+                HotReloadCompositionRoot.Services.PackageRootCapture,
+                EmbeddedPhysicalPath);
 
             Assert.That(relative, Is.EqualTo(EmbeddedLogicalPath));
         }
@@ -49,7 +51,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         public void ToProjectRelativeScriptPath_WhenEmbeddedPackageLogicalPath_ReturnsItUnchanged()
         {
             // Verifies a logical package path survives normalization instead of collapsing to the physical folder.
-            string relative = HotReloadPatchTargetSupport.ToProjectRelativeScriptPath(EmbeddedLogicalPath);
+            string relative = HotReloadPatchTargetSupport.ToProjectRelativeScriptPath(
+                HotReloadCompositionRoot.Services.PackageRootCapture,
+                EmbeddedLogicalPath);
 
             Assert.That(relative, Is.EqualTo(EmbeddedLogicalPath));
         }
@@ -58,7 +62,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         public void ToProjectRelativeScriptPath_WhenGitPackageLogicalPath_ReturnsItUnchanged()
         {
             // Verifies a git package path is not rewritten into its Library/PackageCache location.
-            string relative = HotReloadPatchTargetSupport.ToProjectRelativeScriptPath(GitPackageLogicalPath);
+            string relative = HotReloadPatchTargetSupport.ToProjectRelativeScriptPath(
+                HotReloadCompositionRoot.Services.PackageRootCapture,
+                GitPackageLogicalPath);
 
             Assert.That(relative, Is.EqualTo(GitPackageLogicalPath));
         }
@@ -67,7 +73,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         public void ToProjectRelativeScriptPath_WhenAssetsRelativePath_ReturnsItUnchanged()
         {
             // Verifies an already project-relative Assets path is left alone.
-            string relative = HotReloadPatchTargetSupport.ToProjectRelativeScriptPath(AssetsScriptPath);
+            string relative = HotReloadPatchTargetSupport.ToProjectRelativeScriptPath(
+                HotReloadCompositionRoot.Services.PackageRootCapture,
+                AssetsScriptPath);
 
             Assert.That(relative, Is.EqualTo(AssetsScriptPath));
         }
@@ -78,7 +86,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             // Verifies an absolute path under Assets becomes project-relative.
             string absolutePath = Path.Combine(Application.dataPath, "Tests/Editor/HotReload/HotReloadToolTests.cs");
 
-            string relative = HotReloadPatchTargetSupport.ToProjectRelativeScriptPath(absolutePath);
+            string relative = HotReloadPatchTargetSupport.ToProjectRelativeScriptPath(
+                HotReloadCompositionRoot.Services.PackageRootCapture,
+                absolutePath);
 
             Assert.That(relative, Is.EqualTo(AssetsScriptPath));
         }
@@ -87,7 +97,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         public void ToProjectRelativeScriptPath_WhenEmbeddedPackagePhysicalPath_ResolvesTheOwningAssembly()
         {
             // Verifies the normalized path resolves to the package's own assembly instead of Assembly-CSharp-Editor.
-            string relative = HotReloadPatchTargetSupport.ToProjectRelativeScriptPath(EmbeddedPhysicalPath);
+            string relative = HotReloadPatchTargetSupport.ToProjectRelativeScriptPath(
+                HotReloadCompositionRoot.Services.PackageRootCapture,
+                EmbeddedPhysicalPath);
 
             Assert.That(CompilationPipeline.GetAssemblyNameFromScriptPath(relative), Is.EqualTo(EmbeddedAssemblyName));
         }

--- a/Assets/Tests/Editor/HotReload/HotReloadRetainedArtifactPropagationTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadRetainedArtifactPropagationTests.cs
@@ -183,6 +183,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                     fixture.TargetAssemblyPath),
                 "retained-artifact-propagation");
             return await HotReloadShimIsolation.RunIsolationRetryAsync(
+                HotReloadCompositionRoot.Services.TransformWorkerClient,
                 retryContext,
                 exclusions,
                 new List<HotReloadMethodOutcome>(),

--- a/Assets/Tests/Editor/HotReload/HotReloadServicesTestScope.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadServicesTestScope.cs
@@ -20,7 +20,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
     {
         /// <summary>Replaces the group-run stages, leaving every other collaborator production.</summary>
         internal static IDisposable BeginWithDependencies(
-            Func<TransformWorkerClient, HotReloadEntryApplier, HotReloadGroupProcessorDependencies>
+            Func<HotReloadGroupStageCollaborators, HotReloadGroupProcessorDependencies>
                 buildDependencies)
         {
             HotReloadServices installed = HotReloadCompositionRoot.Services;
@@ -72,7 +72,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         internal static IDisposable BeginWith(
             IHotReloadEditorStateSnapshotCapture editorStateSnapshotCapture,
             TransformWorkerHost transformWorkerHost,
-            Func<TransformWorkerClient, HotReloadEntryApplier, HotReloadGroupProcessorDependencies>
+            Func<HotReloadGroupStageCollaborators, HotReloadGroupProcessorDependencies>
                 buildDependencies)
         {
             HotReloadServices installed = HotReloadCompositionRoot.Services;

--- a/Assets/Tests/Editor/HotReload/HotReloadSignatureChangeCoverageTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadSignatureChangeCoverageTests.cs
@@ -93,6 +93,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
             List<HotReloadMethodOutcome> outcomes =
                 HotReloadSignatureChangeGate.BuildGatedReplacementSkipOutcomes(
+                    HotReloadCompositionRoot.Services.Domain,
                     new[] { replacement },
                     uncoveredByTarget,
                     editedFileIdentities,
@@ -133,6 +134,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
 
             List<HotReloadMethodOutcome> outcomes =
                 HotReloadSignatureChangeGate.BuildGatedReplacementSkipOutcomes(
+                    HotReloadCompositionRoot.Services.Domain,
                     new[] { replacement },
                     uncoveredByTarget,
                     editedFileIdentities,

--- a/Assets/Tests/Editor/HotReload/HotReloadSupersededSignatureRecorderTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadSupersededSignatureRecorderTests.cs
@@ -44,6 +44,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         public void RecordFromAppliedEntries_WhenReplacementWasApplied_RecordsTheSupersededSignature()
         {
             HotReloadSupersededSignatureRecorder.RecordFromAppliedEntries(
+                HotReloadCompositionRoot.Services.Domain,
                 FixtureProjectRelativePath,
                 new[] { CreateDecoyReplacementEntry(), CreateReplacementEntry() },
                 new[] { CreateRemovedSignature() },
@@ -66,6 +67,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         public void RecordFromAppliedEntries_WhenReplacementWasNotApplied_RecordsNothing()
         {
             HotReloadSupersededSignatureRecorder.RecordFromAppliedEntries(
+                HotReloadCompositionRoot.Services.Domain,
                 FixtureProjectRelativePath,
                 new List<TransformWorkerEntryDto>(),
                 new[] { CreateRemovedSignature() },
@@ -88,6 +90,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             TransformWorkerEntryDto entry = CreateReplacementEntry();
 
             HotReloadSupersededSignatureRecorder.RecordFromAppliedEntries(
+                HotReloadCompositionRoot.Services.Domain,
                 FixtureProjectRelativePath,
                 new[] { entry },
                 new[] { CreateRemovedSignature() },

--- a/Assets/Tests/Editor/HotReload/HotReloadUnpatchedMethodLineShiftWarningBuilderTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadUnpatchedMethodLineShiftWarningBuilderTests.cs
@@ -128,6 +128,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 methods,
                 file => "line1\nline2\nline3",
                 file => "line1\nline2",
+                ToProjectRelativeScriptPath,
                 Array.Empty<string>());
 
             Assert.That(warnings.Count, Is.EqualTo(1));
@@ -162,6 +163,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 methods,
                 file => "line1\nline2\nline3",
                 file => "line1\nline2",
+                ToProjectRelativeScriptPath,
                 Array.Empty<string>());
 
             Assert.That(warnings.Count, Is.EqualTo(1));
@@ -193,6 +195,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 file => file.IndexOf("Player", StringComparison.Ordinal) >= 0
                     ? "line1\nline2"
                     : "same\ncount",
+                ToProjectRelativeScriptPath,
                 Array.Empty<string>());
 
             Assert.That(warnings.Count, Is.EqualTo(1));
@@ -224,6 +227,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 file => file.IndexOf("Player", StringComparison.Ordinal) >= 0
                     ? "line1\nline2"
                     : "a\nb",
+                ToProjectRelativeScriptPath,
                 Array.Empty<string>());
 
             Assert.That(warnings.Count, Is.EqualTo(2));
@@ -256,6 +260,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 methods,
                 file => "line1\nline2\nline3",
                 file => "line1\nline2",
+                ToProjectRelativeScriptPath,
                 Array.Empty<string>());
 
             Assert.That(warnings.Count, Is.EqualTo(1));
@@ -287,6 +292,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 methods,
                 file => "line1\nline2\nline3",
                 file => "line1\nline2",
+                ToProjectRelativeScriptPath,
                 Array.Empty<string>());
 
             Assert.That(warnings.Count, Is.EqualTo(2));
@@ -321,6 +327,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 methods,
                 file => "line1\nline2\nline3",
                 file => "line1\nline2",
+                ToProjectRelativeScriptPath,
                 new[] { "Assets/Scripts/Enemy.cs" });
 
             Assert.That(warnings.Count, Is.EqualTo(1));
@@ -352,6 +359,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 methods,
                 file => "line1\nline2\nline3",
                 file => "line1\nline2",
+                ToProjectRelativeScriptPath,
                 new[] { "Assets/Scripts/Enemy.cs" });
 
             Assert.That(warnings.Count, Is.EqualTo(1));
@@ -383,6 +391,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 methods,
                 file => "line1\nline2\nline3",
                 file => "line1\nline2",
+                ToProjectRelativeScriptPath,
                 Array.Empty<string>());
 
             Assert.That(warnings.Count, Is.EqualTo(1));
@@ -489,6 +498,15 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                     File.Delete(absolutePath);
                 }
             }
+        }
+
+        // The path spelling the production response builder passes, so these tests key their
+        // warnings on the same file names a real run does.
+        private static string ToProjectRelativeScriptPath(string path)
+        {
+            return HotReloadPatchTargetSupport.ToProjectRelativeScriptPath(
+                HotReloadCompositionRoot.Services.PackageRootCapture,
+                path);
         }
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadActiveSiblingRebindPlanner.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadActiveSiblingRebindPlanner.cs
@@ -35,11 +35,13 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     internal static class HotReloadActiveSiblingRebindPlanner
     {
         internal static HotReloadActiveSiblingRebindPlan Plan(
+            HotReloadDomain domain,
             string assemblyName,
             string[] assemblySourceFiles,
             IReadOnlyCollection<string> pathsAlreadyInRun,
             Func<string, string> resolveWorkerSourcePath)
         {
+            Debug.Assert(domain != null, "domain must not be null.");
             Debug.Assert(!string.IsNullOrEmpty(assemblyName), "assemblyName must not be empty.");
             Debug.Assert(assemblySourceFiles != null, "assemblySourceFiles must not be null.");
             Debug.Assert(pathsAlreadyInRun != null, "pathsAlreadyInRun must not be null.");
@@ -47,10 +49,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             StringComparer comparer = HotReloadSourcePathNormalizer.ProjectRelativePathComparer();
             HashSet<string> candidates = new HashSet<string>(comparer);
-            AddCandidatePaths(candidates, HotReloadCompositionRoot.Services.Domain.ListActiveFilePaths());
+            AddCandidatePaths(candidates, domain.ListActiveFilePaths());
             AddCandidatePaths(
                 candidates,
-                HotReloadCompositionRoot.Services.Domain.ListPathsWithActiveAddedMembers());
+                domain.ListPathsWithActiveAddedMembers());
 
             HashSet<string> assemblyFiles = new HashSet<string>(comparer);
             for (int index = 0; index < assemblySourceFiles.Length; index++)
@@ -64,6 +66,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             foreach (string path in candidates)
             {
                 ClassifyCandidate(
+                    domain,
                     path,
                     assemblyFiles,
                     pathsAlreadyInRun,
@@ -87,6 +90,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         }
 
         private static void ClassifyCandidate(
+            HotReloadDomain domain,
             string path,
             HashSet<string> assemblyFiles,
             IReadOnlyCollection<string> pathsAlreadyInRun,
@@ -100,7 +104,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             (string Hash, bool IsFullyApplied)? recorded =
-                HotReloadCompositionRoot.Services.Domain.TryGetAppliedSource(path);
+                domain.TryGetAppliedSource(path);
             if (recorded == null)
             {
                 return;

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadAppliedSourceLifecycle.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadAppliedSourceLifecycle.cs
@@ -18,11 +18,13 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         // that stale hash. Non-baseline matches still Clear; Stage/Record writes the same
         // hash+flag back so the next identical reload warns again.
         internal static HotReloadUnchangedSourceDecision TryShortCircuitUnchangedAppliedSource(
+            HotReloadDomain domain,
             string workerSourcePath,
             string projectRelativePath,
             string assemblyResolvePath,
             List<HotReloadMethodOutcome> outcomes)
         {
+            Debug.Assert(domain != null, "domain must not be null.");
             Debug.Assert(!string.IsNullOrEmpty(workerSourcePath), "workerSourcePath must not be empty.");
             Debug.Assert(!string.IsNullOrEmpty(projectRelativePath), "projectRelativePath must not be empty.");
             Debug.Assert(outcomes != null, "outcomes must not be null.");
@@ -39,14 +41,14 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             byte[] probeBytes = File.ReadAllBytes(fullWorkerSourcePath);
             string probeHash = new HotReloadSourceContentHasher().ComputeContentHash(probeBytes);
-            HashSet<string> activeLabels = CollectActiveLabelsForFile(projectRelativePath);
+            HashSet<string> activeLabels = CollectActiveLabelsForFile(domain, projectRelativePath);
             (string Hash, bool IsFullyApplied)? recorded =
-                HotReloadCompositionRoot.Services.Domain.TryGetAppliedSource(projectRelativePath);
+                domain.TryGetAppliedSource(projectRelativePath);
             if (recorded == null
                 || !string.Equals(probeHash, recorded.Value.Hash, StringComparison.Ordinal)
                 || (recorded.Value.IsFullyApplied && activeLabels.Count == 0))
             {
-                HotReloadCompositionRoot.Services.Domain.ClearAppliedSource(projectRelativePath);
+                domain.ClearAppliedSource(projectRelativePath);
                 return HotReloadUnchangedSourceDecision.NotUnchanged;
             }
 
@@ -57,7 +59,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 for (int index = 0; index < sortedLabels.Count; index++)
                 {
                     string label = sortedLabels[index];
-                    string reason = HotReloadCompositionRoot.Services.Domain.IsActiveMember(
+                    string reason = domain.IsActiveMember(
                         projectRelativePath,
                         label)
                         ? HotReloadConstants.AlreadyActiveAddedMemberReason
@@ -69,7 +71,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 return HotReloadUnchangedSourceDecision.ShortCircuited;
             }
 
-            HotReloadCompositionRoot.Services.Domain.ClearAppliedSource(projectRelativePath);
+            domain.ClearAppliedSource(projectRelativePath);
             return HotReloadUnchangedSourceDecision.ReapplyNonBaseline;
         }
 
@@ -144,19 +146,22 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return null;
         }
 
-        internal static HashSet<string> CollectActiveLabelsForFile(string projectRelativePath)
+        internal static HashSet<string> CollectActiveLabelsForFile(
+            HotReloadDomain domain,
+            string projectRelativePath)
         {
+            Debug.Assert(domain != null, "domain must not be null.");
             Debug.Assert(!string.IsNullOrEmpty(projectRelativePath), "projectRelativePath must not be empty.");
             HashSet<string> labels = new HashSet<string>(StringComparer.Ordinal);
             IReadOnlyList<string> addedKeys =
-                HotReloadCompositionRoot.Services.Domain.ListActiveAddedMethodKeys(projectRelativePath);
+                domain.ListActiveAddedMethodKeys(projectRelativePath);
             for (int index = 0; index < addedKeys.Count; index++)
             {
                 labels.Add(addedKeys[index]);
             }
 
             IReadOnlyList<string> patchedKeys =
-                HotReloadCompositionRoot.Services.Domain.ListActiveMethodKeys(projectRelativePath);
+                domain.ListActiveMethodKeys(projectRelativePath);
             for (int index = 0; index < patchedKeys.Count; index++)
             {
                 labels.Add(patchedKeys[index]);
@@ -231,6 +236,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         }
 
         internal static void AppendDeactivatedPatchesWarning(
+            HotReloadDomain domain,
             List<string> warnings,
             HashSet<string> snapshotLabels,
             HashSet<string> snapshotAddedLabels,
@@ -238,12 +244,13 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             TransformWorkerOutputDto workerOutput,
             IReadOnlyList<HotReloadMethodOutcome> outcomes)
         {
+            Debug.Assert(domain != null, "domain must not be null.");
             Debug.Assert(warnings != null, "warnings must not be null.");
             Debug.Assert(snapshotLabels != null, "snapshotLabels must not be null.");
             Debug.Assert(snapshotAddedLabels != null, "snapshotAddedLabels must not be null.");
             Debug.Assert(!string.IsNullOrEmpty(projectRelativePath), "projectRelativePath must not be empty.");
 
-            HashSet<string> currentLabels = CollectActiveLabelsForFile(projectRelativePath);
+            HashSet<string> currentLabels = CollectActiveLabelsForFile(domain, projectRelativePath);
             HashSet<string> stillDeclaredAdded = CollectStillDeclaredAddedLabels(workerOutput, outcomes);
             List<string> deactivatedAdded = new List<string>();
             List<string> deactivatedPatches = new List<string>();

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadApplyResponseBuilder.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadApplyResponseBuilder.cs
@@ -14,9 +14,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     internal static class HotReloadApplyResponseBuilder
     {
         public static HotReloadResponse Build(
+            HotReloadServices services,
             HotReloadOrchestratorResult result,
             IReadOnlyList<string> additionalWarnings)
         {
+            Debug.Assert(services != null, "services must not be null.");
             Debug.Assert(result != null, "result must not be null.");
 
             List<HotReloadMethodResult> methods = new List<HotReloadMethodResult>(result.Methods.Count);
@@ -67,6 +69,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 result.Methods,
                 HotReloadUnpatchedMethodLineShiftWarningBuilder.ReadEditedSourceFromDisk,
                 HotReloadUnpatchedMethodLineShiftWarningBuilder.ReadCompiledSnapshot,
+                path => HotReloadPatchTargetSupport.ToProjectRelativeScriptPath(
+                    services.PackageRootCapture,
+                    path),
                 result.ReappliedSiblingPaths);
 
             // Why before the count snapshot: a Skipped method is applied by 'uloop compile' like
@@ -120,10 +125,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 Methods = methods,
                 Warnings = warnings,
                 IntroducedTypes = HotReloadIntroducedTypeResponseSection.BuildRows(result.IntroducedTypes),
-                ActiveIntroducedTypeTotal = HotReloadCompositionRoot.Services.Domain.IntroducedTypeCount,
+                ActiveIntroducedTypeTotal = services.Domain.IntroducedTypeCount,
                 PatchedTotal = result.PatchedTotal,
                 ActivePatchTotal = result.ActivePatchTotal,
-                AddedFieldTotal = HotReloadCompositionRoot.Services.Domain.DescribeAddedFields().Count,
+                AddedFieldTotal = services.Domain.DescribeAddedFields().Count,
                 UnchangedTotal = result.UnchangedTotal,
                 ClearedCount = result.RevertedUnchangedTotal,
                 AddedFields = result.AddedFields,

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadAutoRefreshHold.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadAutoRefreshHold.cs
@@ -18,6 +18,16 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         private static double _nextReconcileTime;
 
         /// <summary>
+        /// Reads the installed services when the hold syncs itself.
+        /// </summary>
+        /// <remarks>
+        /// Why a provider and not a captured value: this syncs from Editor callbacks that take no
+        /// argument, and a replacement scope installs another domain while those callbacks stay
+        /// registered, so a value captured at startup would count the wrong domain's changes.
+        /// </remarks>
+        internal static Func<HotReloadServices> GetServices { get; set; }
+
+        /// <summary>
         /// Test hook that replaces Unity AssetDatabase calls with recording delegates.
         /// </summary>
         internal static HotReloadAutoRefreshHoldService OverrideServiceForTesting
@@ -43,7 +53,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         /// </remarks>
         internal static HotReloadAutoRefreshHoldSyncResult SyncToActiveChanges()
         {
-            return Sync(HotReloadCompositionRoot.Services.Domain.CountActiveChanges().RuntimeChangeTotal);
+            Debug.Assert(GetServices != null, "GetServices must be set before the hold syncs.");
+            return Sync(GetServices().Domain.CountActiveChanges().RuntimeChangeTotal);
         }
 
         internal static HotReloadAutoRefreshHoldSyncResult FlushDeferredRefresh()

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadCompositionRoot.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadCompositionRoot.cs
@@ -84,7 +84,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             IHotReloadPackageRootCapture packageRootCapture,
             IHotReloadEditorStateSnapshotCapture editorStateSnapshotCapture,
             TransformWorkerHost transformWorkerHost,
-            Func<TransformWorkerClient, HotReloadEntryApplier, HotReloadGroupProcessorDependencies>
+            Func<HotReloadGroupStageCollaborators, HotReloadGroupProcessorDependencies>
                 buildDependencies)
         {
             // Built in dependency order, and every collaborator takes what it needs here: nothing
@@ -95,19 +95,29 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             HotReloadEntryApplier entryApplier =
                 new HotReloadEntryApplier(domain, patcher, fileEntryApplier);
             TransformWorkerClient transformWorkerClient = new TransformWorkerClient(transformWorkerHost);
+            HotReloadGroupStageCollaborators collaborators = new HotReloadGroupStageCollaborators(
+                domain,
+                patcher,
+                fileEntryApplier,
+                entryApplier,
+                transformWorkerClient,
+                packageRootCapture,
+                editorStateSnapshotCapture,
+                new HotReloadGroupCommitPolicy(domain, fileEntryApplier));
             // A factory, not a built value: the stages are bound to the collaborators built here,
             // and a caller that built them from the installed services would bind a replacement's
             // group run back to the domain that was installed when it called.
-            HotReloadGroupProcessorDependencies dependencies =
-                buildDependencies(transformWorkerClient, entryApplier);
+            HotReloadGroupProcessorDependencies dependencies = buildDependencies(collaborators);
             Debug.Assert(dependencies != null, "buildDependencies must not return null.");
-            HotReloadGroupCommitStage groupCommitStage =
-                new HotReloadGroupCommitStage(domain, dependencies, fileEntryApplier, entryApplier);
-            HotReloadGroupProcessor groupProcessor = new HotReloadGroupProcessor(
-                dependencies,
+            HotReloadGroupCommitStage groupCommitStage = new HotReloadGroupCommitStage(
                 domain,
+                dependencies,
                 fileEntryApplier,
                 entryApplier,
+                collaborators.CommitPolicy);
+            HotReloadGroupProcessor groupProcessor = new HotReloadGroupProcessor(
+                dependencies,
+                collaborators,
                 groupCommitStage);
             return new HotReloadServices(
                 domain,
@@ -116,13 +126,19 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 fileEntryApplier,
                 entryApplier,
                 transformWorkerClient,
+                collaborators,
                 groupCommitStage,
                 groupProcessor,
                 new HotReloadOrchestrator(
+                    domain,
+                    patcher,
                     groupProcessor,
-                    new HotReloadInputFileResolver(),
+                    new HotReloadInputFileResolver(
+                        domain,
+                        packageRootCapture,
+                        editorStateSnapshotCapture),
                     new HotReloadDeferredInputClassifier(),
-                    new HotReloadSiblingRebindReporter(),
+                    new HotReloadSiblingRebindReporter(domain),
                     packageRootCapture),
                 new HotReloadStatusExecutor(domain, patcher),
                 packageRootCapture,

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadEditorStartup.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadEditorStartup.cs
@@ -31,6 +31,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             // null delegate as "nothing to lose".
             HotReloadRuntimeChangeCoordination.GetActiveRuntimeChangeCount =
                 () => HotReloadCompositionRoot.Services.Domain.CountActiveChanges().RuntimeChangeTotal;
+            // Why the same shape for these two: both run from Editor callbacks that take no
+            // argument, so they have to read whichever services are installed when they fire.
+            HotReloadAutoRefreshHold.GetServices = () => HotReloadCompositionRoot.Services;
+            HotReloadPlayModeEntryDropRecorder.GetServices = () => HotReloadCompositionRoot.Services;
             EditorApplication.update += CaptureOnFirstUpdateTick;
             HotReloadPlayModeEntryDropRecorder.Initialize();
             HotReloadAutoRefreshHold.Initialize();

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadFileEntryApplier.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadFileEntryApplier.cs
@@ -101,6 +101,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             // Why after the clear: a still-declared added method can be worker-skipped
             // (virtual/generic), leaving entries empty while the registry drop is real.
             HotReloadAppliedSourceLifecycle.AppendDeactivatedPatchesWarning(
+                _domain,
                 file.Sinks.Warnings,
                 file.SnapshotLabels,
                 file.SnapshotAddedLabels,
@@ -168,6 +169,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             // Why here as well as the empty-entries return: apply can drop a still-declared
             // added member by not re-Registering it after BeginFileGeneration.
             HotReloadAppliedSourceLifecycle.AppendDeactivatedPatchesWarning(
+                _domain,
                 sinks.Warnings,
                 file.SnapshotLabels,
                 file.SnapshotAddedLabels,

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupCommitBoundary.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupCommitBoundary.cs
@@ -2,6 +2,8 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 
+using UnityEngine;
+
 namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 {
     /// <summary>
@@ -19,18 +21,21 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         /// <summary>
         /// The reason this group must not be committed, or null when every recheck passed.
         /// </summary>
-        internal static string DescribeStaleReason(HotReloadApplyContext context)
+        internal static string DescribeStaleReason(
+            HotReloadGroupStageCollaborators collaborators,
+            HotReloadApplyContext context)
         {
+            Debug.Assert(collaborators != null, "collaborators must not be null.");
             // The Editor may have started compiling or importing while the run awaited its worker.
             string notReadyReason =
-                HotReloadCompositionRoot.Services.EditorStateSnapshotCapture.CaptureCurrent()
+                collaborators.EditorStateSnapshotCapture.CaptureCurrent()
                     .GetNotReadyReason();
             if (notReadyReason != null)
             {
                 return "The Editor became busy before the reload could be applied: " + notReadyReason;
             }
 
-            string targetAssemblyDrift = DescribeTargetAssemblyDrift(context);
+            string targetAssemblyDrift = DescribeTargetAssemblyDrift(collaborators, context);
             if (targetAssemblyDrift != null)
             {
                 return targetAssemblyDrift;
@@ -55,9 +60,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         /// assembly carries the module version id of the generation it was compiled for and
         /// stays active for the rest of the domain's life.
         /// </remarks>
-        private static string DescribeTargetAssemblyDrift(HotReloadApplyContext context)
+        private static string DescribeTargetAssemblyDrift(
+            HotReloadGroupStageCollaborators collaborators,
+            HotReloadApplyContext context)
         {
-            if (!HotReloadCompositionRoot.Services.GroupCommitStage.CommitsIntroducedTypes(
+            if (!collaborators.CommitPolicy.CommitsIntroducedTypes(
                     context.PreparedIntroducedTypes,
                     context.AssemblyName))
             {

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupCommitPolicy.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupCommitPolicy.cs
@@ -1,0 +1,62 @@
+using System.Collections.Generic;
+
+using UnityEngine;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// The two decisions a group run has to make about introduced types and empty generations,
+    /// held apart from the commit stage itself.
+    /// </summary>
+    /// <remarks>
+    /// Why a type of its own: the stages the group run calls out to need these decisions, and the
+    /// commit stage is built from those stages, so a stage that asked the commit stage for them
+    /// would close a construction cycle. This policy depends only on the domain and the file
+    /// entry applier, both of which exist before the stages are bound.
+    /// </remarks>
+    internal sealed class HotReloadGroupCommitPolicy
+    {
+        private readonly HotReloadDomain _domain;
+        private readonly HotReloadFileEntryApplier _fileEntryApplier;
+
+        internal HotReloadGroupCommitPolicy(
+            HotReloadDomain domain,
+            HotReloadFileEntryApplier fileEntryApplier)
+        {
+            Debug.Assert(domain != null, "domain must not be null.");
+            Debug.Assert(fileEntryApplier != null, "fileEntryApplier must not be null.");
+            _domain = domain;
+            _fileEntryApplier = fileEntryApplier;
+        }
+
+        // A run whose introduced types become active at the commit boundary: the reload either
+        // introduces a type itself, or the assembly it targets already owns one this domain
+        // introduced, in which case its patches resolve through the artifact assemblies too.
+        internal bool CommitsIntroducedTypes(
+            HotReloadPreparedIntroducedTypes prepared,
+            string targetAssemblyName)
+        {
+            return prepared != null
+                || _domain.IntroducedTypes.HasActiveTypesForOriginalAssembly(targetAssemblyName);
+        }
+
+        // Deleting an added method and restoring its callers yields empty entries, so the
+        // post-shim-compile BeginFileGeneration never runs and the previous run's generation would
+        // otherwise stay live.
+        internal void ClearEmptyFileGenerations(HotReloadApplyContext context)
+        {
+            foreach (HotReloadGroupFile file in context.Files)
+            {
+                // A file left unapplied on purpose keeps the previous run's generation even with no
+                // entries: clearing it here would let a reload of broken source silently drop the
+                // added members the previous run applied.
+                if (file.SkipApply)
+                {
+                    continue;
+                }
+
+                _fileEntryApplier.ClearFileGeneration(context, file);
+            }
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupCommitPolicy.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupCommitPolicy.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 54c7c5b16eb8e403994061836e72da25
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupCommitStage.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupCommitStage.cs
@@ -17,21 +17,25 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         private readonly HotReloadGroupProcessorDependencies _dependencies;
         private readonly HotReloadFileEntryApplier _fileEntryApplier;
         private readonly HotReloadEntryApplier _entryApplier;
+        private readonly HotReloadGroupCommitPolicy _commitPolicy;
 
         internal HotReloadGroupCommitStage(
             HotReloadDomain domain,
             HotReloadGroupProcessorDependencies dependencies,
             HotReloadFileEntryApplier fileEntryApplier,
-            HotReloadEntryApplier entryApplier)
+            HotReloadEntryApplier entryApplier,
+            HotReloadGroupCommitPolicy commitPolicy)
         {
             Debug.Assert(domain != null, "domain must not be null.");
             Debug.Assert(dependencies != null, "dependencies must not be null.");
             Debug.Assert(fileEntryApplier != null, "fileEntryApplier must not be null.");
             Debug.Assert(entryApplier != null, "entryApplier must not be null.");
+            Debug.Assert(commitPolicy != null, "commitPolicy must not be null.");
             _domain = domain;
             _dependencies = dependencies;
             _fileEntryApplier = fileEntryApplier;
             _entryApplier = entryApplier;
+            _commitPolicy = commitPolicy;
         }
 
         internal bool HoldsUnresolvedFile(IReadOnlyList<HotReloadPreparedGroupFile> preparedFiles)
@@ -92,7 +96,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 HotReloadIntroducedTypeOutcomeSink.Append(files, BuildIntroducedRows(prepared.Artifact));
             }
 
-            bool commitsIntroducedTypes = CommitsIntroducedTypes(prepared, files[0].AssemblyName);
+            bool commitsIntroducedTypes =
+                _commitPolicy.CommitsIntroducedTypes(prepared, files[0].AssemblyName);
             if (commitsIntroducedTypes)
             {
                 _entryApplier.RevertUnchangedPatchesPerFile(
@@ -107,7 +112,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 // a failed recheck can no longer undo. A run without types already cleared.
                 if (commitsIntroducedTypes)
                 {
-                    ClearEmptyFileGenerations(context);
+                    _commitPolicy.ClearEmptyFileGenerations(context);
                 }
 
                 return _fileEntryApplier.BuildUnappliedGroupResults(files);
@@ -138,36 +143,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return rows;
         }
 
-        // A run whose introduced types become active at the commit boundary: the reload either
-        // introduces a type itself, or the assembly it targets already owns one this domain
-        // introduced, in which case its patches resolve through the artifact assemblies too.
-        internal bool CommitsIntroducedTypes(
-            HotReloadPreparedIntroducedTypes prepared,
-            string targetAssemblyName)
-        {
-            return prepared != null
-                || _domain.IntroducedTypes.HasActiveTypesForOriginalAssembly(targetAssemblyName);
-        }
-
-        // Deleting an added method and restoring its callers yields empty entries, so the
-        // post-shim-compile BeginFileGeneration never runs and the previous run's generation would
-        // otherwise stay live.
-        internal void ClearEmptyFileGenerations(HotReloadApplyContext context)
-        {
-            foreach (HotReloadGroupFile file in context.Files)
-            {
-                // A file left unapplied on purpose keeps the previous run's generation even with no
-                // entries: clearing it here would let a reload of broken source silently drop the
-                // added members the previous run applied.
-                if (file.SkipApply)
-                {
-                    continue;
-                }
-
-                _fileEntryApplier.ClearFileGeneration(context, file);
-            }
-        }
-
         // Why per file: a group applies file by file, so only the rows that actually reached
         // Harmony may claim their removed signatures were superseded. A partly applied file
         // patches some rows and leaves the rest failed or file-atomically skipped.
@@ -180,6 +155,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 HotReloadGroupFile file = context.Files[index];
                 Debug.Assert(file.FileOutput != null, "Every file must carry its worker output row.");
                 HotReloadSupersededSignatureRecorder.RecordFromAppliedEntries(
+                    _domain,
                     file.ProjectRelativePath,
                     file.Sinks.AppliedEntries,
                     file.FileOutput.removedMethodSignatures

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupEntryPreparation.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupEntryPreparation.cs
@@ -19,10 +19,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     internal static class HotReloadGroupEntryPreparation
     {
         internal static IReadOnlyList<HotReloadPreparedGroupFile> PrepareGroup(
+            HotReloadGroupStageCollaborators collaborators,
             HotReloadApplyContext context,
             HotReloadShimCompileResult compileResult,
             TransformWorkerEntryDto[] entriesToPatch)
         {
+            Debug.Assert(collaborators != null, "collaborators must not be null.");
             Debug.Assert(context != null, "context must not be null.");
             Debug.Assert(compileResult != null, "compileResult must not be null.");
             Debug.Assert(entriesToPatch != null, "entriesToPatch must not be null.");
@@ -32,7 +34,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             // Why once for the group: every shim type of the group lives in this one assembly, so
             // binding per file would re-run the same binders and hide which file first failed.
             Dictionary<string, string> bindFailures =
-                HotReloadCompositionRoot.Services.EntryApplier.BindShimAccessors(compileResult.Assembly);
+                collaborators.EntryApplier.BindShimAccessors(compileResult.Assembly);
             List<HotReloadPreparedGroupFile> prepared =
                 new List<HotReloadPreparedGroupFile>(context.Files.Count);
             foreach (HotReloadGroupFile file in context.Files)

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupNotices.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupNotices.cs
@@ -56,6 +56,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         }
 
         internal static void AppendRemovedMemberNotices(
+            HotReloadPatcher patcher,
             HotReloadApplyContext context,
             HotReloadSignatureChangeGate.SignatureChangeGateResult gateResult)
         {
@@ -73,6 +74,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 }
 
                 HotReloadStalePatchOutcomes.Append(
+                    patcher,
                     file.Sinks.Outcomes,
                     context.WorkerOutput,
                     file.FileOutput.removedMethodSignatures,

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupProcessor.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupProcessor.cs
@@ -23,6 +23,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     internal sealed class HotReloadGroupProcessor
     {
         private readonly HotReloadGroupProcessorDependencies _dependencies;
+        private readonly HotReloadGroupStageCollaborators _collaborators;
         private readonly HotReloadDomain _domain;
         private readonly HotReloadFileEntryApplier _fileEntryApplier;
         private readonly HotReloadEntryApplier _entryApplier;
@@ -30,20 +31,17 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
         internal HotReloadGroupProcessor(
             HotReloadGroupProcessorDependencies dependencies,
-            HotReloadDomain domain,
-            HotReloadFileEntryApplier fileEntryApplier,
-            HotReloadEntryApplier entryApplier,
+            HotReloadGroupStageCollaborators collaborators,
             HotReloadGroupCommitStage commitStage)
         {
             Debug.Assert(dependencies != null, "dependencies must not be null.");
-            Debug.Assert(domain != null, "domain must not be null.");
-            Debug.Assert(fileEntryApplier != null, "fileEntryApplier must not be null.");
-            Debug.Assert(entryApplier != null, "entryApplier must not be null.");
+            Debug.Assert(collaborators != null, "collaborators must not be null.");
             Debug.Assert(commitStage != null, "commitStage must not be null.");
             _dependencies = dependencies;
-            _domain = domain;
-            _fileEntryApplier = fileEntryApplier;
-            _entryApplier = entryApplier;
+            _collaborators = collaborators;
+            _domain = collaborators.Domain;
+            _fileEntryApplier = collaborators.FileEntryApplier;
+            _entryApplier = collaborators.EntryApplier;
             _commitStage = commitStage;
         }
 
@@ -201,7 +199,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             // Why a run that commits types skips it: peeling a patch here would mutate the domain
             // before the commit boundary, which a failed recheck could then no longer undo, so
             // such a run reverts at the boundary instead.
-            if (!_commitStage.CommitsIntroducedTypes(prepared, files[0].AssemblyName)
+            if (!_collaborators.CommitPolicy.CommitsIntroducedTypes(prepared, files[0].AssemblyName)
                 && !await RevalidateBeforeRevertAsync(
                     files,
                     ct,
@@ -241,9 +239,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         /// decide whether there is anything left to apply.
         /// </summary>
         internal static async Task<HotReloadGroupGateAndCompileResult> GateAndCompileAsync(
+            HotReloadGroupStageCollaborators collaborators,
             HotReloadApplyContext context,
             CancellationToken ct)
         {
+            Debug.Assert(collaborators != null, "collaborators must not be null.");
             // The worker-bound continuation after the pre-revert check is not guaranteed to
             // resume on Unity's context, while the signature gate reads compilation state.
             await MainThreadSwitcher.SwitchToMainThread(ct);
@@ -251,12 +251,13 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             IReadOnlyList<HotReloadGroupFile> files = context.Files;
             HotReloadGroupFile gateWarningSink = files[0];
             HotReloadSignatureChangeGate.SignatureChangeGateResult gateResult = await HotReloadSignatureChangeGate.TryApplySignatureChangeGateAsync(
+                collaborators,
                 context,
                 ct).ConfigureAwait(false);
             HotReloadWorkerNoticeAppender.AppendRetrySiblingConstDriftWarnings(
                 gateWarningSink.Sinks.SiblingDerivedWarnings,
                 gateResult.Isolation);
-            HotReloadGroupNotices.AppendRemovedMemberNotices(context, gateResult);
+            HotReloadGroupNotices.AppendRemovedMemberNotices(collaborators.Patcher, context, gateResult);
             if (gateResult.FileFailed)
             {
                 // Why not apply first-pass entries: a gate retry null means the replacement was
@@ -276,6 +277,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             gateWarningSink.Sinks.Warnings.AddRange(gateResult.Warnings);
 
             HotReloadGroupCompileResult compile = await HotReloadShimFirstCompile.ResolveEntriesToPatchAsync(
+                collaborators,
                 context,
                 gateResult,
                 ct).ConfigureAwait(false);
@@ -317,13 +319,14 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             await MainThreadSwitcher.SwitchToMainThread(ct);
             ct.ThrowIfCancellationRequested();
-            if (!TryAppendNewSourceMembershipFailure(context.Files))
+            if (!TryAppendNewSourceMembershipFailure(_collaborators, context.Files))
             {
                 return _fileEntryApplier.BuildUnappliedGroupResults(context.Files);
             }
 
             ct.ThrowIfCancellationRequested();
-            string staleReason = HotReloadGroupCommitBoundary.DescribeStaleReason(context);
+            string staleReason =
+                HotReloadGroupCommitBoundary.DescribeStaleReason(_collaborators, context);
             if (staleReason != null)
             {
                 HotReloadGroupOutcomeRouter.AppendGroupFailure(context.Files, "(file)", staleReason);
@@ -354,9 +357,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return _commitStage.Commit(context, gateResult, compile, preparedFiles);
         }
 
-        internal static bool TryAppendNewSourceMembershipFailure(IReadOnlyList<HotReloadGroupFile> files)
+        internal static bool TryAppendNewSourceMembershipFailure(
+            HotReloadGroupStageCollaborators collaborators,
+            IReadOnlyList<HotReloadGroupFile> files)
         {
-            string failure = HotReloadNewSourceMembershipValidator.TryRevalidateFiles(files);
+            string failure =
+                HotReloadNewSourceMembershipValidator.TryRevalidateFiles(collaborators, files);
             if (failure == null)
             {
                 return true;
@@ -374,7 +380,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             Debug.Assert(revertUnchangedPatches != null, "revertUnchangedPatches must not be null.");
             await MainThreadSwitcher.SwitchToMainThread(ct);
             ct.ThrowIfCancellationRequested();
-            if (!TryAppendNewSourceMembershipFailure(files))
+            if (!TryAppendNewSourceMembershipFailure(_collaborators, files))
             {
                 return false;
             }
@@ -391,8 +397,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 // Why snapshot at the group's apply entry: runs process groups sequentially, and
                 // RevertUnchangedPatches / BeginFileGeneration mutate ledgers after the worker.
                 // The worker itself does not.
-                file.SnapshotLabels =
-                    HotReloadAppliedSourceLifecycle.CollectActiveLabelsForFile(file.ProjectRelativePath);
+                file.SnapshotLabels = HotReloadAppliedSourceLifecycle.CollectActiveLabelsForFile(
+                    _domain,
+                    file.ProjectRelativePath);
                 file.SnapshotAddedLabels = new HashSet<string>(
                     _domain.ListActiveAddedMethodKeys(file.ProjectRelativePath),
                     StringComparer.Ordinal);

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupProcessorDependencies.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupProcessorDependencies.cs
@@ -72,16 +72,17 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         /// The production stages, bound to the services of one domain.
         /// </summary>
         internal static HotReloadGroupProcessorDependencies CreateProduction(
-            TransformWorkerClient transformWorkerClient,
-            HotReloadEntryApplier entryApplier)
+            HotReloadGroupStageCollaborators collaborators)
         {
             return new HotReloadGroupProcessorDependencies(
-                HotReloadGroupProcessor.TryAppendNewSourceMembershipFailure,
-                HotReloadIntroducedTypePreparation.PrepareAsync,
-                transformWorkerClient.RunAsync,
-                HotReloadGroupProcessor.GateAndCompileAsync,
-                HotReloadGroupEntryPreparation.PrepareGroup,
-                entryApplier.ApplyPreparedEntries);
+                files => HotReloadGroupProcessor.TryAppendNewSourceMembershipFailure(collaborators, files),
+                (files, input, ct) =>
+                    HotReloadIntroducedTypePreparation.PrepareAsync(collaborators, files, input, ct),
+                collaborators.TransformWorkerClient.RunAsync,
+                (context, ct) => HotReloadGroupProcessor.GateAndCompileAsync(collaborators, context, ct),
+                (context, compileResult, entriesToPatch) => HotReloadGroupEntryPreparation.PrepareGroup(
+                    collaborators, context, compileResult, entriesToPatch),
+                collaborators.EntryApplier.ApplyPreparedEntries);
         }
 
         internal static HotReloadGroupProcessorDependencies Create(

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupStageCollaborators.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupStageCollaborators.cs
@@ -1,0 +1,62 @@
+using UnityEngine;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// The collaborators the stages of one group run are bound to, handed to each stage as an
+    /// argument instead of read back from the installed services.
+    /// </summary>
+    /// <remarks>
+    /// Why this is not <see cref="HotReloadServices"/>: this is the bundle that is finished before
+    /// the stages are, and the services are only complete after them, so the stages cannot be
+    /// handed the services they are part of. A stage that read the installed services at call time
+    /// would run a replacement's group against whichever domain happened to be installed.
+    /// </remarks>
+    internal sealed class HotReloadGroupStageCollaborators
+    {
+        internal HotReloadGroupStageCollaborators(
+            HotReloadDomain domain,
+            HotReloadPatcher patcher,
+            HotReloadFileEntryApplier fileEntryApplier,
+            HotReloadEntryApplier entryApplier,
+            TransformWorkerClient transformWorkerClient,
+            IHotReloadPackageRootCapture packageRootCapture,
+            IHotReloadEditorStateSnapshotCapture editorStateSnapshotCapture,
+            HotReloadGroupCommitPolicy commitPolicy)
+        {
+            Debug.Assert(domain != null, "domain must not be null.");
+            Debug.Assert(patcher != null, "patcher must not be null.");
+            Debug.Assert(fileEntryApplier != null, "fileEntryApplier must not be null.");
+            Debug.Assert(entryApplier != null, "entryApplier must not be null.");
+            Debug.Assert(transformWorkerClient != null, "transformWorkerClient must not be null.");
+            Debug.Assert(packageRootCapture != null, "packageRootCapture must not be null.");
+            Debug.Assert(
+                editorStateSnapshotCapture != null, "editorStateSnapshotCapture must not be null.");
+            Debug.Assert(commitPolicy != null, "commitPolicy must not be null.");
+            Domain = domain;
+            Patcher = patcher;
+            FileEntryApplier = fileEntryApplier;
+            EntryApplier = entryApplier;
+            TransformWorkerClient = transformWorkerClient;
+            PackageRootCapture = packageRootCapture;
+            EditorStateSnapshotCapture = editorStateSnapshotCapture;
+            CommitPolicy = commitPolicy;
+        }
+
+        internal HotReloadDomain Domain { get; }
+
+        internal HotReloadPatcher Patcher { get; }
+
+        internal HotReloadFileEntryApplier FileEntryApplier { get; }
+
+        internal HotReloadEntryApplier EntryApplier { get; }
+
+        internal TransformWorkerClient TransformWorkerClient { get; }
+
+        internal IHotReloadPackageRootCapture PackageRootCapture { get; }
+
+        internal IHotReloadEditorStateSnapshotCapture EditorStateSnapshotCapture { get; }
+
+        internal HotReloadGroupCommitPolicy CommitPolicy { get; }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupStageCollaborators.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupStageCollaborators.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8bb4e229bf0c944c89209304afdd34f4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadInputFileResolver.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadInputFileResolver.cs
@@ -2,6 +2,8 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 
+using UnityEngine;
+
 namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 {
     /// <summary>
@@ -9,6 +11,25 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     /// </summary>
     internal sealed class HotReloadInputFileResolver
     {
+        private readonly HotReloadDomain _domain;
+        private readonly IHotReloadPackageRootCapture _packageRootCapture;
+        private readonly IHotReloadEditorStateSnapshotCapture _editorStateSnapshotCapture;
+
+        internal HotReloadInputFileResolver(
+            HotReloadDomain domain,
+            IHotReloadPackageRootCapture packageRootCapture,
+            IHotReloadEditorStateSnapshotCapture editorStateSnapshotCapture)
+        {
+            Debug.Assert(domain != null, "domain must not be null.");
+            Debug.Assert(packageRootCapture != null, "packageRootCapture must not be null.");
+            Debug.Assert(
+                editorStateSnapshotCapture != null,
+                "editorStateSnapshotCapture must not be null.");
+            _domain = domain;
+            _packageRootCapture = packageRootCapture;
+            _editorStateSnapshotCapture = editorStateSnapshotCapture;
+        }
+
         // Resolves one input path's patch target and either records its early result or enrolls
         // it in the group plan.
         internal void ResolveInputFile(
@@ -31,6 +52,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             List<HotReloadMethodOutcome> alreadyActiveOutcomes = new List<HotReloadMethodOutcome>();
 
             HotReloadPatchTargetResolution resolution = HotReloadPatchTargetSupport.ResolvePatchTarget(
+                _domain,
+                _packageRootCapture,
+                _editorStateSnapshotCapture,
                 filePath,
                 workerSourcePath,
                 sinks.Outcomes,
@@ -40,7 +64,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             if (resolution.IsEarlyExit)
             {
                 slot.Result = resolution.EarlyResult;
-                slot.ResultPath = HotReloadPatchTargetSupport.ToProjectRelativeScriptPath(filePath);
+                slot.ResultPath = HotReloadPatchTargetSupport.ToProjectRelativeScriptPath(
+                    _packageRootCapture,
+                    filePath);
                 return;
             }
 
@@ -73,7 +99,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 StringComparer comparer = HotReloadSourcePathNormalizer.ProjectRelativePathComparer();
                 foreach (KeyValuePair<string, string> pair in overrideByFile)
                 {
-                    string keyRelative = HotReloadPatchTargetSupport.ToProjectRelativeScriptPath(pair.Key);
+                    string keyRelative = HotReloadPatchTargetSupport.ToProjectRelativeScriptPath(
+                        _packageRootCapture,
+                        pair.Key);
                     if (comparer.Equals(keyRelative, projectRelativePath))
                     {
                         return Path.GetFullPath(pair.Value);

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadIntroducedTypePreparation.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadIntroducedTypePreparation.cs
@@ -18,14 +18,16 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         private static readonly string SessionId = Guid.NewGuid().ToString("N");
 
         public static async Task<HotReloadIntroducedTypePreparationResult> PrepareAsync(
+            HotReloadGroupStageCollaborators collaborators,
             IReadOnlyList<HotReloadGroupFile> files,
             TransformWorkerInputDto transformInput,
             CancellationToken ct)
         {
+            Debug.Assert(collaborators != null, "collaborators must not be null.");
             Debug.Assert(files != null && files.Count > 0, "A group must hold a file.");
             Debug.Assert(transformInput != null, "The preparation reuses the transform input.");
 
-            TransformWorkerClientResult prepareResult = await HotReloadCompositionRoot.Services.TransformWorkerClient.RunAsync(
+            TransformWorkerClientResult prepareResult = await collaborators.TransformWorkerClient.RunAsync(
                 BuildPrepareInput(transformInput),
                 ct).ConfigureAwait(false);
             if (!prepareResult.Success)

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadIntroducedTypeStatusSection.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadIntroducedTypeStatusSection.cs
@@ -1,6 +1,8 @@
 using System.Collections.Generic;
 using System.Globalization;
 
+using UnityEngine;
+
 namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 {
     /// <summary>
@@ -16,10 +18,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         /// batch that compiled it, so a report built from artifacts would name one row for two
         /// types the caller can each reach by name.
         /// </remarks>
-        internal static List<HotReloadIntroducedTypeResult> BuildActiveRows()
+        internal static List<HotReloadIntroducedTypeResult> BuildActiveRows(HotReloadDomain domain)
         {
+            Debug.Assert(domain != null, "domain must not be null.");
             IReadOnlyList<HotReloadIntroducedTypeDescriptor> descriptors =
-                HotReloadCompositionRoot.Services.Domain.IntroducedTypes.DescribeActive();
+                domain.IntroducedTypes.DescribeActive();
             List<HotReloadIntroducedTypeResult> rows =
                 new List<HotReloadIntroducedTypeResult>(descriptors.Count);
             foreach (HotReloadIntroducedTypeDescriptor descriptor in descriptors)

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadNewSourceMembershipValidator.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadNewSourceMembershipValidator.cs
@@ -92,6 +92,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         }
 
         internal static string TryCapture(
+            IHotReloadEditorStateSnapshotCapture editorStateSnapshotCapture,
             string projectRoot,
             string projectRelativePath,
             string assemblyName,
@@ -99,10 +100,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             string targetDllPath,
             out HotReloadNewSourceMembershipEvidence evidence)
         {
+            Debug.Assert(editorStateSnapshotCapture != null, "editorStateSnapshotCapture must not be null.");
             evidence = null;
-            string notReadyReason =
-                HotReloadCompositionRoot.Services.EditorStateSnapshotCapture.CaptureCurrent()
-                    .GetNotReadyReason();
+            string notReadyReason = editorStateSnapshotCapture.CaptureCurrent().GetNotReadyReason();
             if (notReadyReason != null)
             {
                 return notReadyReason;
@@ -140,12 +140,13 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return null;
         }
 
-        internal static string TryRevalidate(HotReloadNewSourceMembershipEvidence evidence)
+        internal static string TryRevalidate(
+            IHotReloadEditorStateSnapshotCapture editorStateSnapshotCapture,
+            HotReloadNewSourceMembershipEvidence evidence)
         {
+            Debug.Assert(editorStateSnapshotCapture != null, "editorStateSnapshotCapture must not be null.");
             Debug.Assert(evidence != null, "evidence must not be null.");
-            string notReadyReason =
-                HotReloadCompositionRoot.Services.EditorStateSnapshotCapture.CaptureCurrent()
-                    .GetNotReadyReason();
+            string notReadyReason = editorStateSnapshotCapture.CaptureCurrent().GetNotReadyReason();
             if (notReadyReason != null)
             {
                 return notReadyReason;
@@ -210,8 +211,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return null;
         }
 
-        internal static string TryRevalidateFiles(IReadOnlyList<HotReloadGroupFile> files)
+        internal static string TryRevalidateFiles(
+            HotReloadGroupStageCollaborators collaborators,
+            IReadOnlyList<HotReloadGroupFile> files)
         {
+            Debug.Assert(collaborators != null, "collaborators must not be null.");
             Debug.Assert(files != null && files.Count > 0, "files must not be empty.");
             for (int index = 0; index < files.Count; index++)
             {
@@ -221,7 +225,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     continue;
                 }
 
-                string failure = TryRevalidate(evidence);
+                string failure = TryRevalidate(collaborators.EditorStateSnapshotCapture, evidence);
                 if (failure != null)
                 {
                     return failure;

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadOrchestrator.cs
@@ -20,19 +20,27 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         private readonly HotReloadDeferredInputClassifier _deferredInputClassifier;
         private readonly HotReloadSiblingRebindReporter _siblingRebindReporter;
         private readonly IHotReloadPackageRootCapture _packageRootCapture;
+        private readonly HotReloadDomain _domain;
+        private readonly HotReloadPatcher _patcher;
 
         internal HotReloadOrchestrator(
+            HotReloadDomain domain,
+            HotReloadPatcher patcher,
             HotReloadGroupProcessor groupProcessor,
             HotReloadInputFileResolver inputFileResolver,
             HotReloadDeferredInputClassifier deferredInputClassifier,
             HotReloadSiblingRebindReporter siblingRebindReporter,
             IHotReloadPackageRootCapture packageRootCapture)
         {
+            Debug.Assert(domain != null, "domain must not be null.");
+            Debug.Assert(patcher != null, "patcher must not be null.");
             Debug.Assert(groupProcessor != null, "groupProcessor must not be null.");
             Debug.Assert(inputFileResolver != null, "inputFileResolver must not be null.");
             Debug.Assert(deferredInputClassifier != null, "deferredInputClassifier must not be null.");
             Debug.Assert(siblingRebindReporter != null, "siblingRebindReporter must not be null.");
             Debug.Assert(packageRootCapture != null, "packageRootCapture must not be null.");
+            _domain = domain;
+            _patcher = patcher;
             _groupProcessor = groupProcessor;
             _inputFileResolver = inputFileResolver;
             _deferredInputClassifier = deferredInputClassifier;
@@ -68,7 +76,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             // Why after the switch: the accumulator has to read the Auto Refresh hold flag out of
             // SessionState, which is a main-thread API.
             HotReloadRunAccumulator run =
-                new HotReloadRunAccumulator(HotReloadAutoRefreshHold.IsHeld);
+                new HotReloadRunAccumulator(_domain, _patcher, HotReloadAutoRefreshHold.IsHeld);
             HotReloadInputResolutionSlot[] slots = new HotReloadInputResolutionSlot[files.Count];
             for (int index = 0; index < slots.Length; index++)
             {

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadPatchTargetSupport.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadPatchTargetSupport.cs
@@ -24,6 +24,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         // short-circuit is decided here but applied by the orchestrator so a changed
         // sibling in the same assembly can still pull the file into the group.
         internal static HotReloadPatchTargetResolution ResolvePatchTarget(
+            HotReloadDomain domain,
+            IHotReloadPackageRootCapture packageRootCapture,
+            IHotReloadEditorStateSnapshotCapture editorStateSnapshotCapture,
             string assemblyResolvePath,
             string workerSourcePath,
             List<HotReloadMethodOutcome> outcomes,
@@ -31,11 +34,17 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             string correlationId,
             List<HotReloadMethodOutcome> alreadyActiveOutcomes)
         {
+            Debug.Assert(domain != null, "domain must not be null.");
+            Debug.Assert(packageRootCapture != null, "packageRootCapture must not be null.");
+            Debug.Assert(
+                editorStateSnapshotCapture != null,
+                "editorStateSnapshotCapture must not be null.");
             Debug.Assert(alreadyActiveOutcomes != null, "alreadyActiveOutcomes must not be null.");
 
             // CompilationPipeline.GetAssemblyNameFromScriptPath expects a project-relative path
             // (Assets/... or Packages/...) and returns a file name that already includes ".dll".
-            string projectRelativePath = ToProjectRelativeScriptPath(assemblyResolvePath);
+            string projectRelativePath =
+                ToProjectRelativeScriptPath(packageRootCapture, assemblyResolvePath);
             string rawAssemblyName = CompilationPipeline.GetAssemblyNameFromScriptPath(projectRelativePath);
             if (string.IsNullOrEmpty(rawAssemblyName))
             {
@@ -80,8 +89,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             if (isNewSource)
             {
                 string notReadyReason =
-                    HotReloadCompositionRoot.Services.EditorStateSnapshotCapture.CaptureCurrent()
-                        .GetNotReadyReason();
+                    editorStateSnapshotCapture.CaptureCurrent().GetNotReadyReason();
                 if (notReadyReason != null)
                 {
                     outcomes.Add(HotReloadMethodOutcome.Failed("(file)", notReadyReason, assemblyResolvePath));
@@ -119,6 +127,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             if (isNewSource)
             {
                 string membershipFailure = HotReloadNewSourceMembershipValidator.TryCapture(
+                    editorStateSnapshotCapture,
                     projectRoot,
                     projectRelativePath,
                     assemblyName,
@@ -138,9 +147,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             // an artifact assembly whose owner declaration still has to be verified, so an
             // unchanged source must reach that verification with its ledger entry intact.
             HotReloadUnchangedSourceDecision unchangedDecision = HotReloadUnchangedSourceDecision.NotUnchanged;
-            if (!HotReloadCompositionRoot.Services.Domain.IntroducedTypes.HasActiveTypesForOriginalAssembly(assemblyName))
+            if (!domain.IntroducedTypes.HasActiveTypesForOriginalAssembly(assemblyName))
             {
                 unchangedDecision = HotReloadAppliedSourceLifecycle.TryShortCircuitUnchangedAppliedSource(
+                    domain,
                     workerSourcePath,
                     projectRelativePath,
                     assemblyResolvePath,
@@ -226,8 +236,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return HotReloadConstants.AssemblyNotLoadedHint;
         }
 
-        internal static string ToProjectRelativeScriptPath(string path)
+        internal static string ToProjectRelativeScriptPath(
+            IHotReloadPackageRootCapture packageRootCapture,
+            string path)
         {
+            Debug.Assert(packageRootCapture != null, "packageRootCapture must not be null.");
             Debug.Assert(!string.IsNullOrEmpty(path), "path must not be empty.");
             string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
 
@@ -242,7 +255,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return HotReloadScriptPathNormalizer.ToProjectRelative(
                 fullPath,
                 projectRoot,
-                HotReloadCompositionRoot.Services.PackageRootCapture.Current,
+                packageRootCapture.Current,
                 comparison);
         }
     }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadPlayModeEntryDropRecorder.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadPlayModeEntryDropRecorder.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 using UnityEditor;
@@ -15,6 +16,16 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     internal static class HotReloadPlayModeEntryDropRecorder
     {
         private static int _currentCompilationErrorCount;
+
+        /// <summary>
+        /// Reads the installed services when Play entry collects what it would drop.
+        /// </summary>
+        /// <remarks>
+        /// Why a provider and not a captured value: the collectors run from Editor callbacks that
+        /// take no argument, and a replacement scope installs another domain while those callbacks
+        /// stay registered, so a value captured at startup would list the wrong domain's changes.
+        /// </remarks>
+        internal static Func<HotReloadServices> GetServices { get; set; }
 
         // Why static: a domain reload wipes this list. The next playModeStateChanged
         // in the same domain therefore means Play entry was cancelled and the just-recorded
@@ -201,9 +212,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         /// </summary>
         internal static IReadOnlyList<string> CollectActiveIdentities()
         {
-            IReadOnlyList<HotReloadActivePatchInfo> patches = HotReloadCompositionRoot.Services.Patcher.DescribeActivePatches();
+            Debug.Assert(GetServices != null, "GetServices must be set before identities are collected.");
+            HotReloadServices services = GetServices();
+            IReadOnlyList<HotReloadActivePatchInfo> patches = services.Patcher.DescribeActivePatches();
             IReadOnlyList<HotReloadAddedMemberInfo> addedMembers =
-                HotReloadCompositionRoot.Services.Domain.DescribeAddedMembers();
+                services.Domain.DescribeAddedMembers();
             List<string> identities = new List<string>(patches.Count + addedMembers.Count);
             for (int index = 0; index < patches.Count; index++)
             {
@@ -218,7 +231,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             // Why the types belong here: they live in artifact assemblies only a domain reload
             // unloads, so Play entry discards them exactly as it discards a patch.
             IReadOnlyList<HotReloadIntroducedTypeDescriptor> introducedTypes =
-                HotReloadCompositionRoot.Services.Domain.IntroducedTypes.DescribeActive();
+                services.Domain.IntroducedTypes.DescribeActive();
             for (int index = 0; index < introducedTypes.Count; index++)
             {
                 HotReloadIntroducedTypeDescriptor descriptor = introducedTypes[index];

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadRunAccumulator.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadRunAccumulator.cs
@@ -38,6 +38,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         // hold from one that merely found it armed. What the caller promised is "the first apply
         // that arms the hold", which only the state before the run answers.
         private readonly bool _autoRefreshHeldAtStart;
+        private readonly HotReloadDomain _domain;
+        private readonly HotReloadPatcher _patcher;
         private int _patchedTotal;
         private int _unchangedTotal;
         private int _revertedUnchangedTotal;
@@ -46,8 +48,15 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         /// Whether the Auto Refresh hold was already armed when the run started. Read on the Unity
         /// main thread, because the flag lives in SessionState.
         /// </param>
-        public HotReloadRunAccumulator(bool autoRefreshHeldAtStart)
+        public HotReloadRunAccumulator(
+            HotReloadDomain domain,
+            HotReloadPatcher patcher,
+            bool autoRefreshHeldAtStart)
         {
+            Debug.Assert(domain != null, "domain must not be null.");
+            Debug.Assert(patcher != null, "patcher must not be null.");
+            _domain = domain;
+            _patcher = patcher;
             _autoRefreshHeldAtStart = autoRefreshHeldAtStart;
         }
 
@@ -98,7 +107,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         {
             foreach (KeyValuePair<string, (string Hash, bool IsFullyApplied)> pair in _appliedSourceHashByPath)
             {
-                HotReloadCompositionRoot.Services.Domain.RecordAppliedSource(
+                _domain.RecordAppliedSource(
                     pair.Key,
                     pair.Value.Hash,
                     pair.Value.IsFullyApplied);
@@ -139,7 +148,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 methods: _outcomes,
                 warnings: _warnings,
                 patchedTotal: _patchedTotal,
-                activePatchTotal: HotReloadCompositionRoot.Services.Patcher.ActiveChangeCount,
+                activePatchTotal: _patcher.ActiveChangeCount,
                 suppressedPausePointIds: _suppressedPausePointIds,
                 unchangedTotal: _unchangedTotal,
                 retargetedPausePointIds: _retargetedPausePointIds,

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadServices.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadServices.cs
@@ -15,6 +15,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             HotReloadFileEntryApplier fileEntryApplier,
             HotReloadEntryApplier entryApplier,
             TransformWorkerClient transformWorkerClient,
+            HotReloadGroupStageCollaborators groupStageCollaborators,
             HotReloadGroupCommitStage groupCommitStage,
             HotReloadGroupProcessor groupProcessor,
             IHotReloadOrchestrator orchestrator,
@@ -29,6 +30,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             Debug.Assert(fileEntryApplier != null, "fileEntryApplier must not be null.");
             Debug.Assert(entryApplier != null, "entryApplier must not be null.");
             Debug.Assert(transformWorkerClient != null, "transformWorkerClient must not be null.");
+            Debug.Assert(
+                groupStageCollaborators != null, "groupStageCollaborators must not be null.");
             Debug.Assert(groupCommitStage != null, "groupCommitStage must not be null.");
             Debug.Assert(groupProcessor != null, "groupProcessor must not be null.");
             Debug.Assert(orchestrator != null, "orchestrator must not be null.");
@@ -43,6 +46,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             FileEntryApplier = fileEntryApplier;
             EntryApplier = entryApplier;
             TransformWorkerClient = transformWorkerClient;
+            GroupStageCollaborators = groupStageCollaborators;
             GroupCommitStage = groupCommitStage;
             GroupProcessor = groupProcessor;
             Orchestrator = orchestrator;
@@ -63,6 +67,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         internal HotReloadEntryApplier EntryApplier { get; }
 
         internal TransformWorkerClient TransformWorkerClient { get; }
+
+        /// <summary>
+        /// The collaborators one group run's stages were bound to. Kept here so a test that calls
+        /// a stage directly passes the same bundle the installed run uses.
+        /// </summary>
+        internal HotReloadGroupStageCollaborators GroupStageCollaborators { get; }
 
         internal HotReloadGroupCommitStage GroupCommitStage { get; }
 
@@ -92,6 +102,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 FileEntryApplier,
                 EntryApplier,
                 TransformWorkerClient,
+                GroupStageCollaborators,
                 GroupCommitStage,
                 GroupProcessor,
                 orchestrator,
@@ -114,6 +125,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 FileEntryApplier,
                 EntryApplier,
                 TransformWorkerClient,
+                GroupStageCollaborators,
                 GroupCommitStage,
                 GroupProcessor,
                 Orchestrator,

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadShimFirstCompile.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadShimFirstCompile.cs
@@ -18,15 +18,17 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         // Why a helper: the gate-retry / empty-entries / first-pass compile fork is one
         // entries-to-patch stage and kept the group pipeline over CA1502.
         internal static async Task<HotReloadGroupCompileResult> ResolveEntriesToPatchAsync(
+            HotReloadGroupStageCollaborators collaborators,
             HotReloadApplyContext context,
             HotReloadSignatureChangeGate.SignatureChangeGateResult gateResult,
             CancellationToken ct)
         {
+            Debug.Assert(collaborators != null, "collaborators must not be null.");
             Debug.Assert(context != null, "context must not be null.");
             Debug.Assert(gateResult != null, "gateResult must not be null.");
 
             await MainThreadSwitcher.SwitchToMainThread(ct);
-            if (!HotReloadGroupProcessor.TryAppendNewSourceMembershipFailure(context.Files))
+            if (!HotReloadGroupProcessor.TryAppendNewSourceMembershipFailure(collaborators, context.Files))
             {
                 return HotReloadGroupCompileResult.Failed();
             }
@@ -54,17 +56,17 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 // Why a run that commits types skips it: clearing a generation here would mutate
                 // the domain before the commit boundary, which a failed recheck could then no
                 // longer undo, so such a run clears at the boundary instead.
-                if (!HotReloadCompositionRoot.Services.GroupCommitStage.CommitsIntroducedTypes(
+                if (!collaborators.CommitPolicy.CommitsIntroducedTypes(
                         context.PreparedIntroducedTypes,
                         context.AssemblyName))
                 {
-                    HotReloadCompositionRoot.Services.GroupCommitStage.ClearEmptyFileGenerations(context);
+                    collaborators.CommitPolicy.ClearEmptyFileGenerations(context);
                 }
 
                 return HotReloadGroupCompileResult.ReadyWithoutMethods();
             }
 
-            return await CompileShimForGroupAsync(context, ct).ConfigureAwait(false);
+            return await CompileShimForGroupAsync(collaborators, context, ct).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -73,6 +75,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         /// they already consumed the one worker retry.
         /// </summary>
         private static async Task<HotReloadGroupCompileResult> CompileShimForGroupAsync(
+            HotReloadGroupStageCollaborators collaborators,
             HotReloadApplyContext context,
             CancellationToken ct)
         {
@@ -119,6 +122,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             // third worker run. Gate retry compile failures return Failed from the gate and
             // never reach this first-compile path.
             HotReloadShimIsolation.HotReloadShimIsolationResult isolation = await HotReloadShimIsolation.TryIsolateShimCompileFailureAsync(
+                collaborators.TransformWorkerClient,
                 context.WorkerInput,
                 workerOutput,
                 compileResult,

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadShimIsolation.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadShimIsolation.cs
@@ -27,6 +27,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         /// Failed outcome per file (method-attributed when the group holds a single entry).
         /// </summary>
         internal static async Task<HotReloadShimIsolationResult> TryIsolateShimCompileFailureAsync(
+            TransformWorkerClient transformWorkerClient,
             TransformWorkerInputDto workerInput,
             TransformWorkerOutputDto workerOutput,
             HotReloadShimCompileResult compileResult,
@@ -85,6 +86,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 groupFilePaths,
                 correlationId);
             IsolationRetryRunResult retry = await RunIsolationRetryAsync(
+                transformWorkerClient,
                 retryContext,
                 exclusions,
                 failedMethodOutcomes,
@@ -96,6 +98,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         }
 
         internal static async Task<IsolationRetryRunResult> RunIsolationRetryAsync(
+            TransformWorkerClient transformWorkerClient,
             HotReloadIsolationRetryContext context,
             IsolationExclusions exclusions,
             List<HotReloadMethodOutcome> failedMethodOutcomes,
@@ -129,7 +132,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             };
 
             TransformWorkerClientResult retryWorkerResult =
-                await HotReloadCompositionRoot.Services.TransformWorkerClient.RunAsync(retryInput, ct).ConfigureAwait(false);
+                await transformWorkerClient.RunAsync(retryInput, ct).ConfigureAwait(false);
             if (!retryWorkerResult.Success)
             {
                 HotReloadOrchestratorLog.LogHotReloadIsolationRetry(

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadSiblingRebindReporter.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadSiblingRebindReporter.cs
@@ -11,6 +11,14 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     /// </summary>
     internal sealed class HotReloadSiblingRebindReporter
     {
+        private readonly HotReloadDomain _domain;
+
+        internal HotReloadSiblingRebindReporter(HotReloadDomain domain)
+        {
+            Debug.Assert(domain != null, "domain must not be null.");
+            _domain = domain;
+        }
+
         // Why the resolver arrives per call: the reporter holds no collaborator of its own, and
         // the orchestrator already owns the one resolver this run uses.
         internal void AppendActiveSiblingsToGroup(
@@ -22,6 +30,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         {
             HotReloadGroupFile firstFile = filesOfGroup[0];
             HotReloadActiveSiblingRebindPlan rebind = HotReloadActiveSiblingRebindPlanner.Plan(
+                _domain,
                 firstFile.AssemblyName,
                 firstFile.CompilationAssembly.sourceFiles,
                 pathsInRun,

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadSignatureChangeGate.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadSignatureChangeGate.cs
@@ -17,9 +17,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         /// trigger means the scanner is not called.
         /// </summary>
         internal static async Task<SignatureChangeGateResult> TryApplySignatureChangeGateAsync(
+            HotReloadGroupStageCollaborators collaborators,
             HotReloadApplyContext context,
             CancellationToken ct)
         {
+            Debug.Assert(collaborators != null, "collaborators must not be null.");
             Debug.Assert(context != null, "context must not be null.");
             TransformWorkerEntryDto[] entries = context.WorkerOutput.entries ?? Array.Empty<TransformWorkerEntryDto>();
             TransformWorkerRemovedMethodSignatureDto[] removedSignatures = context.RemovedMethodSignatures;
@@ -67,6 +69,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     entries,
                     context.WorkerOutput.unchangedMethods ?? Array.Empty<TransformWorkerUnchangedMethodDto>());
             List<HotReloadMethodOutcome> skippedOutcomes = BuildGatedReplacementSkipOutcomes(
+                collaborators.Domain,
                 gatedReplacements,
                 uncoveredCallersByTarget,
                 editedFileMethodIdentitiesByFile,
@@ -86,6 +89,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 context.GroupFilePaths,
                 context.CorrelationId);
             HotReloadShimIsolation.IsolationRetryRunResult retry = await HotReloadShimIsolation.RunIsolationRetryAsync(
+                collaborators.TransformWorkerClient,
                 retryContext,
                 exclusions,
                 new List<HotReloadMethodOutcome>(),
@@ -263,11 +267,13 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         }
 
         internal static List<HotReloadMethodOutcome> BuildGatedReplacementSkipOutcomes(
+            HotReloadDomain domain,
             IReadOnlyList<TransformWorkerEntryDto> gatedReplacements,
             Dictionary<string, List<HotReloadQualifiedMethodIdentity>> uncoveredCallersByTarget,
             Dictionary<string, HashSet<HotReloadQualifiedMethodIdentity>> editedFileMethodIdentitiesByFile,
             HotReloadGroupFilePaths groupFilePaths)
         {
+            Debug.Assert(domain != null, "domain must not be null.");
             List<HotReloadMethodOutcome> outcomes = new List<HotReloadMethodOutcome>();
             foreach (TransformWorkerEntryDto entry in gatedReplacements)
             {
@@ -278,7 +284,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 // this gate, so the previous apply's added members are still listed here.
                 // Why the entry's own file: a group run gates the replacements of several files,
                 // and a member is active per file.
-                if (HotReloadCompositionRoot.Services.Domain.IsActiveMember(
+                if (domain.IsActiveMember(
                         entry.sourceProjectRelativePath,
                         methodLabel))
                 {

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadStalePatchOutcomes.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadStalePatchOutcomes.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
 
+using UnityEngine;
+
 namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 {
     /// <summary>
@@ -11,6 +13,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     internal static class HotReloadStalePatchOutcomes
     {
         public static void Append(
+            HotReloadPatcher patcher,
             List<HotReloadMethodOutcome> outcomes,
             TransformWorkerOutputDto workerOutput,
             TransformWorkerRemovedMethodSignatureDto[] removedMethodSignatures,
@@ -18,6 +21,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             string projectRelativePath,
             string assemblyResolvePath)
         {
+            Debug.Assert(patcher != null, "patcher must not be null.");
             if (workerOutput == null
                 || removedMethodSignatures == null || removedMethodSignatures.Length == 0)
             {
@@ -25,7 +29,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             HashSet<string> activeDisplayKeys = new HashSet<string>(
-                HotReloadCompositionRoot.Services.Patcher.ListActiveMethodKeys(projectRelativePath),
+                patcher.ListActiveMethodKeys(projectRelativePath),
                 StringComparer.Ordinal);
             if (activeDisplayKeys.Count == 0)
             {

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadStatusExecutor.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadStatusExecutor.cs
@@ -48,7 +48,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 Warnings = warnings,
                 // Why the rows too: a total without them names nothing, so a caller told that
                 // types stayed loaded could not tell which ones a revert left behind.
-                IntroducedTypes = HotReloadIntroducedTypeStatusSection.BuildActiveRows(),
+                IntroducedTypes = HotReloadIntroducedTypeStatusSection.BuildActiveRows(_domain),
                 ActiveIntroducedTypeTotal = snapshot.IntroducedTypeCount,
                 Message = HotReloadIntroducedTypeStatusSection.AppendRevertAllNote(
                     clearedCount == 0
@@ -142,7 +142,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 Success = true,
                 Methods = methods,
                 Warnings = warnings,
-                IntroducedTypes = HotReloadIntroducedTypeStatusSection.BuildActiveRows(),
+                IntroducedTypes = HotReloadIntroducedTypeStatusSection.BuildActiveRows(_domain),
                 ActiveIntroducedTypeTotal = snapshot.IntroducedTypeCount,
                 ActivePatchTotal = count,
                 AddedFieldTotal = addedFields.Count,

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadSupersededSignatureRecorder.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadSupersededSignatureRecorder.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
 
+using UnityEngine;
+
 namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 {
     /// <summary>
@@ -15,11 +17,13 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         /// compiled signature it would have superseded.
         /// </remarks>
         public static void RecordFromAppliedEntries(
+            HotReloadDomain domain,
             string projectRelativePath,
             IReadOnlyList<TransformWorkerEntryDto> appliedEntries,
             IReadOnlyList<TransformWorkerRemovedMethodSignatureDto> removedMethodSignatures,
             IReadOnlyCollection<string> gatedReplacementMethodKeys)
         {
+            Debug.Assert(domain != null, "domain must not be null.");
             if (appliedEntries == null || removedMethodSignatures == null)
             {
                 return;
@@ -28,7 +32,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             // Why the file's own generation: the signature a patch superseded belongs to the file
             // whose apply superseded it, and is discarded with that file's generation.
             HotReloadFileGeneration generation =
-                HotReloadCompositionRoot.Services.Domain.FindGeneration(projectRelativePath);
+                domain.FindGeneration(projectRelativePath);
             if (generation == null)
             {
                 return;

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadTools.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadTools.cs
@@ -195,6 +195,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     || (parameters.Files != null && parameters.Files.Length > 0))
                 {
                     return CreateValidationFailure(
+                        services,
                         new HotReloadValidationFailure(
                             "--status cannot be combined with --files or --revert-all.",
                             HotReloadValidationErrorCodes.StatusConflict,
@@ -216,7 +217,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             HotReloadValidationFailure validationFailure = ValidateApplyParameters(parameters);
             if (validationFailure != null)
             {
-                return CreateValidationFailure(validationFailure);
+                return CreateValidationFailure(services, validationFailure);
             }
 
             // Why here and not only at the run entry: the tool normalizes script paths for its own
@@ -227,7 +228,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 services.ChangeDetector.Detect);
             if (selection.ValidationFailure != null)
             {
-                return CreateValidationFailure(selection.ValidationFailure);
+                return CreateValidationFailure(services, selection.ValidationFailure);
             }
 
             HotReloadOrchestratorResult result = await services.Orchestrator
@@ -239,7 +240,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 result.Methods,
                 result.IntroducedTypes);
 
-            HotReloadResponse response = BuildApplyResponse(result, selection.ScanLimitWarnings);
+            HotReloadResponse response = HotReloadApplyResponseBuilder.Build(
+                services,
+                result,
+                selection.ScanLimitWarnings);
             if (!string.IsNullOrEmpty(selection.SelectionMessage))
             {
                 response.Message = selection.SelectionMessage + " " + response.Message;
@@ -274,21 +278,30 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return null;
         }
 
+        // Why this reads the services itself: the apply path above passes the services it read
+        // at its own entry, and this shim exists only for callers that hold a result but not the
+        // run that produced it.
         internal static HotReloadResponse BuildApplyResponse(
             HotReloadOrchestratorResult result,
             IReadOnlyList<string> additionalWarnings = null)
         {
-            return HotReloadApplyResponseBuilder.Build(result, additionalWarnings);
+            return HotReloadApplyResponseBuilder.Build(
+                HotReloadCompositionRoot.Services,
+                result,
+                additionalWarnings);
         }
 
-        private static HotReloadResponse CreateValidationFailure(HotReloadValidationFailure failure)
+        private static HotReloadResponse CreateValidationFailure(
+            HotReloadServices services,
+            HotReloadValidationFailure failure)
         {
+            Debug.Assert(services != null, "services must not be null.");
             Debug.Assert(failure != null, "failure must not be null.");
             // Why two numbers from one read: the suffix warns that the refusal left something
             // live, and an introduced type is live even when nothing is patched. ActivePatchTotal
             // counts patched methods and added members, which is what callers read it against
             // PatchedTotal for; the runtime total adds the introduced types on top.
-            HotReloadActiveChangeSnapshot snapshot = HotReloadCompositionRoot.Services.Domain.CountActiveChanges();
+            HotReloadActiveChangeSnapshot snapshot = services.Domain.CountActiveChanges();
             int activePatchTotal = snapshot.PatchAndAddedMemberCount;
             int runtimeChangeTotal = snapshot.RuntimeChangeTotal;
             string message = failure.Message;

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadUnpatchedMethodLineShiftWarningBuilder.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadUnpatchedMethodLineShiftWarningBuilder.cs
@@ -49,12 +49,16 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             IReadOnlyList<HotReloadMethodOutcome> methods,
             Func<string, string> readEditedSource,
             Func<string, string> readCompiledSource,
+            Func<string, string> toProjectRelativeScriptPath,
             IReadOnlyCollection<string> reappliedSiblingPaths)
         {
             Debug.Assert(warnings != null, "warnings must not be null.");
             Debug.Assert(methods != null, "methods must not be null.");
             Debug.Assert(readEditedSource != null, "readEditedSource must not be null.");
             Debug.Assert(readCompiledSource != null, "readCompiledSource must not be null.");
+            Debug.Assert(
+                toProjectRelativeScriptPath != null,
+                "toProjectRelativeScriptPath must not be null.");
             Debug.Assert(reappliedSiblingPaths != null, "reappliedSiblingPaths must not be null.");
 
             StringComparer fileComparer = Application.platform == RuntimePlatform.WindowsEditor
@@ -63,6 +67,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             List<LineShiftFileBucket> buckets = CollectUniqueFileBuckets(
                 methods,
                 reappliedSiblingPaths,
+                toProjectRelativeScriptPath,
                 fileComparer);
             List<string> continuingFiles = new List<string>();
             for (int index = 0; index < buckets.Count; index++)
@@ -98,11 +103,15 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         private static List<LineShiftFileBucket> CollectUniqueFileBuckets(
             IReadOnlyList<HotReloadMethodOutcome> methods,
             IReadOnlyCollection<string> reappliedSiblingPaths,
+            Func<string, string> toProjectRelativeScriptPath,
             StringComparer fileComparer)
         {
             List<LineShiftFileBucket> buckets = new List<LineShiftFileBucket>();
             Dictionary<string, LineShiftFileBucket> byFile = new Dictionary<string, LineShiftFileBucket>(fileComparer);
-            HashSet<string> siblingKeys = BuildReappliedSiblingKeys(reappliedSiblingPaths, fileComparer);
+            HashSet<string> siblingKeys = BuildReappliedSiblingKeys(
+                reappliedSiblingPaths,
+                toProjectRelativeScriptPath,
+                fileComparer);
             for (int index = 0; index < methods.Count; index++)
             {
                 string filePath = methods[index].FilePath;
@@ -111,7 +120,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     continue;
                 }
 
-                string canonicalFile = HotReloadPatchTargetSupport.ToProjectRelativeScriptPath(filePath);
+                string canonicalFile = toProjectRelativeScriptPath(filePath);
                 if (!byFile.TryGetValue(canonicalFile, out LineShiftFileBucket bucket))
                 {
                     bucket = new LineShiftFileBucket { CanonicalFile = canonicalFile };
@@ -133,6 +142,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
         private static HashSet<string> BuildReappliedSiblingKeys(
             IReadOnlyCollection<string> reappliedSiblingPaths,
+            Func<string, string> toProjectRelativeScriptPath,
             StringComparer fileComparer)
         {
             HashSet<string> keys = new HashSet<string>(fileComparer);
@@ -143,7 +153,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     continue;
                 }
 
-                keys.Add(HotReloadPatchTargetSupport.ToProjectRelativeScriptPath(path));
+                keys.Add(toProjectRelativeScriptPath(path));
             }
 
             return keys;


### PR DESCRIPTION
## Summary
- No user-visible change. This is an internal refactor of the hot-reload subsystem.

## User Impact
- Before: production hot-reload code resolved its collaborators from the composition root deep inside a run, so a run could observe a services replacement that closed half-way through it.
- After: a run is bound to one set of collaborators at its entry, so its behaviour no longer depends on when a replacement scope opens or closes.

## Changes
- Add `HotReloadGroupStageCollaborators`, an immutable bundle of the collaborators that are ready before the group dependencies are built, and pass it explicitly to the group stages.
- Extract `HotReloadGroupCommitPolicy` (depends only on the domain and the file entry applier) to break the construction-order cycle between the dependencies and the commit stage. The commit stage uses the same policy instance, so there is no second implementation.
- Take the domain, patcher and captures as parameters in the remaining hot-reload types instead of resolving them from the composition root.
- Keep the two `EditorApplication` callbacks resolving the services lazily through a `Func<HotReloadServices>` provider, because the domain test scope replaces the installed services after startup has run.
- Expose `HotReloadServices.GroupStageCollaborators` so a test that calls a stage outside a dependency-building callback can pass the same bundle the installed run uses.

Remaining `HotReloadCompositionRoot.Services` reads in production are the entry points only: `HotReloadEditorStartup` (provider wiring), `HotReloadTools` (read once at the tool entry and passed down, plus the documented apply-response shim), and a comment mention in `HotReloadDomain`.

## Test follow-ups caused by the `buildDependencies` signature change
The dependency-building callback now receives the collaborators bundle, so these test files were updated:

- `HotReloadServicesTestScope` — callback type now takes the bundle.
- `HotReloadIntroducedTypeActivationTests` — 11 dependency-building helpers take the bundle; method groups became lambdas.
- `HotReloadIntroducedTypeResponseTests` — 4 dependency-building helpers take the bundle.
- `HotReloadGroupProcessorTests`, `HotReloadOrchestratorTests` — direct stage/ctor calls now pass the bundle or the individual services members.
- `HotReloadSupersededSignatureRecorderTests`, `HotReloadSignatureChangeCoverageTests`, `HotReloadRetainedArtifactPropagationTests`, `HotReloadAssemblyResolutionDiagnosticsTests`, `HotReloadNewSourceMembershipTests`, `HotReloadPatchTargetSupportPathTests`, `HotReloadCrossFileE2ETests`, `HotReloadIntroducedTypeHoldTests` — direct static/ctor calls updated with the corresponding arguments.
- `HotReloadUnpatchedMethodLineShiftWarningBuilderTests` — the 9 `Append` calls pass the project-relative path conversion the production response builder uses.

## Verification
- `uloop compile`: 0 errors.
- `uloop run-tests --filter-type regex --filter-value '.*HotReload.*'`: 1194 / 1194 passed, 0 failed.
- `CODE_FILE_LENGTH_MAX_LENGTH=400 sh scripts/check-file-length.sh`: no file touched by this change appears in the findings.
- `CODE_FILE_LENGTH_FAIL_ON_EXCEEDED=true sh scripts/check-file-length.sh`: exit 0.
- `go run ./cmd/check-asmdef-policy`: no violation.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2738?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

