### PR TITLE
fix: Hot reload stops an invalid patch instead of reporting a change that is not live

### DIFF
--- a/Assets/Tests/Editor/HotReload/HotReloadFileGenerationContractTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadFileGenerationContractTests.cs
@@ -1,0 +1,173 @@
+using System;
+using System.Reflection;
+
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
+{
+    /// <summary>
+    /// The invariants one file's hot-reload generation refuses to break. Each condition gets its
+    /// own test, so a rejection that covers two of them cannot hide a missing check.
+    /// </summary>
+    public class HotReloadFileGenerationContractTests
+    {
+        private const string FixtureProjectRelativePath =
+            "Assets/Tests/Editor/HotReload/FileGenerationContractFixture.cs";
+        private const string AddedMethodKey = "FileGenerationContractFixture.AddedMember()";
+
+        // Any non-empty byte array satisfies a shim generation no test loads bytes from.
+        private static readonly byte[] PlaceholderAssemblyBytes = { 0x4D, 0x5A };
+
+        /// <summary>
+        /// What: a patch of a method whose shim this generation never registered is refused, which
+        /// is the invariant that every patch is a patch of a method the edited source declares.
+        /// </summary>
+        [Test]
+        public void BeginPatch_WithoutARegisteredShim_Throws()
+        {
+            HotReloadFileGeneration generation = CreateStartedGeneration();
+
+            Assert.Throws<InvalidOperationException>(
+                () => generation.BeginPatch(GetShimTarget(), GetAddedTarget()));
+            Assert.That(generation.HasPatch(GetShimTarget()), Is.False);
+        }
+
+        /// <summary>
+        /// What: opening a second patch of a method that already holds a pending one is refused, so
+        /// a pending entry a Harmony call is still reading cannot be replaced under it.
+        /// </summary>
+        [Test]
+        public void BeginPatch_WhenThePatchIsPending_Throws()
+        {
+            HotReloadFileGeneration generation = CreateStartedGeneration();
+            RegisterShim(generation);
+            generation.BeginPatch(GetShimTarget(), GetAddedTarget());
+
+            Assert.Throws<InvalidOperationException>(
+                () => generation.BeginPatch(GetShimTarget(), GetAddedTarget()));
+            Assert.That(generation.IsPatchPending(GetShimTarget()), Is.True);
+        }
+
+        /// <summary>
+        /// What: opening a patch of a method that already holds a live one is refused, so a
+        /// re-apply that skipped the deactivation cannot lose the live entry.
+        /// </summary>
+        [Test]
+        public void BeginPatch_WhenThePatchIsActive_Throws()
+        {
+            HotReloadFileGeneration generation = CreateStartedGeneration();
+            RegisterShim(generation);
+            generation.BeginPatch(GetShimTarget(), GetAddedTarget());
+            generation.CommitPatch(GetShimTarget());
+
+            Assert.Throws<InvalidOperationException>(
+                () => generation.BeginPatch(GetShimTarget(), GetAddedTarget()));
+            Assert.That(generation.IsPatchActive(GetShimTarget()), Is.True);
+        }
+
+        /// <summary>
+        /// What: committing a patch that was never opened is refused, so a run cannot report a
+        /// live patch Harmony was never asked to install.
+        /// </summary>
+        [Test]
+        public void CommitPatch_WithoutAPendingPatch_Throws()
+        {
+            HotReloadFileGeneration generation = CreateStartedGeneration();
+            RegisterShim(generation);
+
+            Assert.Throws<InvalidOperationException>(() => generation.CommitPatch(GetShimTarget()));
+            Assert.That(generation.IsPatchActive(GetShimTarget()), Is.False);
+        }
+
+        /// <summary>
+        /// What: registering a shim before the shim generation is opened is refused, so a
+        /// registration cannot land in a generation the next apply run will not clear.
+        /// </summary>
+        [Test]
+        public void RegisterShimMethod_BeforeTheGenerationIsOpened_Throws()
+        {
+            HotReloadFileGeneration generation = new HotReloadFileGeneration(FixtureProjectRelativePath);
+
+            Assert.Throws<InvalidOperationException>(() => RegisterShim(generation));
+            Assert.That(generation.FindShim(GetShimTarget()), Is.Null);
+        }
+
+        /// <summary>
+        /// What: registering an added member before the added-member generation is opened is
+        /// refused, for the same reason the shim registration is.
+        /// </summary>
+        [Test]
+        public void RegisterAddedMethod_BeforeTheGenerationIsOpened_Throws()
+        {
+            HotReloadFileGeneration generation = new HotReloadFileGeneration(FixtureProjectRelativePath);
+
+            Assert.Throws<InvalidOperationException>(
+                () => generation.RegisterAddedMethod(
+                    AddedMethodKey,
+                    GetAddedTarget(),
+                    FixtureProjectRelativePath));
+            Assert.That(generation.AddedMemberCount, Is.EqualTo(0));
+        }
+
+        /// <summary>
+        /// What: dropping the shim of a method whose patch is still live is refused, because that
+        /// is the operation that would leave a live patch of a method with no registered shim.
+        /// </summary>
+        [Test]
+        public void RemoveShimMethod_WhileThePatchIsActive_Throws()
+        {
+            HotReloadFileGeneration generation = CreateStartedGeneration();
+            RegisterShim(generation);
+            generation.BeginPatch(GetShimTarget(), GetAddedTarget());
+            generation.CommitPatch(GetShimTarget());
+
+            Assert.Throws<InvalidOperationException>(
+                () => generation.RemoveShimMethod(GetShimTarget()));
+            Assert.That(generation.FindShim(GetShimTarget()), Is.Not.Null);
+        }
+
+        private static HotReloadFileGeneration CreateStartedGeneration()
+        {
+            HotReloadFileGeneration generation =
+                new HotReloadFileGeneration(FixtureProjectRelativePath);
+            generation.BeginShimGeneration(
+                PlaceholderAssemblyBytes,
+                null,
+                typeof(HotReloadFileGenerationContractTests).Assembly);
+            return generation;
+        }
+
+        private static void RegisterShim(HotReloadFileGeneration generation)
+        {
+            generation.RegisterShimMethod(
+                GetShimTarget(),
+                new HotReloadShimMethodEntry(GetAddedTarget(), false, 1, 2));
+        }
+
+        private static MethodInfo GetShimTarget()
+        {
+            return typeof(HotReloadFileGenerationContractTests).GetMethod(
+                nameof(ShimTarget),
+                BindingFlags.Static | BindingFlags.NonPublic);
+        }
+
+        private static MethodInfo GetAddedTarget()
+        {
+            return typeof(HotReloadFileGenerationContractTests).GetMethod(
+                nameof(AddedTarget),
+                BindingFlags.Static | BindingFlags.NonPublic);
+        }
+
+        private static int ShimTarget()
+        {
+            return 1;
+        }
+
+        private static int AddedTarget()
+        {
+            return 2;
+        }
+    }
+}

