### PR TITLE
feat(cli): resolve the Unity-bundled csc and dotnet host from an Editor install

### DIFF
--- a/cli/dispatcher/internal/compilecheck/editor_layout.go
+++ b/cli/dispatcher/internal/compilecheck/editor_layout.go
@@ -1,0 +1,427 @@
+// Package compilecheck compiles Unity assemblies with the C# compiler bundled with a Unity
+// Editor install, without launching or contacting the Editor itself.
+package compilecheck
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+const (
+	netCoreRuntimeDirectoryName    = "NetCoreRuntime"
+	dotNetSdkRoslynDirectoryName   = "DotNetSdkRoslyn"
+	dotNetSdkDirectoryName         = "DotNetSdk"
+	sdkDirectoryName               = "sdk"
+	roslynDirectoryName            = "Roslyn"
+	bincoreDirectoryName           = "bincore"
+	compilerDllFileName            = "csc.dll"
+	compilerRuntimeConfigFileName  = "csc.runtimeconfig.json"
+	compilerDepsFileName           = "csc.deps.json"
+	codeAnalysisDllFileName        = "Microsoft.CodeAnalysis.dll"
+	codeAnalysisCSharpDllFileName  = "Microsoft.CodeAnalysis.CSharp.dll"
+	sharedDirectoryName            = "shared"
+	sharedFrameworkName            = "Microsoft.NETCore.App"
+	scriptingRootScanDepthLimit    = 4
+	macOSExecutableDirectoryName   = "MacOS"
+	editorContentsDirectoryName    = "Contents"
+	windowsEditorDataDirectoryName = "Data"
+)
+
+// EditorCompilerPaths locates the csc and dotnet host bundled with one Unity Editor install.
+type EditorCompilerPaths struct {
+	DotnetHostPath      string // .../NetCoreRuntime/dotnet or .../DotNetSdk/dotnet (dotnet.exe on Windows)
+	CompilerDllPath     string // .../csc.dll
+	CompilerDirectory   string
+	SharedFrameworkPath string // .../shared/Microsoft.NETCore.App/<version>
+}
+
+// ResolveEditorCompilerPaths finds the bundled compiler that belongs to the given Editor executable.
+func ResolveEditorCompilerPaths(editorExecutablePath string) (EditorCompilerPaths, error) {
+	contentsPath, err := resolveEditorContentsPath(editorExecutablePath)
+	if err != nil {
+		return EditorCompilerPaths{}, err
+	}
+
+	scriptingRootPath := resolveScriptingRootPath(contentsPath)
+	if scriptingRootPath == "" {
+		return EditorCompilerPaths{}, fmt.Errorf(
+			"no Unity-bundled C# compiler layout found under %s", contentsPath)
+	}
+
+	compilerDirectoryPath := resolveCompilerDirectoryPath(scriptingRootPath)
+	if compilerDirectoryPath == "" {
+		return EditorCompilerPaths{}, fmt.Errorf(
+			"no Unity-bundled C# compiler layout found under %s", contentsPath)
+	}
+
+	hostPath, sharedFrameworkPath := resolveRuntimePairing(scriptingRootPath, compilerDirectoryPath)
+	paths := EditorCompilerPaths{
+		DotnetHostPath:      hostPath,
+		CompilerDllPath:     filepath.Join(compilerDirectoryPath, compilerDllFileName),
+		CompilerDirectory:   compilerDirectoryPath,
+		SharedFrameworkPath: sharedFrameworkPath,
+	}
+	if err := verifyRequiredCompilerFiles(paths, scriptingRootPath); err != nil {
+		return EditorCompilerPaths{}, err
+	}
+
+	return paths, nil
+}
+
+// verifyRequiredCompilerFiles fails when any file the compiler invocation needs is absent.
+func verifyRequiredCompilerFiles(paths EditorCompilerPaths, scriptingRootPath string) error {
+	if paths.SharedFrameworkPath == "" {
+		return fmt.Errorf(
+			"required compiler file missing: %s",
+			filepath.Join(scriptingRootPath, netCoreRuntimeDirectoryName, sharedDirectoryName, sharedFrameworkName))
+	}
+
+	required := []string{
+		paths.DotnetHostPath,
+		paths.CompilerDllPath,
+		filepath.Join(paths.CompilerDirectory, compilerRuntimeConfigFileName),
+		filepath.Join(paths.CompilerDirectory, compilerDepsFileName),
+		filepath.Join(paths.CompilerDirectory, codeAnalysisDllFileName),
+		filepath.Join(paths.CompilerDirectory, codeAnalysisCSharpDllFileName),
+	}
+	for _, path := range required {
+		if !fileExists(path) {
+			return fmt.Errorf("required compiler file missing: %s", path)
+		}
+	}
+
+	return nil
+}
+
+// resolveEditorContentsPath maps an Editor executable to the directory that holds its bundled data.
+func resolveEditorContentsPath(editorExecutablePath string) (string, error) {
+	if editorExecutablePath == "" {
+		return "", errors.New("the Unity Editor executable path is empty")
+	}
+
+	executableDirectoryPath := filepath.Dir(editorExecutablePath)
+	if filepath.Base(executableDirectoryPath) == macOSExecutableDirectoryName {
+		contentsPath := filepath.Dir(executableDirectoryPath)
+		if filepath.Base(contentsPath) == editorContentsDirectoryName {
+			return contentsPath, nil
+		}
+	}
+
+	dataDirectoryPath := filepath.Join(executableDirectoryPath, windowsEditorDataDirectoryName)
+	if directoryExists(dataDirectoryPath) {
+		return dataDirectoryPath, nil
+	}
+
+	return "", fmt.Errorf(
+		"unrecognized Unity Editor install layout for %s", editorExecutablePath)
+}
+
+// resolveScriptingRootPath finds the directory that holds the compiler layout inside the Editor.
+func resolveScriptingRootPath(contentsPath string) string {
+	resourcesScriptingRootPath := filepath.Join(contentsPath, "Resources", "Scripting")
+	if containsExternalCompilerLayout(resourcesScriptingRootPath) {
+		return resourcesScriptingRootPath
+	}
+
+	if containsExternalCompilerLayout(contentsPath) {
+		return contentsPath
+	}
+
+	return resolveScriptingRootPathByScan(contentsPath)
+}
+
+// resolveScriptingRootPathByScan walks the Editor data directory breadth-first for a compiler layout.
+func resolveScriptingRootPathByScan(contentsPath string) string {
+	type pendingDirectory struct {
+		path  string
+		depth int
+	}
+
+	pending := []pendingDirectory{{path: contentsPath, depth: 0}}
+	for len(pending) > 0 {
+		current := pending[0]
+		pending = pending[1:]
+		if containsExternalCompilerLayout(current.path) {
+			return current.path
+		}
+		if current.depth >= scriptingRootScanDepthLimit {
+			continue
+		}
+		for _, childPath := range childDirectoryPaths(current.path) {
+			pending = append(pending, pendingDirectory{path: childPath, depth: current.depth + 1})
+		}
+	}
+
+	return ""
+}
+
+// containsExternalCompilerLayout reports whether a directory holds a compiler and a runtime for it.
+func containsExternalCompilerLayout(rootPath string) bool {
+	compilerDirectoryPath := resolveCompilerDirectoryPath(rootPath)
+	if compilerDirectoryPath == "" {
+		return false
+	}
+
+	if directoryExists(filepath.Join(rootPath, netCoreRuntimeDirectoryName)) {
+		return true
+	}
+
+	dotNetSdkRootPath := findDirectoryContainingSdk(compilerDirectoryPath)
+	if dotNetSdkRootPath == "" {
+		return false
+	}
+
+	return directoryExists(filepath.Join(dotNetSdkRootPath, sharedDirectoryName, sharedFrameworkName))
+}
+
+// resolveCompilerDirectoryPath picks the directory holding csc.dll, preferring the legacy layout.
+func resolveCompilerDirectoryPath(scriptingRootPath string) string {
+	if scriptingRootPath == "" {
+		return ""
+	}
+
+	legacyCompilerDirectoryPath := filepath.Join(scriptingRootPath, dotNetSdkRoslynDirectoryName)
+	if fileExists(filepath.Join(legacyCompilerDirectoryPath, compilerDllFileName)) {
+		return legacyCompilerDirectoryPath
+	}
+
+	sdkRootPath := filepath.Join(scriptingRootPath, dotNetSdkDirectoryName, sdkDirectoryName)
+	for _, sdkDirectoryPath := range sortedVersionDirectoriesDescending(sdkRootPath) {
+		compilerDirectoryPath := filepath.Join(sdkDirectoryPath, roslynDirectoryName, bincoreDirectoryName)
+		if directoryExists(compilerDirectoryPath) {
+			return compilerDirectoryPath
+		}
+	}
+
+	return ""
+}
+
+// resolveRuntimePairing chooses the dotnet host and shared framework that satisfy csc's required major.
+// Why NetCoreRuntime first: the editors that ship both already satisfy the required major there, and
+// switching unconditionally would change which runtime those installs compile with.
+func resolveRuntimePairing(scriptingRootPath string, compilerDirectoryPath string) (string, string) {
+	netCoreHostPath := filepath.Join(scriptingRootPath, netCoreRuntimeDirectoryName, hostFileName())
+	netCoreSharedRootPath := filepath.Join(
+		scriptingRootPath, netCoreRuntimeDirectoryName, sharedDirectoryName, sharedFrameworkName)
+	netCoreSharedPath := resolveHighestSharedFrameworkPath(netCoreSharedRootPath)
+
+	requiredMajor, hasRequiredMajor := readRequiredRuntimeMajor(compilerDirectoryPath)
+	if !hasRequiredMajor || sharedRootSatisfiesRequiredMajor(netCoreSharedRootPath, requiredMajor) {
+		return netCoreHostPath, netCoreSharedPath
+	}
+
+	sdkHostPath, sdkSharedPath := resolveDotNetSdkRuntimePairing(compilerDirectoryPath, requiredMajor)
+	if sdkHostPath == "" {
+		return netCoreHostPath, netCoreSharedPath
+	}
+
+	return sdkHostPath, sdkSharedPath
+}
+
+// resolveDotNetSdkRuntimePairing pairs the compiler with the runtime shipped inside its own SDK root.
+func resolveDotNetSdkRuntimePairing(compilerDirectoryPath string, requiredMajor int) (string, string) {
+	dotNetSdkRootPath := findDirectoryContainingSdk(compilerDirectoryPath)
+	if dotNetSdkRootPath == "" {
+		return "", ""
+	}
+
+	hostPath := filepath.Join(dotNetSdkRootPath, hostFileName())
+	if !fileExists(hostPath) {
+		return "", ""
+	}
+
+	sharedRootPath := filepath.Join(dotNetSdkRootPath, sharedDirectoryName, sharedFrameworkName)
+	if !sharedRootSatisfiesRequiredMajor(sharedRootPath, requiredMajor) {
+		return "", ""
+	}
+
+	sharedPath := resolveHighestSharedFrameworkPath(sharedRootPath)
+	if sharedPath == "" {
+		return "", ""
+	}
+
+	return hostPath, sharedPath
+}
+
+// readRequiredRuntimeMajor reads the major runtime version csc.runtimeconfig.json demands.
+func readRequiredRuntimeMajor(compilerDirectoryPath string) (int, bool) {
+	content, err := os.ReadFile(filepath.Join(compilerDirectoryPath, compilerRuntimeConfigFileName))
+	if err != nil {
+		return 0, false
+	}
+
+	var config struct {
+		RuntimeOptions struct {
+			Framework struct {
+				Version string `json:"version"`
+			} `json:"framework"`
+		} `json:"runtimeOptions"`
+	}
+	if err := json.Unmarshal(content, &config); err != nil {
+		return 0, false
+	}
+
+	parts, ok := parseVersionParts(config.RuntimeOptions.Framework.Version)
+	if !ok {
+		return 0, false
+	}
+
+	return parts[0], true
+}
+
+// sharedRootSatisfiesRequiredMajor reports whether any installed framework meets the required major.
+func sharedRootSatisfiesRequiredMajor(sharedRootPath string, requiredMajor int) bool {
+	for _, directoryPath := range childDirectoryPaths(sharedRootPath) {
+		parts, ok := parseVersionParts(filepath.Base(directoryPath))
+		if ok && parts[0] >= requiredMajor {
+			return true
+		}
+	}
+
+	return false
+}
+
+// resolveHighestSharedFrameworkPath picks the newest installed shared framework directory.
+func resolveHighestSharedFrameworkPath(sharedRootPath string) string {
+	directoryPaths := sortedVersionDirectoriesDescending(sharedRootPath)
+	if len(directoryPaths) == 0 {
+		return ""
+	}
+
+	return directoryPaths[0]
+}
+
+// sortedVersionDirectoriesDescending orders child directories newest first, version names before others.
+func sortedVersionDirectoriesDescending(rootPath string) []string {
+	directoryPaths := childDirectoryPaths(rootPath)
+	sort.SliceStable(directoryPaths, func(left int, right int) bool {
+		return compareVersionDirectoryNames(
+			filepath.Base(directoryPaths[left]), filepath.Base(directoryPaths[right])) < 0
+	})
+
+	return directoryPaths
+}
+
+// compareVersionDirectoryNames orders two directory names newest first for version-shaped names.
+func compareVersionDirectoryNames(leftName string, rightName string) int {
+	leftParts, leftIsVersion := parseVersionParts(leftName)
+	rightParts, rightIsVersion := parseVersionParts(rightName)
+	switch {
+	case leftIsVersion && rightIsVersion:
+		if comparison := compareVersionParts(rightParts, leftParts); comparison != 0 {
+			return comparison
+		}
+	case leftIsVersion:
+		return -1
+	case rightIsVersion:
+		return 1
+	}
+
+	return strings.Compare(rightName, leftName)
+}
+
+// parseVersionParts reads a dotted numeric version name, mirroring the .NET Version parser.
+func parseVersionParts(name string) ([]int, bool) {
+	segments := strings.Split(name, ".")
+	if len(segments) < 2 || len(segments) > 4 {
+		return nil, false
+	}
+
+	parts := make([]int, 0, len(segments))
+	for _, segment := range segments {
+		value, err := strconv.Atoi(segment)
+		if err != nil || value < 0 {
+			return nil, false
+		}
+		parts = append(parts, value)
+	}
+
+	return parts, true
+}
+
+// compareVersionParts orders two parsed versions, treating an absent component as lower.
+func compareVersionParts(left []int, right []int) int {
+	for index := 0; index < len(left) && index < len(right); index++ {
+		if left[index] != right[index] {
+			if left[index] < right[index] {
+				return -1
+			}
+			return 1
+		}
+	}
+
+	switch {
+	case len(left) < len(right):
+		return -1
+	case len(left) > len(right):
+		return 1
+	default:
+		return 0
+	}
+}
+
+// findDirectoryContainingSdk walks up from the compiler directory to the .NET SDK root above it.
+func findDirectoryContainingSdk(startDirectoryPath string) string {
+	currentPath := startDirectoryPath
+	for currentPath != "" {
+		if directoryExists(filepath.Join(currentPath, sdkDirectoryName)) {
+			return currentPath
+		}
+		parentPath := filepath.Dir(currentPath)
+		if parentPath == currentPath {
+			return ""
+		}
+		currentPath = parentPath
+	}
+
+	return ""
+}
+
+// childDirectoryPaths lists the immediate subdirectories of a directory in ordinal name order.
+func childDirectoryPaths(rootPath string) []string {
+	entries, err := os.ReadDir(rootPath)
+	if err != nil {
+		return nil
+	}
+
+	// Why os.Stat instead of entry.IsDir: Editor installs link some directories, and a symlinked
+	// directory must be walked like a real one.
+	directoryPaths := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		childPath := filepath.Join(rootPath, entry.Name())
+		if directoryExists(childPath) {
+			directoryPaths = append(directoryPaths, childPath)
+		}
+	}
+	sort.Strings(directoryPaths)
+
+	return directoryPaths
+}
+
+// hostFileName is the dotnet host executable name for the running platform.
+func hostFileName() string {
+	if runtime.GOOS == "windows" {
+		return "dotnet.exe"
+	}
+
+	return "dotnet"
+}
+
+func fileExists(path string) bool {
+	info, err := os.Stat(path)
+
+	return err == nil && !info.IsDir()
+}
+
+func directoryExists(path string) bool {
+	info, err := os.Stat(path)
+
+	return err == nil && info.IsDir()
+}