--- a/Assets/Tests/Editor/HotReload/HotReloadFileGenerationContractTests.cs.meta
+++ b/Assets/Tests/Editor/HotReload/HotReloadFileGenerationContractTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6e6d98582a0c941e0b2d8f53d4d1cb1d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/HotReload/HotReloadPatcherContractTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadPatcherContractTests.cs
@@ -1,0 +1,233 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+using HarmonyLib;
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
+{
+    /// <summary>
+    /// What the patcher guarantees about the domain when Harmony refuses a call, and what the
+    /// totals a report prints are counted from. The failure guarantees are asserted one per test,
+    /// so a state that happens to be right for an unrelated reason cannot hide a missing check.
+    /// </summary>
+    public class HotReloadPatcherContractTests
+    {
+        private const string FixtureProjectRelativePath = "Assets/Tests/Fixture.cs";
+        private const string AddedFieldOnlyPath =
+            "Assets/Tests/Editor/HotReload/PatcherContractAddedFieldHost.cs";
+
+        /// <summary>Refuses every patch, so the apply path's failure branch is the one under test.</summary>
+        private sealed class RefusingPatchHarmony : IHotReloadHarmony
+        {
+            public void Patch(MethodBase original, HarmonyMethod transpiler)
+            {
+                throw new InvalidOperationException("patch refused");
+            }
+
+            public void Unpatch(MethodBase original, HarmonyPatchType patchType, string harmonyId)
+            {
+            }
+
+            public void UnpatchAll(string harmonyId)
+            {
+            }
+        }
+
+        /// <summary>
+        /// What: a refused patch leaves no generation claiming the method, so a failed apply cannot
+        /// be reported as an applied change.
+        /// </summary>
+        [Test]
+        public void Apply_WhenHarmonyRefusesThePatch_LeavesNoActivePatch()
+        {
+            using (BeginReplacementWith(new RefusingPatchHarmony()))
+            {
+                HotReloadDomainTestAccess access = new HotReloadDomainTestAccess();
+                Assert.That(
+                    access.ApplyPatch(
+                        GetPatchTarget(),
+                        GetShim(),
+                        HotReloadPatchShape.Transplant,
+                        FixtureProjectRelativePath).Success,
+                    Is.False,
+                    "Precondition: the harmony double has to refuse this patch.");
+
+                Assert.That(access.Domain.ActivePatchCount, Is.EqualTo(0));
+                Assert.That(
+                    access.Domain.FindGeneration(FixtureProjectRelativePath).IsPatchActive(GetPatchTarget()),
+                    Is.False);
+            }
+        }
+
+        /// <summary>
+        /// What: a refused patch keeps the shim the apply run registered, because the generation is
+        /// what a later attempt on the same file resolves that shim from.
+        /// </summary>
+        [Test]
+        public void Apply_WhenHarmonyRefusesThePatch_KeepsTheShimRegistration()
+        {
+            using (BeginReplacementWith(new RefusingPatchHarmony()))
+            {
+                HotReloadDomainTestAccess access = new HotReloadDomainTestAccess();
+                access.ApplyPatch(
+                    GetPatchTarget(),
+                    GetShim(),
+                    HotReloadPatchShape.Transplant,
+                    FixtureProjectRelativePath);
+
+                Assert.That(
+                    access.Domain.FindGeneration(FixtureProjectRelativePath).FindShim(GetPatchTarget()),
+                    Is.EqualTo(GetShim()));
+            }
+        }
+
+        /// <summary>
+        /// What: a refused patch leaves no invocation count behind, so a report cannot show calls
+        /// against a patch that never went live.
+        /// </summary>
+        [Test]
+        public void Apply_WhenHarmonyRefusesThePatch_LeavesNoInvocationCount()
+        {
+            using (BeginReplacementWith(new RefusingPatchHarmony()))
+            {
+                string methodKey = HotReloadMethodKeys.FormatMethodLabel(GetPatchTarget());
+                HotReloadInvocationRegistry.Increment(methodKey);
+                Assert.That(
+                    HotReloadInvocationRegistry.GetCount(methodKey),
+                    Is.EqualTo(1L),
+                    "Precondition: a count has to exist for the failed apply to clear.");
+
+                new HotReloadDomainTestAccess().ApplyPatch(
+                    GetPatchTarget(),
+                    GetShim(),
+                    HotReloadPatchShape.Transplant,
+                    FixtureProjectRelativePath);
+
+                Assert.That(HotReloadInvocationRegistry.GetCount(methodKey), Is.EqualTo(0L));
+            }
+        }
+
+        /// <summary>
+        /// What: by the time RevertAll tells pause point a method is no longer patched, the domain
+        /// has already dropped that method — the order pause point re-instruments its markers in.
+        /// </summary>
+        [Test]
+        public void RevertAll_TellsPausePointOnlyAfterTheDomainHasDroppedTheMethod()
+        {
+            using (new HotReloadDomainTestScope())
+            {
+                MethodInfo patched = GetPatchTarget();
+                Assert.That(
+                    new HotReloadDomainTestAccess().ApplyPatch(
+                        patched,
+                        GetShim(),
+                        HotReloadPatchShape.Transplant,
+                        FixtureProjectRelativePath).Success,
+                    Is.True,
+                    "Precondition: a live patch is what RevertAll then reports.");
+
+                List<bool> generationStillClaimedTheMethod = new List<bool>();
+                using (PausePointSidePortScope portScope = new PausePointSidePortScope())
+                {
+                    portScope.Port.HotReloadPatchStateChanged = (method, isPatched) =>
+                    {
+                        if (isPatched || !ReferenceEquals(method, patched))
+                        {
+                            return;
+                        }
+
+                        generationStillClaimedTheMethod.Add(
+                            HotReloadCompositionRoot.Services.Domain.FindGenerationForMethod(method) != null);
+                    };
+
+                    HotReloadCompositionRoot.Services.Patcher.RevertAll();
+                }
+
+                Assert.That(
+                    generationStillClaimedTheMethod,
+                    Is.EqualTo(new[] { false }),
+                    "The revert has to be reported exactly once, with the domain already emptied.");
+            }
+        }
+
+        /// <summary>
+        /// What: the active-change total counts patches and added members only, so a domain that
+        /// also carries added fields still totals exactly the rows that are not added fields.
+        /// </summary>
+        [Test]
+        public void CountActiveChanges_WithAnAddedFieldGeneration_MatchesTheNonFieldStatusRows()
+        {
+            using (new HotReloadDomainTestScope())
+            {
+                HotReloadDomainTestAccess access = new HotReloadDomainTestAccess();
+                Assert.That(
+                    access.ApplyPatch(
+                        GetPatchTarget(),
+                        GetShim(),
+                        HotReloadPatchShape.Transplant,
+                        FixtureProjectRelativePath).Success,
+                    Is.True);
+                access.ReplaceAddedFields(
+                    AddedFieldOnlyPath,
+                    new[] { "PatcherContractAddedFieldHost.count" });
+
+                HotReloadResponse status = HotReloadCompositionRoot.Services.StatusExecutor.ExecuteStatus();
+
+                Assert.That(
+                    status.AddedFieldTotal,
+                    Is.EqualTo(1),
+                    "Precondition: the added-field generation has to reach the report.");
+                Assert.That(
+                    access.Domain.CountActiveChanges().PatchAndAddedMemberCount,
+                    Is.EqualTo(CountRowsExcludingAddedFields(status)));
+                Assert.That(status.ActivePatchTotal, Is.EqualTo(CountRowsExcludingAddedFields(status)));
+            }
+        }
+
+        private static int CountRowsExcludingAddedFields(HotReloadResponse status)
+        {
+            int count = 0;
+            foreach (HotReloadMethodResult row in status.Methods)
+            {
+                if (row.Kind != HotReloadConstants.AddedFieldKind)
+                {
+                    count++;
+                }
+            }
+
+            return count;
+        }
+
+        private static IDisposable BeginReplacementWith(IHotReloadHarmony harmony)
+        {
+            HotReloadPackageRootCapture packageRootCapture = new HotReloadPackageRootCapture();
+            packageRootCapture.CaptureCurrent();
+            return HotReloadCompositionRoot.BeginReplacement(
+                HotReloadCompositionRoot.CreateServices(
+                    HotReloadCompositionRoot.CreateProductionDomain(),
+                    harmony,
+                    packageRootCapture,
+                    new HotReloadEditorStateSnapshotCapture(),
+                    TransformWorkerHost.Shared,
+                    HotReloadGroupProcessorDependencies.CreateProduction));
+        }
+
+        private static MethodInfo GetPatchTarget()
+        {
+            return AccessTools.Method(
+                typeof(HotReloadCoreFixture), nameof(HotReloadCoreFixture.ReplaceableCompute));
+        }
+
+        private static MethodInfo GetShim()
+        {
+            return AccessTools.Method(
+                typeof(HotReloadHandwrittenShims),
+                nameof(HotReloadHandwrittenShims.ReplaceableCompute__shim0));
+        }
+    }
+}

--- a/Assets/Tests/Editor/HotReload/HotReloadPatcherContractTests.cs.meta
+++ b/Assets/Tests/Editor/HotReload/HotReloadPatcherContractTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 54fa39408ce574aa484e636b9f057e2d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/HotReload/HotReloadPatcherTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadPatcherTests.cs
@@ -569,12 +569,12 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
-        /// What: a Harmony rebuild failure while reverting keeps the whole ledger entry of the
-        /// still-patched method, including the transplant locals and preamble length that
-        /// pause-point reads when it joins the shim chain.
+        /// What: a Harmony rebuild failure while reverting leaves the method's generation holding
+        /// the patch whole, including the transplant locals and preamble length that pause point
+        /// reads when it joins the shim chain.
         /// </summary>
         [Test]
-        public void Revert_WhenHarmonyCannotRebuild_KeepsTransplantLedgerForTheLivePatch()
+        public void Revert_WhenHarmonyCannotRebuild_KeepsTheLivePatchInItsGeneration()
         {
             MethodInfo failing = AccessTools.Method(
                 typeof(HotReloadCoreFixture), nameof(HotReloadCoreFixture.ReplaceableCompute));
@@ -599,14 +599,18 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                         Is.EqualTo(HotReloadRevertOutcome.UnpatchFailed));
                     harmony.RefuseUnpatch = false;
 