--- a/cli/dispatcher/internal/compilecheck/editor_layout_test.go
+++ b/cli/dispatcher/internal/compilecheck/editor_layout_test.go
@@ -1,0 +1,210 @@
+package compilecheck
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// writeFileAt creates a file and every parent directory it needs.
+func writeFileAt(t *testing.T, path string, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("failed to create directory for %s: %v", path, err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("failed to write %s: %v", path, err)
+	}
+}
+
+// makeDirAt creates a directory and every parent directory it needs.
+func makeDirAt(t *testing.T, path string) {
+	t.Helper()
+	if err := os.MkdirAll(path, 0o755); err != nil {
+		t.Fatalf("failed to create directory %s: %v", path, err)
+	}
+}
+
+// writeCompilerFiles fills a compiler directory with the files the resolver requires.
+func writeCompilerFiles(t *testing.T, compilerDirectoryPath string, runtimeConfigContent string) {
+	t.Helper()
+	writeFileAt(t, filepath.Join(compilerDirectoryPath, compilerDllFileName), "")
+	writeFileAt(t, filepath.Join(compilerDirectoryPath, compilerRuntimeConfigFileName), runtimeConfigContent)
+	writeFileAt(t, filepath.Join(compilerDirectoryPath, compilerDepsFileName), "")
+	writeFileAt(t, filepath.Join(compilerDirectoryPath, codeAnalysisDllFileName), "")
+	writeFileAt(t, filepath.Join(compilerDirectoryPath, codeAnalysisCSharpDllFileName), "")
+}
+
+// runtimeConfigWithVersion builds a csc.runtimeconfig.json that requires the given framework version.
+func runtimeConfigWithVersion(version string) string {
+	return `{"runtimeOptions":{"framework":{"name":"Microsoft.NETCore.App","version":"` + version + `"}}}`
+}
+
+// writeSharedRuntime creates a dotnet host plus one installed shared framework version.
+func writeSharedRuntime(t *testing.T, runtimeRootPath string, version string) {
+	t.Helper()
+	writeFileAt(t, filepath.Join(runtimeRootPath, hostFileName()), "")
+	makeDirAt(t, filepath.Join(runtimeRootPath, sharedDirectoryName, sharedFrameworkName, version))
+}
+
+// Verifies the 2022-era layout resolves the compiler under Contents and pairs it with NetCoreRuntime.
+func TestResolveEditorCompilerPathsForContentsRootLayout(t *testing.T) {
+	contentsPath := filepath.Join(t.TempDir(), "Unity.app", "Contents")
+	compilerDirectoryPath := filepath.Join(contentsPath, dotNetSdkRoslynDirectoryName)
+	writeCompilerFiles(t, compilerDirectoryPath, "{}")
+	writeSharedRuntime(t, filepath.Join(contentsPath, netCoreRuntimeDirectoryName), "6.0.21")
+
+	paths, err := ResolveEditorCompilerPaths(filepath.Join(contentsPath, "MacOS", "Unity"))
+	if err != nil {
+		t.Fatalf("expected the layout to resolve, got error: %v", err)
+	}
+
+	wantHost := filepath.Join(contentsPath, netCoreRuntimeDirectoryName, hostFileName())
+	if paths.DotnetHostPath != wantHost {
+		t.Errorf("host path = %s, want %s", paths.DotnetHostPath, wantHost)
+	}
+	wantShared := filepath.Join(
+		contentsPath, netCoreRuntimeDirectoryName, sharedDirectoryName, sharedFrameworkName, "6.0.21")
+	if paths.SharedFrameworkPath != wantShared {
+		t.Errorf("shared framework path = %s, want %s", paths.SharedFrameworkPath, wantShared)
+	}
+	if paths.CompilerDllPath != filepath.Join(compilerDirectoryPath, compilerDllFileName) {
+		t.Errorf("compiler dll path = %s, want it under %s", paths.CompilerDllPath, compilerDirectoryPath)
+	}
+}
+
+// Verifies a Resources/Scripting SDK layout keeps NetCoreRuntime when it satisfies the required major.
+func TestResolveEditorCompilerPathsKeepsNetCoreRuntimeWhenMajorIsSatisfied(t *testing.T) {
+	contentsPath := filepath.Join(t.TempDir(), "Unity.app", "Contents")
+	scriptingRootPath := filepath.Join(contentsPath, "Resources", "Scripting")
+	compilerDirectoryPath := filepath.Join(
+		scriptingRootPath, dotNetSdkDirectoryName, sdkDirectoryName, "8.0.318",
+		roslynDirectoryName, bincoreDirectoryName)
+	writeCompilerFiles(t, compilerDirectoryPath, runtimeConfigWithVersion("8.0.21"))
+	writeSharedRuntime(t, filepath.Join(scriptingRootPath, netCoreRuntimeDirectoryName), "8.0.21")
+
+	paths, err := ResolveEditorCompilerPaths(filepath.Join(contentsPath, "MacOS", "Unity"))
+	if err != nil {
+		t.Fatalf("expected the layout to resolve, got error: %v", err)
+	}
+
+	wantHost := filepath.Join(scriptingRootPath, netCoreRuntimeDirectoryName, hostFileName())
+	if paths.DotnetHostPath != wantHost {
+		t.Errorf("host path = %s, want %s", paths.DotnetHostPath, wantHost)
+	}
+	if paths.CompilerDirectory != compilerDirectoryPath {
+		t.Errorf("compiler directory = %s, want %s", paths.CompilerDirectory, compilerDirectoryPath)
+	}
+}
+
+// Verifies the resolver switches to the DotNetSdk runtime when NetCoreRuntime is too old for csc.
+func TestResolveEditorCompilerPathsSwitchesToDotNetSdkRuntime(t *testing.T) {
+	contentsPath := filepath.Join(t.TempDir(), "Unity.app", "Contents")
+	scriptingRootPath := filepath.Join(contentsPath, "Resources", "Scripting")
+	dotNetSdkRootPath := filepath.Join(scriptingRootPath, dotNetSdkDirectoryName)
+	compilerDirectoryPath := filepath.Join(
+		dotNetSdkRootPath, sdkDirectoryName, "10.0.301", roslynDirectoryName, bincoreDirectoryName)
+	writeCompilerFiles(t, compilerDirectoryPath, runtimeConfigWithVersion("10.0.9"))
+	writeSharedRuntime(t, filepath.Join(scriptingRootPath, netCoreRuntimeDirectoryName), "8.0.21")
+	writeSharedRuntime(t, dotNetSdkRootPath, "10.0.9")
+
+	paths, err := ResolveEditorCompilerPaths(filepath.Join(contentsPath, "MacOS", "Unity"))
+	if err != nil {
+		t.Fatalf("expected the layout to resolve, got error: %v", err)
+	}
+
+	wantHost := filepath.Join(dotNetSdkRootPath, hostFileName())
+	if paths.DotnetHostPath != wantHost {
+		t.Errorf("host path = %s, want %s", paths.DotnetHostPath, wantHost)
+	}
+	wantShared := filepath.Join(dotNetSdkRootPath, sharedDirectoryName, sharedFrameworkName, "10.0.9")
+	if paths.SharedFrameworkPath != wantShared {
+		t.Errorf("shared framework path = %s, want %s", paths.SharedFrameworkPath, wantShared)
+	}
+}
+
+// Verifies a Windows-shaped install resolves its compiler from the Data directory beside Unity.exe.
+func TestResolveEditorCompilerPathsForWindowsDataLayout(t *testing.T) {
+	editorDirectoryPath := filepath.Join(t.TempDir(), "Editor")
+	dataPath := filepath.Join(editorDirectoryPath, windowsEditorDataDirectoryName)
+	compilerDirectoryPath := filepath.Join(dataPath, dotNetSdkRoslynDirectoryName)
+	writeCompilerFiles(t, compilerDirectoryPath, "{}")
+	writeSharedRuntime(t, filepath.Join(dataPath, netCoreRuntimeDirectoryName), "6.0.21")
+
+	paths, err := ResolveEditorCompilerPaths(filepath.Join(editorDirectoryPath, "Unity.exe"))
+	if err != nil {
+		t.Fatalf("expected the layout to resolve, got error: %v", err)
+	}
+
+	if paths.CompilerDirectory != compilerDirectoryPath {
+		t.Errorf("compiler directory = %s, want %s", paths.CompilerDirectory, compilerDirectoryPath)
+	}
+}
+
+// Verifies a missing required compiler file is reported by name instead of resolving silently.
+func TestResolveEditorCompilerPathsReportsMissingRequiredFile(t *testing.T) {
+	contentsPath := filepath.Join(t.TempDir(), "Unity.app", "Contents")
+	compilerDirectoryPath := filepath.Join(contentsPath, dotNetSdkRoslynDirectoryName)
+	writeCompilerFiles(t, compilerDirectoryPath, "{}")
+	if err := os.Remove(filepath.Join(compilerDirectoryPath, compilerDepsFileName)); err != nil {
+		t.Fatalf("failed to remove %s: %v", compilerDepsFileName, err)
+	}
+	writeSharedRuntime(t, filepath.Join(contentsPath, netCoreRuntimeDirectoryName), "6.0.21")
+
+	_, err := ResolveEditorCompilerPaths(filepath.Join(contentsPath, "MacOS", "Unity"))
+	if err == nil {
+		t.Fatal("expected an error when a required compiler file is missing")
+	}
+	if !strings.Contains(err.Error(), compilerDepsFileName) {
+		t.Errorf("error %q does not name the missing file %s", err.Error(), compilerDepsFileName)
+	}
+}
+
+// Verifies the newest SDK directory wins when an Editor ships several Roslyn SDKs.
+func TestResolveEditorCompilerPathsPicksNewestSdkDirectory(t *testing.T) {
+	contentsPath := filepath.Join(t.TempDir(), "Unity.app", "Contents")
+	scriptingRootPath := filepath.Join(contentsPath, "Resources", "Scripting")
+	sdkRootPath := filepath.Join(scriptingRootPath, dotNetSdkDirectoryName, sdkDirectoryName)
+	olderCompilerDirectoryPath := filepath.Join(
+		sdkRootPath, "8.0.318", roslynDirectoryName, bincoreDirectoryName)
+	newerCompilerDirectoryPath := filepath.Join(
+		sdkRootPath, "9.0.100", roslynDirectoryName, bincoreDirectoryName)
+	writeCompilerFiles(t, olderCompilerDirectoryPath, runtimeConfigWithVersion("8.0.21"))
+	writeCompilerFiles(t, newerCompilerDirectoryPath, runtimeConfigWithVersion("8.0.21"))
+	writeSharedRuntime(t, filepath.Join(scriptingRootPath, netCoreRuntimeDirectoryName), "8.0.21")
+
+	paths, err := ResolveEditorCompilerPaths(filepath.Join(contentsPath, "MacOS", "Unity"))
+	if err != nil {
+		t.Fatalf("expected the layout to resolve, got error: %v", err)
+	}
+
+	if paths.CompilerDirectory != newerCompilerDirectoryPath {
+		t.Errorf("compiler directory = %s, want %s", paths.CompilerDirectory, newerCompilerDirectoryPath)
+	}
+}
+
+// Verifies an unrecognized Editor executable location is rejected instead of guessed at.
+func TestResolveEditorCompilerPathsRejectsUnknownEditorLayout(t *testing.T) {
+	_, err := ResolveEditorCompilerPaths(filepath.Join(t.TempDir(), "Unity"))
+	if err == nil {
+		t.Fatal("expected an error for an executable with no Editor layout around it")
+	}
+}
+
+// Verifies the resolver finds a real bundled compiler when an installed Editor is pointed at.
+func TestResolveEditorCompilerPathsAgainstInstalledEditor(t *testing.T) {
+	editorExecutablePath := os.Getenv("ULOOP_EDITOR_EXE")
+	if editorExecutablePath == "" {
+		t.Skip("set ULOOP_EDITOR_EXE to a Unity Editor executable to run this check")
+	}
+
+	paths, err := ResolveEditorCompilerPaths(editorExecutablePath)
+	if err != nil {
+		t.Fatalf("failed to resolve the bundled compiler for %s: %v", editorExecutablePath, err)
+	}
+
+	t.Logf("host: %s", paths.DotnetHostPath)
+	t.Logf("compiler: %s", paths.CompilerDllPath)
+	t.Logf("shared framework: %s", paths.SharedFrameworkPath)
+}