+                    HotReloadFileGeneration generation =
+                        HotReloadCompositionRoot.Services.Domain.FindGenerationForMethod(failing);
+                    Assert.That(generation, Is.Not.Null, "The refused revert must leave the method claimed.");
+                    Assert.That(generation.IsPatchActive(failing), Is.True);
                     Assert.That(
                         HotReloadPausePointCoordination.HotReloadSide.GetTransplantLocals(failing),
                         Is.Not.Null,
-                        "The transpiler is still live, so pause-point must still find its transplant locals.");
+                        "The transpiler is still live, so pause point must still find its transplant locals.");
                     Assert.That(
                         HotReloadPausePointCoordination.HotReloadSide.GetTransplantPreambleLength(failing),
                         Is.GreaterThan(0),
-                        "The retained entry must keep the preamble length pause-point offsets against.");
+                        "The retained patch must keep the preamble length pause point offsets against.");
                 }
                 finally
                 {

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadFileGeneration.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadFileGeneration.cs
@@ -96,7 +96,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         {
             Debug.Assert(originalMethod != null, "originalMethod must not be null.");
             Debug.Assert(entry != null, "entry must not be null.");
-            Debug.Assert(HasShimGeneration, "BeginShimGeneration must run before RegisterShimMethod.");
+            if (!HasShimGeneration)
+            {
+                throw new InvalidOperationException(
+                    "BeginShimGeneration must run before RegisterShimMethod.");
+            }
 
             _shimMethodsByMethod[originalMethod] = entry;
         }
@@ -105,7 +109,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         {
             Debug.Assert(!string.IsNullOrEmpty(methodKey), "methodKey must not be empty.");
             Debug.Assert(shimMethod != null, "shimMethod must not be null.");
-            Debug.Assert(HasAddedMemberGeneration, "BeginAddedMemberGeneration must run before RegisterAddedMethod.");
+            if (!HasAddedMemberGeneration)
+            {
+                throw new InvalidOperationException(
+                    "BeginAddedMemberGeneration must run before RegisterAddedMethod.");
+            }
 
             _addedMembersByMethodKey[methodKey] =
                 new HotReloadAddedMemberInfo(methodKey, filePath ?? string.Empty, shimMethod);
@@ -118,9 +126,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         internal void RemoveShimMethod(MethodBase originalMethod)
         {
             Debug.Assert(originalMethod != null, "originalMethod must not be null.");
-            Debug.Assert(
-                !IsPatchActive(originalMethod),
-                "A method with an active patch must be deactivated before its shim is removed.");
+            if (IsPatchActive(originalMethod))
+            {
+                throw new InvalidOperationException(
+                    "A method with an active patch must be deactivated before its shim is removed.");
+            }
 
             _shimMethodsByMethod.Remove(originalMethod);
         }
@@ -180,12 +190,17 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         {
             Debug.Assert(method != null, "method must not be null.");
             Debug.Assert(shim != null, "shim must not be null.");
-            Debug.Assert(
-                _shimMethodsByMethod.ContainsKey(method),
-                "A shim must be registered for this method before its patch begins.");
-            Debug.Assert(
-                !_patchesByMethod.ContainsKey(method),
-                "This method already holds a pending or active patch.");
+            if (!_shimMethodsByMethod.ContainsKey(method))
+            {
+                throw new InvalidOperationException(
+                    "A shim must be registered for this method before its patch begins.");
+            }
+
+            if (_patchesByMethod.ContainsKey(method))
+            {
+                throw new InvalidOperationException(
+                    "This method already holds a pending or active patch.");
+            }
 
             _patchesByMethod[method] = new HotReloadActivePatchEntry(method, shim);
         }
@@ -196,11 +211,13 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             Debug.Assert(method != null, "method must not be null.");
             if (!_patchesByMethod.TryGetValue(method, out HotReloadActivePatchEntry entry))
             {
-                Debug.Assert(false, "CommitPatch needs a pending patch for this method.");
-                return;
+                throw new InvalidOperationException("CommitPatch needs a pending patch for this method.");
             }
 
-            Debug.Assert(!entry.IsActive, "CommitPatch needs a pending patch, not an active one.");
+            if (entry.IsActive)
+            {
+                throw new InvalidOperationException("CommitPatch needs a pending patch, not an active one.");
+            }
             entry.Activate();
         }
 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadPatcher.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadPatcher.cs
@@ -310,7 +310,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         {
             HotReloadFileGeneration generation = TranspilerDomain.FindGenerationForMethod(original);
             MethodInfo shimMethod = generation?.FindPatchShim(original);
-            Debug.Assert(shimMethod != null, "Shim must be registered before Patch runs.");
             if (shimMethod == null)
             {
                 throw new InvalidOperationException("Shim must be registered before Patch runs.");
@@ -343,17 +342,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         {
             HotReloadFileGeneration generation = TranspilerDomain.FindGenerationForMethod(original);
             MethodInfo shimMethod = generation?.FindPatchShim(original);
-            Debug.Assert(shimMethod != null, "Shim must be registered before Patch runs.");
             if (shimMethod == null)
             {
                 throw new InvalidOperationException("Shim must be registered before Patch runs.");
             }
 
-
             int argumentSlotCount = original.GetParameters().Length + (original.IsStatic ? 0 : 1);
-            Debug.Assert(
-                argumentSlotCount == shimMethod.GetParameters().Length,
-                "Shim parameter count must equal the original's argument slots (instance receiver included).");
             if (argumentSlotCount != shimMethod.GetParameters().Length)
             {
                 throw new InvalidOperationException(

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadPatcher.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadPatcher.cs
@@ -28,13 +28,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             typeof(HotReloadPatcher).GetMethod(
                 nameof(ReplaceWithDelegationTranspiler),
                 BindingFlags.NonPublic | BindingFlags.Static);
-        private static readonly MethodInfo IncrementInvocationMethodInfo =
-            typeof(HotReloadInvocationRegistry).GetMethod(
-                nameof(HotReloadInvocationRegistry.Increment),
-                BindingFlags.Public | BindingFlags.Static,
-                null,
-                new[] { typeof(string) },
-                null);
+        private static readonly MethodInfo IncrementInvocationMethodInfo = ResolveIncrementInvocationMethod();
 
         private readonly HotReloadDomain _domain;
         private readonly IHotReloadHarmony _harmony;
@@ -317,6 +311,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             HotReloadFileGeneration generation = TranspilerDomain.FindGenerationForMethod(original);
             MethodInfo shimMethod = generation?.FindPatchShim(original);
             Debug.Assert(shimMethod != null, "Shim must be registered before Patch runs.");
+            if (shimMethod == null)
+            {
+                throw new InvalidOperationException("Shim must be registered before Patch runs.");
+            }
+
             // Discard the original (and any prior transpiler) instructions entirely — the shim IL
             // is the whole replacement body.
             // Read shim IL without letting MethodBodyReader declare locals on a throwaway path, then
@@ -345,11 +344,21 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             HotReloadFileGeneration generation = TranspilerDomain.FindGenerationForMethod(original);
             MethodInfo shimMethod = generation?.FindPatchShim(original);
             Debug.Assert(shimMethod != null, "Shim must be registered before Patch runs.");
+            if (shimMethod == null)
+            {
+                throw new InvalidOperationException("Shim must be registered before Patch runs.");
+            }
+
 
             int argumentSlotCount = original.GetParameters().Length + (original.IsStatic ? 0 : 1);
             Debug.Assert(
                 argumentSlotCount == shimMethod.GetParameters().Length,
                 "Shim parameter count must equal the original's argument slots (instance receiver included).");
+            if (argumentSlotCount != shimMethod.GetParameters().Length)
+            {
+                throw new InvalidOperationException(
+                    "Shim parameter count must equal the original's argument slots (instance receiver included).");
+            }
 
             List<CodeInstruction> forwarding = new List<CodeInstruction>(argumentSlotCount + 4);
             PrependInvocationCountIncrement(forwarding, original, generation);
@@ -363,6 +372,24 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return forwarding;
         }
 
+        // Why resolve through a method: every patched body calls this counter, so a signature the
+        // transpiler cannot find has to stop the patch here rather than emit a call to null.
+        private static MethodInfo ResolveIncrementInvocationMethod()
+        {
+            MethodInfo method = typeof(HotReloadInvocationRegistry).GetMethod(
+                nameof(HotReloadInvocationRegistry.Increment),
+                BindingFlags.Public | BindingFlags.Static,
+                null,
+                new[] { typeof(string) },
+                null);
+            if (method == null)
+            {
+                throw new InvalidOperationException("Increment method must resolve.");
+            }
+
+            return method;
+        }
+
         // What: records one invocation before the patched body runs (transplant or delegation).
         // Why move entry labels onto Ldstr: branches targeting the old first instruction must
         // still hit the counter when that instruction is no longer at offset 0.
@@ -371,7 +398,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             MethodBase original,
             HotReloadFileGeneration generation)
         {
-            Debug.Assert(IncrementInvocationMethodInfo != null, "Increment method must resolve.");
             CodeInstruction loadKey = new CodeInstruction(OpCodes.Ldstr, HotReloadMethodKeys.FormatMethodLabel(original));
             CodeInstruction increment = new CodeInstruction(OpCodes.Call, IncrementInvocationMethodInfo);
             if (instructions.Count > 0 && instructions[0].labels.Count > 0)


### PR DESCRIPTION
## Summary
- Hot-reload now refuses a patch state its aggregate says cannot exist, instead of logging an assertion and carrying on.

## User Impact
- Before: registering a shim before its generation was opened, opening a second patch of an already patched method, or committing a patch that was never opened only wrote an assertion message. Assertions are stripped from player builds, so the run continued and could report a patch Harmony had never installed.
- After: those conditions throw `InvalidOperationException`, so the failing file's apply reports the failure instead of a change that is not live. `--status` and `--revert-all` responses are unchanged for every state that was already valid.

## Behavior change: log to exception
These sites now throw `InvalidOperationException` where they previously only asserted:
- `HotReloadFileGeneration.RegisterShimMethod` — shim generation not opened
- `HotReloadFileGeneration.RegisterAddedMethod` — added-member generation not opened
- `HotReloadFileGeneration.RemoveShimMethod` — the method still holds an active patch
- `HotReloadFileGeneration.BeginPatch` — no shim registered for the method; the method already holds a pending or active patch
- `HotReloadFileGeneration.CommitPatch` — no pending patch for the method; the patch is already active
- `HotReloadPatcher` transpilers — the shim is not registered when Patch runs (transplant and delegation paths); the shim's parameter count does not match the original's argument slots
- `HotReloadPatcher` — the invocation counter method does not resolve (now raised where it is resolved, rather than checked at every emit)

`HotReloadDomain.BeginGeneration` is deliberately left as it is: replacing an existing generation is the normal path for a repeated apply.

## Changes
- Replaced the condition assertions above with explicit checks and exceptions; null-argument assertions stay as they are.
- Resolved the invocation-counter `MethodInfo` through a method that raises when the lookup fails.
- Added `HotReloadFileGenerationContractTests` (7 tests, one per refused condition) and `HotReloadPatcherContractTests` (apply-failure guarantees split into three tests, the RevertAll-to-pause-point ordering, and the active-change total against the status rows).
- Rewrote the retained-patch revert test in `HotReloadPatcherTests` in the aggregate's vocabulary.

## Verification
- `uloop compile` — 0 errors.
- `uloop run-tests --filter-type regex --filter-value "HotReloadFileGenerationContractTests|HotReloadPatcherContractTests|HotReloadPatcherTests|HotReloadFileGenerationTests|HotReloadDomainTests"` — 65/65 passed.
- Red check: with the production change reverted, 7 of the 12 new contract tests failed (`Expected: <System.InvalidOperationException> But was: null`); they pass with it applied.
- `CODE_FILE_LENGTH_MAX_LENGTH=400 sh scripts/check-file-length.sh` — no touched file listed. `CODE_FILE_LENGTH_FAIL_ON_EXCEEDED=true sh scripts/check-file-length.sh` — exit 0.
- `go run ./cmd/check-asmdef-policy` — no violation.
- `uloop hot-reload --status` and `--revert-all` responses captured before and after the change — `diff` empty for both.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2739?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