--- a/cli/dispatcher/internal/compilecheck/editor_layout_test.go
+++ b/cli/dispatcher/internal/compilecheck/editor_layout_test.go
@@ -83,6 +83,9 @@ func TestResolveEditorCompilerPathsKeepsNetCoreRuntimeWhenMajorIsSatisfied(t *te
 		roslynDirectoryName, bincoreDirectoryName)
 	writeCompilerFiles(t, compilerDirectoryPath, runtimeConfigWithVersion("8.0.21"))
 	writeSharedRuntime(t, filepath.Join(scriptingRootPath, netCoreRuntimeDirectoryName), "8.0.21")
+	// Both runtimes satisfy the required major here, so only a resolver that prefers NetCoreRuntime
+	// passes this test; without the second runtime the fallback would produce the same answer.
+	writeSharedRuntime(t, filepath.Join(scriptingRootPath, dotNetSdkDirectoryName), "8.0.21")
 
 	paths, err := ResolveEditorCompilerPaths(filepath.Join(contentsPath, "MacOS", "Unity"))
 	if err != nil {
@@ -92,6 +95,11 @@ func TestResolveEditorCompilerPathsKeepsNetCoreRuntimeWhenMajorIsSatisfied(t *te
 	wantHost := filepath.Join(scriptingRootPath, netCoreRuntimeDirectoryName, hostFileName())
 	if paths.DotnetHostPath != wantHost {
 		t.Errorf("host path = %s, want %s", paths.DotnetHostPath, wantHost)
+	}
+	wantShared := filepath.Join(
+		scriptingRootPath, netCoreRuntimeDirectoryName, sharedDirectoryName, sharedFrameworkName, "8.0.21")
+	if paths.SharedFrameworkPath != wantShared {
+		t.Errorf("shared framework path = %s, want %s", paths.SharedFrameworkPath, wantShared)
 	}
 	if paths.CompilerDirectory != compilerDirectoryPath {
 		t.Errorf("compiler directory = %s, want %s", paths.CompilerDirectory, compilerDirectoryPath)

--- a/cli/release-automation/internal/architecture/architecture_test.go
+++ b/cli/release-automation/internal/architecture/architecture_test.go
@@ -269,7 +269,7 @@ func TestInternalBoundariesPerModule(t *testing.T) {
 		{
 			moduleDir:  filepath.Join(repositoryRoot, contract.Layout.Modules.Dispatcher),
 			modulePath: dispatcherModulePath,
-			allowed:    []string{"attestation", "dispatcher", "githubapi", "install", "nativepath", "uninstall", "update"},
+			allowed:    []string{"attestation", "compilecheck", "dispatcher", "githubapi", "install", "nativepath", "uninstall", "update"},
 		},
 		{
 			moduleDir:  filepath.Join(repositoryRoot, contract.Layout.Modules.ReleaseAutomation),


### PR DESCRIPTION
## Summary
- First step of an offline `uloop compile-check`: locate the C# compiler that ships inside a Unity Editor install, so a later change can compile a project without launching or contacting the Editor.
- No user-visible command yet; this PR only adds the resolution layer and its tests.

## User Impact
- Nothing changes for users in this PR on its own. It removes the blocker for compiling a Unity project's C# while the Editor is closed: the CLI can now find the same Roslyn compiler and .NET host Unity itself uses, on every Editor generation currently installable.

## Changes
- New package `cli/dispatcher/internal/compilecheck` with `ResolveEditorCompilerPaths`, ported from the Editor-side `ExternalCompilerPathResolver`:
  - maps an Editor executable to its `Contents` (macOS) or `Editor\Data` (Windows) directory;
  - finds the scripting root that holds a compiler layout (`Resources/Scripting`, the data root, then a bounded breadth-first scan);
  - picks the compiler directory, preferring `DotNetSdkRoslyn` and otherwise the newest `DotNetSdk/sdk/<version>/Roslyn/bincore`;
  - pairs it with a dotnet host whose shared framework satisfies the major version `csc.runtimeconfig.json` asks for, falling back from `NetCoreRuntime` to the SDK root only when that major is unmet;
  - fails with the missing file's name when any required compiler file is absent.
- Allows the new internal package in the dispatcher module boundary test.

## Verification
- `go test ./internal/compilecheck/ -run TestResolveEditorCompilerPaths -v` — 7/7 PASS (four layout shapes, a missing-file case, newest-SDK selection, and an unrecognized install).
- Mutation check: forcing the runtime pairing to always keep `NetCoreRuntime` makes `TestResolveEditorCompilerPathsSwitchesToDotNetSdkRuntime` fail, then passes again once reverted.
- `scripts/check-go-cli.sh` — exit 0 (format, vet, lint, tests, dist rebuild).
- Against every Editor installed on the verification machine, via the env-gated `TestResolveEditorCompilerPathsAgainstInstalledEditor` (`ULOOP_EDITOR_EXE=...`), all PASS:

| Editor | compiler | host | shared framework |
|---|---|---|---|
| 2022.3.62f3 | `Contents/DotNetSdkRoslyn/csc.dll` | `Contents/NetCoreRuntime/dotnet` | `NetCoreRuntime/.../6.0.21` |
| 6000.3.15f1 | `.../Scripting/DotNetSdkRoslyn/csc.dll` | `.../Scripting/NetCoreRuntime/dotnet` | `NetCoreRuntime/.../6.0.21` |
| 6000.5.8f1 | `.../Scripting/DotNetSdk/sdk/8.0.318/Roslyn/bincore/csc.dll` | `.../Scripting/NetCoreRuntime/dotnet` | `NetCoreRuntime/.../8.0.21` |
| 6000.6.0f1 | `.../Scripting/DotNetSdk/sdk/8.0.318/Roslyn/bincore/csc.dll` | `.../Scripting/NetCoreRuntime/dotnet` | `NetCoreRuntime/.../8.0.21` |
| 6000.7.0a4 | `.../Scripting/DotNetSdk/sdk/10.0.301/Roslyn/bincore/csc.dll` | `.../Scripting/DotNetSdk/dotnet` | `DotNetSdk/.../10.0.9` |

6000.7 is the case that proves the pairing step is needed: its Roslyn requires .NET 10 while its `NetCoreRuntime` only carries 8.0.21, so the resolver switches hosts there and nowhere else.

Windows path handling is exercised only by the layout-shaped unit test; a real Windows run is verified later in this series.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2743?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

