### PR TITLE
feat(cli): replay Bee response files to compile assemblies outside the Editor

### DIFF
--- a/cli/dispatcher/internal/compilecheck/assembly_set.go
+++ b/cli/dispatcher/internal/compilecheck/assembly_set.go
@@ -1,0 +1,116 @@
+package compilecheck
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"time"
+)
+
+const (
+	changeReasonAssemblyAdded   = "was added after the last Unity build"
+	changeReasonAssemblyRemoved = "was removed after the last Unity build"
+)
+
+// predefinedAssemblyNames are the assemblies Unity builds without an .asmdef of their own.
+var predefinedAssemblyNames = map[string]bool{
+	"Assembly-CSharp":                  true,
+	"Assembly-CSharp-firstpass":        true,
+	"Assembly-CSharp-Editor":           true,
+	"Assembly-CSharp-Editor-firstpass": true,
+}
+
+// DetectAssemblySetChange refuses a run whose set of assemblies no longer matches the last build.
+// Why it cannot be replayed: an added or removed assembly definition changes which assemblies exist
+// and which sources belong to each of them, and the response files describe the old set only.
+func DetectAssemblySetChange(
+	projectRoot string, dagDir string, graph assemblyGraph,
+	assemblyDefinitions map[string]AssemblyDefinition,
+) error {
+	buildTime, err := newestBuildTime(projectRoot, dagDir)
+	if err != nil {
+		return err
+	}
+
+	if name, found := addedAssemblyName(graph, assemblyDefinitions, buildTime); found {
+		return fmt.Errorf(
+			"assembly definition %s %s; %s", name, changeReasonAssemblyAdded, runCompileFirstAdvice)
+	}
+	if name, found := removedAssemblyName(graph, assemblyDefinitions); found {
+		return fmt.Errorf(
+			"assembly definition %s %s; %s", name, changeReasonAssemblyRemoved, runCompileFirstAdvice)
+	}
+
+	return nil
+}
+
+// addedAssemblyName names an assembly definition written after the last build that Bee never saw.
+// Why the modification time matters: an assembly definition excluded by platform or test settings
+// legitimately has no response file, so the absence alone would reject healthy projects.
+func addedAssemblyName(
+	graph assemblyGraph, assemblyDefinitions map[string]AssemblyDefinition, buildTime time.Time,
+) (string, bool) {
+	names := make([]string, 0, len(assemblyDefinitions))
+	for name := range assemblyDefinitions {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	for _, name := range names {
+		if _, built := graph.byName[name]; built {
+			continue
+		}
+		written, err := modificationTime(assemblyDefinitions[name].Path)
+		if err != nil || !written.After(buildTime) {
+			continue
+		}
+
+		return name, true
+	}
+
+	return "", false
+}
+
+// removedAssemblyName names an assembly Bee built whose assembly definition is gone from the project.
+func removedAssemblyName(
+	graph assemblyGraph, assemblyDefinitions map[string]AssemblyDefinition,
+) (string, bool) {
+	for _, name := range graph.names {
+		if predefinedAssemblyNames[name] {
+			continue
+		}
+		if _, defined := assemblyDefinitions[name]; !defined {
+			return name, true
+		}
+	}
+
+	return "", false
+}
+
+// newestBuildTime is when the Editor last wrote an assembly into the dag, the baseline every
+// project change is compared against.
+func newestBuildTime(projectRoot string, dagDir string) (time.Time, error) {
+	dagDirectoryPath := filepath.Join(projectRoot, dagDir)
+	matches, err := filepath.Glob(filepath.Join(dagDirectoryPath, "*"+assemblyExtension))
+	if err != nil {
+		return time.Time{}, fmt.Errorf("failed to list assemblies in %s: %w", dagDirectoryPath, err)
+	}
+
+	newest := time.Time{}
+	for _, path := range matches {
+		info, statErr := os.Stat(path)
+		if statErr != nil {
+			continue
+		}
+		if info.ModTime().After(newest) {
+			newest = info.ModTime()
+		}
+	}
+	if newest.IsZero() {
+		return time.Time{}, fmt.Errorf(
+			"the Unity Editor has never built %s; %s", dagDirectoryPath, runCompileFirstAdvice)
+	}
+
+	return newest, nil
+}

--- a/cli/dispatcher/internal/compilecheck/compiler.go
+++ b/cli/dispatcher/internal/compilecheck/compiler.go
@@ -1,0 +1,254 @@
+package compilecheck
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	severityError   = "error"
+	severityWarning = "warning"
+
+	compilerExecArgument      = "exec"
+	compilerNoStdLibFlag      = "/nostdlib"
+	compilerNoConfigFlag      = "/noconfig"
+	compilerLibraryTargetFlag = "-target:library"
+	multiLevelLookupSetting   = "DOTNET_MULTILEVEL_LOOKUP=0"
+
+	responseFilePermissions = 0o600
+	outputDirPermissions    = 0o755
+)
+
+// diagnosticPattern matches one csc diagnostic line: "<file>(<line>,<column>): <severity> <code>: <message>".
+var diagnosticPattern = regexp.MustCompile(
+	`^(?P<file>.+)\((?P<line>\d+),(?P<column>\d+)\): (?P<severity>error|warning) (?P<code>[A-Z]+\d+): (?P<message>.+)$`)
+
+// Diagnostic is one error or warning csc reported at a source position.
+type Diagnostic struct {
+	Severity string
+	Code     string
+	Message  string
+	File     string // as csc printed it, which is relative to the project root
+	Line     int
+	Column   int
+}
+
+// UnitResult is what compiling one assembly produced.
+type UnitResult struct {
+	Assembly    string
+	Diagnostics []Diagnostic
+	Succeeded   bool
+	RawOutput   string // filled only when csc failed without saying why in a diagnostic
+	Duration    time.Duration
+}
+
+// CommandRunner runs one compiler invocation, so tests can stand in for the real process.
+type CommandRunner func(ctx context.Context, cmd *exec.Cmd) (string, string, int, error)
+
+// Compiler runs the Unity-bundled csc over the units of a build plan.
+type Compiler struct {
+	Paths       EditorCompilerPaths
+	ProjectRoot string
+	Timeout     time.Duration
+	Run         CommandRunner
+}
+
+// CompileUnit compiles one assembly and reports the diagnostics csc produced for it.
+func (c Compiler) CompileUnit(
+	ctx context.Context, plan BuildPlan, unit CompileUnit,
+) (UnitResult, error) {
+	outputDirectoryPath := filepath.Join(c.ProjectRoot, plan.OutputDir)
+	if err := os.MkdirAll(outputDirectoryPath, outputDirPermissions); err != nil {
+		return UnitResult{}, fmt.Errorf("failed to create %s: %w", outputDirectoryPath, err)
+	}
+
+	responseFilePath, err := writeRewrittenResponseFile(c.ProjectRoot, plan, unit)
+	if err != nil {
+		return UnitResult{}, err
+	}
+
+	invocationContext, cancel := context.WithTimeout(ctx, c.Timeout)
+	defer cancel()
+
+	command := exec.CommandContext(invocationContext,
+		c.Paths.DotnetHostPath, compilerExecArgument, c.Paths.CompilerDllPath,
+		compilerNoStdLibFlag, compilerNoConfigFlag, "@"+responseFilePath)
+	command.Dir = c.ProjectRoot
+	command.Env = append(os.Environ(), multiLevelLookupSetting)
+
+	startedAt := time.Now()
+	stdout, stderr, exitCode, runErr := c.Run(invocationContext, command)
+	duration := time.Since(startedAt)
+	// Why a non-zero exit is not an error here: that is how csc reports compile errors, and those
+	// belong in the diagnostics. Only a failure to run the compiler at all is an error.
+	if runErr != nil && !isExitError(runErr) {
+		return UnitResult{}, fmt.Errorf(
+			"failed to run the C# compiler for %s: %w: %s",
+			unit.Assembly.AssemblyName, runErr, strings.TrimSpace(stderr))
+	}
+
+	return buildUnitResult(unit.Assembly.AssemblyName, stdout, stderr, exitCode, duration), nil
+}
+
+// buildUnitResult turns one compiler invocation's output into the result for its assembly.
+func buildUnitResult(
+	assemblyName string, stdout string, stderr string, exitCode int, duration time.Duration,
+) UnitResult {
+	combinedOutput := stdout + "\n" + stderr
+	diagnostics := ParseDiagnostics(combinedOutput)
+
+	rawOutput := ""
+	// Why a failure with no error diagnostic is kept verbatim: without it the run would report a
+	// clean compile for an assembly that never actually compiled.
+	if exitCode != 0 && !containsError(diagnostics) {
+		rawOutput = fmt.Sprintf(
+			"csc exited with code %d without reporting an error diagnostic:\n%s",
+			exitCode, strings.TrimSpace(combinedOutput))
+	}
+
+	return UnitResult{
+		Assembly:    assemblyName,
+		Diagnostics: diagnostics,
+		Succeeded:   exitCode == 0,
+		RawOutput:   rawOutput,
+		Duration:    duration,
+	}
+}
+
+// containsError reports whether any diagnostic is an error rather than a warning.
+func containsError(diagnostics []Diagnostic) bool {
+	for _, diagnostic := range diagnostics {
+		if diagnostic.Severity == severityError {
+			return true
+		}
+	}
+
+	return false
+}
+
+// isExitError reports whether a run failure is the compiler exiting non-zero rather than not running.
+func isExitError(err error) bool {
+	var exitError *exec.ExitError
+
+	return errors.As(err, &exitError)
+}
+
+// ParseDiagnostics reads every diagnostic csc printed, dropping repeats of the same position and code.
+func ParseDiagnostics(output string) []Diagnostic {
+	diagnostics := []Diagnostic{}
+	seen := map[string]bool{}
+	for _, rawLine := range strings.Split(output, "\n") {
+		diagnostic, ok := parseDiagnosticLine(strings.TrimSpace(rawLine))
+		if !ok {
+			continue
+		}
+		key := fmt.Sprintf("%s:%d:%d:%s", diagnostic.File, diagnostic.Line, diagnostic.Column, diagnostic.Code)
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		diagnostics = append(diagnostics, diagnostic)
+	}
+
+	return diagnostics
+}
+
+// parseDiagnosticLine reads one csc output line, if it carries a positioned diagnostic.
+func parseDiagnosticLine(line string) (Diagnostic, bool) {
+	match := diagnosticPattern.FindStringSubmatch(line)
+	if match == nil {
+		return Diagnostic{}, false
+	}
+
+	lineNumber, lineErr := strconv.Atoi(match[diagnosticPattern.SubexpIndex("line")])
+	columnNumber, columnErr := strconv.Atoi(match[diagnosticPattern.SubexpIndex("column")])
+	if lineErr != nil || columnErr != nil {
+		return Diagnostic{}, false
+	}
+
+	return Diagnostic{
+		Severity: match[diagnosticPattern.SubexpIndex("severity")],
+		Code:     match[diagnosticPattern.SubexpIndex("code")],
+		Message:  match[diagnosticPattern.SubexpIndex("message")],
+		File:     match[diagnosticPattern.SubexpIndex("file")],
+		Line:     lineNumber,
+		Column:   columnNumber,
+	}, true
+}
+
+// writeRewrittenResponseFile writes the response file that compiles one unit into the check's own
+// output directory, so nothing this run produces can reach the assemblies Unity loads.
+func writeRewrittenResponseFile(
+	projectRoot string, plan BuildPlan, unit CompileUnit,
+) (string, error) {
+	rsp := unit.Assembly
+	lines := []string{
+		compilerLibraryTargetFlag,
+		quoteFlag("-out:", filepath.Join(plan.OutputDir, filepath.Base(rsp.OutputPath))),
+		quoteFlag("-refout:", filepath.Join(plan.OutputDir, filepath.Base(rsp.RefOutputPath))),
+	}
+	for _, define := range rsp.Defines {
+		lines = append(lines, defineFlagPrefix+define)
+	}
+	for _, reference := range rsp.References {
+		lines = append(lines, quoteFlag(referenceFlagPrefix, rewriteReference(plan, reference)))
+	}
+	for _, analyzer := range rsp.Analyzers {
+		lines = append(lines, quoteFlag(analyzerFlagPrefix, analyzer))
+	}
+	for _, source := range unit.Sources {
+		lines = append(lines, `"`+source+`"`)
+	}
+	for _, flag := range rsp.OtherFlags {
+		if flag == compilerLibraryTargetFlag {
+			continue
+		}
+		lines = append(lines, flag)
+	}
+	if rsp.AdditionalFile != "" {
+		lines = append(lines, quoteFlag(additionalFileFlagPrefix, rsp.AdditionalFile))
+	}
+
+	path := filepath.Join(projectRoot, plan.OutputDir, rsp.AssemblyName+responseFileExtension)
+	if err := os.WriteFile(path, []byte(strings.Join(lines, "\n")), responseFilePermissions); err != nil {
+		return "", fmt.Errorf("failed to write %s: %w", path, err)
+	}
+
+	return path, nil
+}
+
+// rewriteReference points a reference at this run's own output when this run rebuilds that assembly.
+// Why the others stay: an assembly this run skipped is unchanged, so Unity's own reference assembly
+// still describes it exactly.
+func rewriteReference(plan BuildPlan, reference string) string {
+	name, ok := projectAssemblyReferenceName(reference, plan.DagDir)
+	if !ok || !planCompiles(plan, name) {
+		return reference
+	}
+
+	return filepath.Join(plan.OutputDir, name+referenceAssemblyExtension)
+}
+
+// planCompiles reports whether a plan rebuilds a given assembly.
+func planCompiles(plan BuildPlan, name string) bool {
+	for _, unit := range plan.Units {
+		if unit.Assembly.AssemblyName == name {
+			return true
+		}
+	}
+
+	return false
+}
+
+// quoteFlag writes one response file flag with its value quoted the way Bee quotes paths.
+func quoteFlag(prefix string, value string) string {
+	return prefix + `"` + value + `"`
+}

--- a/cli/dispatcher/internal/compilecheck/compiler.go
+++ b/cli/dispatcher/internal/compilecheck/compiler.go
@@ -199,7 +199,8 @@ func writeRewrittenResponseFile(
 		lines = append(lines, defineFlagPrefix+define)
 	}
 	for _, reference := range rsp.References {
-		lines = append(lines, quoteFlag(referenceFlagPrefix, rewriteReference(plan, reference)))
+		lines = append(lines,
+			quoteFlag(referenceFlagPrefix, rewriteReference(projectRoot, plan, reference)))
 	}
 	for _, analyzer := range rsp.Analyzers {
 		lines = append(lines, quoteFlag(analyzerFlagPrefix, analyzer))
@@ -227,14 +228,20 @@ func writeRewrittenResponseFile(
 
 // rewriteReference points a reference at this run's own output when this run rebuilds that assembly.
 // Why the others stay: an assembly this run skipped is unchanged, so Unity's own reference assembly
-// still describes it exactly.
-func rewriteReference(plan BuildPlan, reference string) string {
+// still describes it exactly. An assembly this run failed to compile wrote no reference assembly at
+// all, so it falls back to Unity's too rather than failing the dependent on a missing file.
+func rewriteReference(projectRoot string, plan BuildPlan, reference string) string {
 	name, ok := projectAssemblyReferenceName(reference, plan.DagDir)
 	if !ok || !planCompiles(plan, name) {
 		return reference
 	}
 
-	return filepath.Join(plan.OutputDir, name+referenceAssemblyExtension)
+	rewritten := filepath.Join(plan.OutputDir, name+referenceAssemblyExtension)
+	if !fileExists(filepath.Join(projectRoot, rewritten)) {
+		return reference
+	}
+
+	return rewritten
 }
 
 // planCompiles reports whether a plan rebuilds a given assembly.

--- a/cli/dispatcher/internal/compilecheck/compiler.go
+++ b/cli/dispatcher/internal/compilecheck/compiler.go
@@ -70,6 +70,13 @@ func (c Compiler) CompileUnit(
 		return UnitResult{}, fmt.Errorf("failed to create %s: %w", outputDirectoryPath, err)
 	}
 
+	// Why the previous run's outputs go first: csc writes nothing when it fails, so a leftover
+	// reference assembly from an earlier run would keep describing an assembly that no longer
+	// compiles, and every dependent would be checked against an API that is gone.
+	if err := removeUnitOutputs(outputDirectoryPath, unit); err != nil {
+		return UnitResult{}, err
+	}
+
 	responseFilePath, err := writeRewrittenResponseFile(c.ProjectRoot, plan, unit)
 	if err != nil {
 		return UnitResult{}, err
@@ -96,6 +103,22 @@ func (c Compiler) CompileUnit(
 	}
 
 	return buildUnitResult(unit.Assembly.AssemblyName, stdout, stderr, exitCode, duration), nil
+}
+
+// removeUnitOutputs deletes what a previous run left for this assembly in the check's output directory.
+func removeUnitOutputs(outputDirectoryPath string, unit CompileUnit) error {
+	names := []string{
+		unit.Assembly.AssemblyName + assemblyExtension,
+		unit.Assembly.AssemblyName + referenceAssemblyExtension,
+	}
+	for _, name := range names {
+		path := filepath.Join(outputDirectoryPath, name)
+		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("failed to remove %s: %w", path, err)
+		}
+	}
+
+	return nil
 }
 
 // buildUnitResult turns one compiler invocation's output into the result for its assembly.
@@ -192,8 +215,13 @@ func writeRewrittenResponseFile(
 	rsp := unit.Assembly
 	lines := []string{
 		compilerLibraryTargetFlag,
-		quoteFlag("-out:", filepath.Join(plan.OutputDir, filepath.Base(rsp.OutputPath))),
-		quoteFlag("-refout:", filepath.Join(plan.OutputDir, filepath.Base(rsp.RefOutputPath))),
+		quoteFlag(outputFlagPrefix, filepath.Join(plan.OutputDir, filepath.Base(rsp.OutputPath))),
+	}
+	// Why the guard: an assembly built without a reference assembly has no base name to join, and
+	// joining an empty one would point -refout at the output directory itself.
+	if rsp.RefOutputPath != "" {
+		lines = append(lines, quoteFlag(
+			referenceOutputFlagPref, filepath.Join(plan.OutputDir, filepath.Base(rsp.RefOutputPath))))
 	}
 	for _, define := range rsp.Defines {
 		lines = append(lines, defineFlagPrefix+define)

--- a/cli/dispatcher/internal/compilecheck/compiler_test.go
+++ b/cli/dispatcher/internal/compilecheck/compiler_test.go
@@ -60,6 +60,9 @@ func compileSecondUnit(t *testing.T, stdout string, exitCode int) (string, UnitR
 		Run:         stubRunner(stdout, exitCode, &captured),
 	}
 
+	// The referenced assembly is compiled first in a real run, so its reference assembly exists.
+	writeFileAt(t, filepath.Join(projectRoot, plan.OutputDir, "A.ref.dll"), "")
+
 	result, err := compiler.CompileUnit(context.Background(), plan, plan.Units[1])
 	if err != nil {
 		t.Fatalf("expected the unit to compile, got error: %v", err)
@@ -137,6 +140,31 @@ func TestCompileUnitRewritesTheResponseFile(t *testing.T) {
 	}
 	if strings.Contains(written, filepath.Join(planDagDirectory, "B.dll")) {
 		t.Error("the rewritten response file must not write into the Bee artifacts directory")
+	}
+}
+
+// Verifies a reference falls back to Unity's own reference assembly when this run produced none.
+func TestCompileUnitFallsBackWhenTheRebuiltReferenceIsMissing(t *testing.T) {
+	projectRoot := t.TempDir()
+	plan := newCompilerPlan()
+	captured := exec.Cmd{}
+	compiler := Compiler{
+		Paths:       EditorCompilerPaths{DotnetHostPath: "/dotnet", CompilerDllPath: "/csc.dll"},
+		ProjectRoot: projectRoot,
+		Timeout:     time.Minute,
+		Run:         stubRunner("", 0, &captured),
+	}
+
+	if _, err := compiler.CompileUnit(context.Background(), plan, plan.Units[1]); err != nil {
+		t.Fatalf("expected the unit to compile, got error: %v", err)
+	}
+
+	written, err := os.ReadFile(filepath.Join(projectRoot, plan.OutputDir, "B.rsp"))
+	if err != nil {
+		t.Fatalf("failed to read the rewritten response file: %v", err)
+	}
+	if !strings.Contains(string(written), `-r:"`+filepath.Join(planDagDirectory, "A.ref.dll")+`"`) {
+		t.Errorf("expected the reference to fall back to the Bee artifact, got:\n%s", written)
 	}
 }
 

--- a/cli/dispatcher/internal/compilecheck/compiler_test.go
+++ b/cli/dispatcher/internal/compilecheck/compiler_test.go
@@ -1,0 +1,184 @@
+package compilecheck
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// newCompilerPlan builds a two-unit plan whose second unit references the first and one skipped one.
+func newCompilerPlan() BuildPlan {
+	return BuildPlan{
+		DagDir:    planDagDirectory,
+		OutputDir: filepath.Join("Library", "uloop", "compile-check", "aaaa.dag"),
+		Units: []CompileUnit{
+			{Assembly: ResponseFile{AssemblyName: "A"}},
+			{
+				Assembly: ResponseFile{
+					AssemblyName:   "B",
+					OutputPath:     filepath.Join(planDagDirectory, "B.dll"),
+					RefOutputPath:  filepath.Join(planDagDirectory, "B.ref.dll"),
+					Defines:        []string{"UNITY_EDITOR"},
+					References:     []string{filepath.Join(planDagDirectory, "A.ref.dll"), filepath.Join(planDagDirectory, "Skipped.ref.dll"), filepath.FromSlash("/Editor/UnityEngine.dll")},
+					Analyzers:      []string{filepath.FromSlash("/Editor/Unity.SourceGenerators.dll")},
+					AdditionalFile: filepath.Join(planDagDirectory, "B.UnityAdditionalFile.txt"),
+					OtherFlags:     []string{"-target:library", "-langversion:9.0", "/deterministic"},
+				},
+				Sources: []string{filepath.Join("Assets", "B", "New.cs")},
+				Reason:  changeReasonSourceNewer,
+			},
+		},
+	}
+}
+
+// stubRunner returns a CommandRunner that reports fixed output and captures the command it was given.
+func stubRunner(stdout string, exitCode int, captured *exec.Cmd) CommandRunner {
+	return func(_ context.Context, cmd *exec.Cmd) (string, string, int, error) {
+		*captured = *cmd
+		if exitCode == 0 {
+			return stdout, "", 0, nil
+		}
+
+		return stdout, "", exitCode, &exec.ExitError{}
+	}
+}
+
+// compileSecondUnit runs the plan's referencing unit through a stubbed compiler.
+func compileSecondUnit(t *testing.T, stdout string, exitCode int) (string, UnitResult) {
+	t.Helper()
+	projectRoot := t.TempDir()
+	plan := newCompilerPlan()
+	captured := exec.Cmd{}
+	compiler := Compiler{
+		Paths:       EditorCompilerPaths{DotnetHostPath: "/dotnet", CompilerDllPath: "/csc.dll"},
+		ProjectRoot: projectRoot,
+		Timeout:     time.Minute,
+		Run:         stubRunner(stdout, exitCode, &captured),
+	}
+
+	result, err := compiler.CompileUnit(context.Background(), plan, plan.Units[1])
+	if err != nil {
+		t.Fatalf("expected the unit to compile, got error: %v", err)
+	}
+
+	written, err := os.ReadFile(filepath.Join(projectRoot, plan.OutputDir, "B.rsp"))
+	if err != nil {
+		t.Fatalf("failed to read the rewritten response file: %v", err)
+	}
+
+	return string(written), result
+}
+
+// Verifies positioned diagnostics are read out of csc output and unpositioned lines are ignored.
+func TestParseDiagnosticsReadsPositionedLinesOnly(t *testing.T) {
+	output := strings.Join([]string{
+		`Assets/Foo/A.cs(12,9): error CS0029: Cannot implicitly convert type 'string' to 'int'`,
+		`Assets/Foo/B.cs(3,1): warning CS0168: The variable 'x' is declared but never used`,
+		`error CS0006: Metadata file 'Missing.dll' could not be found`,
+		`Microsoft (R) Visual C# Compiler version 4.1.0`,
+	}, "\n")
+
+	diagnostics := ParseDiagnostics(output)
+
+	if len(diagnostics) != 2 {
+		t.Fatalf("diagnostics = %+v, want 2", diagnostics)
+	}
+	first := diagnostics[0]
+	if first.Severity != severityError || first.Code != "CS0029" || first.Line != 12 || first.Column != 9 {
+		t.Errorf("first diagnostic = %+v", first)
+	}
+	if first.File != "Assets/Foo/A.cs" {
+		t.Errorf("file = %s, want the path csc printed", first.File)
+	}
+	if diagnostics[1].Severity != severityWarning {
+		t.Errorf("second diagnostic = %+v, want a warning", diagnostics[1])
+	}
+}
+
+// Verifies the same diagnostic printed twice is reported once.
+func TestParseDiagnosticsDropsRepeatedDiagnostics(t *testing.T) {
+	line := `Assets/Foo/A.cs(12,9): error CS0029: Cannot implicitly convert type 'string' to 'int'`
+
+	diagnostics := ParseDiagnostics(line + "\n" + line)
+
+	if len(diagnostics) != 1 {
+		t.Errorf("diagnostics = %+v, want 1", diagnostics)
+	}
+}
+
+// Verifies the rewritten response file writes into the check's own directory and repoints references.
+func TestCompileUnitRewritesTheResponseFile(t *testing.T) {
+	written, _ := compileSecondUnit(t, "", 0)
+
+	outputDir := filepath.Join("Library", "uloop", "compile-check", "aaaa.dag")
+	expected := []string{
+		`-out:"` + filepath.Join(outputDir, "B.dll") + `"`,
+		`-refout:"` + filepath.Join(outputDir, "B.ref.dll") + `"`,
+		`-r:"` + filepath.Join(outputDir, "A.ref.dll") + `"`,
+		`-r:"` + filepath.Join(planDagDirectory, "Skipped.ref.dll") + `"`,
+		`-r:"` + filepath.FromSlash("/Editor/UnityEngine.dll") + `"`,
+		`-define:UNITY_EDITOR`,
+		`"` + filepath.Join("Assets", "B", "New.cs") + `"`,
+		`-langversion:9.0`,
+		`/deterministic`,
+		`/additionalfile:"` + filepath.Join(planDagDirectory, "B.UnityAdditionalFile.txt") + `"`,
+	}
+	for _, line := range expected {
+		if !strings.Contains(written, line+"\n") && !strings.HasSuffix(written, line) {
+			t.Errorf("the rewritten response file is missing %q\ngot:\n%s", line, written)
+		}
+	}
+	if strings.Count(written, "-target:library") != 1 {
+		t.Errorf("-target:library should appear once, got:\n%s", written)
+	}
+	if strings.Contains(written, filepath.Join(planDagDirectory, "B.dll")) {
+		t.Error("the rewritten response file must not write into the Bee artifacts directory")
+	}
+}
+
+// Verifies a failing compile with an error diagnostic is reported as diagnostics, not as an error.
+func TestCompileUnitReportsCompileErrorsAsDiagnostics(t *testing.T) {
+	stdout := `Assets/B/New.cs(1,1): error CS0029: Cannot implicitly convert type 'string' to 'int'`
+
+	_, result := compileSecondUnit(t, stdout, 1)
+
+	if result.Succeeded {
+		t.Error("a non-zero exit must not be reported as success")
+	}
+	if len(result.Diagnostics) != 1 {
+		t.Errorf("diagnostics = %+v, want 1", result.Diagnostics)
+	}
+	if result.RawOutput != "" {
+		t.Errorf("raw output should stay empty when csc explained itself, got: %s", result.RawOutput)
+	}
+}
+
+// Verifies a failing compile that reported nothing keeps the compiler output so the run is not silent.
+func TestCompileUnitKeepsOutputWhenTheCompilerFailsWithoutADiagnostic(t *testing.T) {
+	_, result := compileSecondUnit(t, "Unhandled exception. System.IO.FileNotFoundException", 1)
+
+	if result.RawOutput == "" {
+		t.Fatal("expected the compiler output to be kept")
+	}
+	if !strings.Contains(result.RawOutput, "FileNotFoundException") {
+		t.Errorf("raw output should carry the compiler message, got: %s", result.RawOutput)
+	}
+}
+
+// Verifies a failing compile that reported only warnings is still surfaced as an infrastructure failure.
+func TestCompileUnitKeepsOutputWhenOnlyWarningsAccompanyAFailure(t *testing.T) {
+	stdout := `Assets/B/New.cs(3,1): warning CS0168: The variable 'x' is declared but never used`
+
+	_, result := compileSecondUnit(t, stdout, 1)
+
+	if result.RawOutput == "" {
+		t.Fatal("a failure with only warnings must still be reported")
+	}
+	if len(result.Diagnostics) != 1 || result.Diagnostics[0].Severity != severityWarning {
+		t.Errorf("diagnostics = %+v, want the warning to survive", result.Diagnostics)
+	}
+}

--- a/cli/dispatcher/internal/compilecheck/compiler_test.go
+++ b/cli/dispatcher/internal/compilecheck/compiler_test.go
@@ -210,3 +210,63 @@ func TestCompileUnitKeepsOutputWhenOnlyWarningsAccompanyAFailure(t *testing.T) {
 		t.Errorf("diagnostics = %+v, want the warning to survive", result.Diagnostics)
 	}
 }
+
+// Verifies a failed unit cannot leave a previous run's reference assembly behind for its dependents.
+func TestCompileUnitDropsAStaleReferenceAssemblyOfAFailedUnit(t *testing.T) {
+	projectRoot := t.TempDir()
+	plan := newCompilerPlan()
+	stale := filepath.Join(projectRoot, plan.OutputDir, "A.ref.dll")
+	writeFileAt(t, stale, "from an earlier run")
+
+	failing := exec.Cmd{}
+	compiler := Compiler{
+		Paths:       EditorCompilerPaths{DotnetHostPath: "/dotnet", CompilerDllPath: "/csc.dll"},
+		ProjectRoot: projectRoot,
+		Timeout:     time.Minute,
+		Run:         stubRunner("Assets/A/A.cs(1,1): error CS1002: ; expected", 1, &failing),
+	}
+
+	if _, err := compiler.CompileUnit(context.Background(), plan, plan.Units[0]); err != nil {
+		t.Fatalf("expected the failing unit to report diagnostics, got error: %v", err)
+	}
+	if fileExists(stale) {
+		t.Fatal("expected the previous run's reference assembly to be gone")
+	}
+
+	if _, err := compiler.CompileUnit(context.Background(), plan, plan.Units[1]); err != nil {
+		t.Fatalf("expected the dependent to compile, got error: %v", err)
+	}
+
+	written, err := os.ReadFile(filepath.Join(projectRoot, plan.OutputDir, "B.rsp"))
+	if err != nil {
+		t.Fatalf("failed to read the rewritten response file: %v", err)
+	}
+	if !strings.Contains(string(written), `-r:"`+filepath.Join(planDagDirectory, "A.ref.dll")+`"`) {
+		t.Errorf("expected the reference to fall back to the Bee artifact, got:\n%s", written)
+	}
+}
+
+// Verifies an assembly built without a reference assembly gets no -refout line at all.
+func TestCompileUnitOmitsRefOutWhenTheAssemblyHasNone(t *testing.T) {
+	projectRoot := t.TempDir()
+	plan := newCompilerPlan()
+	captured := exec.Cmd{}
+	compiler := Compiler{
+		Paths:       EditorCompilerPaths{DotnetHostPath: "/dotnet", CompilerDllPath: "/csc.dll"},
+		ProjectRoot: projectRoot,
+		Timeout:     time.Minute,
+		Run:         stubRunner("", 0, &captured),
+	}
+
+	if _, err := compiler.CompileUnit(context.Background(), plan, plan.Units[0]); err != nil {
+		t.Fatalf("expected the unit to compile, got error: %v", err)
+	}
+
+	written, err := os.ReadFile(filepath.Join(projectRoot, plan.OutputDir, "A.rsp"))
+	if err != nil {
+		t.Fatalf("failed to read the rewritten response file: %v", err)
+	}
+	if strings.Contains(string(written), referenceOutputFlagPref) {
+		t.Errorf("expected no -refout line, got:\n%s", written)
+	}
+}

--- a/cli/dispatcher/internal/compilecheck/plan.go
+++ b/cli/dispatcher/internal/compilecheck/plan.go
@@ -141,6 +141,10 @@ func selectChangedAssemblies(
 		return nil, err
 	}
 
+	if setErr := DetectAssemblySetChange(projectRoot, dagDir, graph, assemblyDefinitions); setErr != nil {
+		return nil, setErr
+	}
+
 	reasons := map[string]string{}
 	for _, name := range graph.names {
 		rsp := graph.byName[name]

--- a/cli/dispatcher/internal/compilecheck/plan.go
+++ b/cli/dispatcher/internal/compilecheck/plan.go
@@ -1,0 +1,271 @@
+package compilecheck
+
+import (
+	"fmt"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+const (
+	movedFrameworkResponseSuffix = ".mvfrm.rsp"
+	compileCheckOutputRoot       = "Library/uloop/compile-check"
+	dependencyReasonPrefix       = "depends on "
+)
+
+// CompileUnit is one assembly the offline compile has to rebuild, and why.
+type CompileUnit struct {
+	Assembly ResponseFile
+	Sources  []string
+	Reason   string // empty when the unit was selected by --all rather than by a change
+}
+
+// BuildPlan is the ordered set of assemblies to compile for one run.
+type BuildPlan struct {
+	DagDir    string        // relative to the project root
+	OutputDir string        // relative to the project root
+	Units     []CompileUnit // dependency order: an assembly comes after everything it references
+	Skipped   int           // assemblies left out because nothing they compile from changed
+}
+
+// assemblyGraph holds every response file in the dag together with the edges between them.
+type assemblyGraph struct {
+	byName     map[string]ResponseFile
+	sources    map[string][]string
+	references map[string][]string // assembly -> the project assemblies it references
+	dependents map[string][]string // assembly -> the project assemblies that reference it
+	names      []string
+}
+
+// BuildCompilePlan decides which assemblies to compile, in which order, for one project.
+func BuildCompilePlan(projectRoot string, dagDir string, all bool) (BuildPlan, error) {
+	graph, err := loadAssemblyGraph(projectRoot, dagDir)
+	if err != nil {
+		return BuildPlan{}, err
+	}
+
+	reasons, err := selectChangedAssemblies(projectRoot, dagDir, graph, all)
+	if err != nil {
+		return BuildPlan{}, err
+	}
+	propagateToDependents(graph, reasons)
+
+	order, err := topologicalOrder(graph, reasons)
+	if err != nil {
+		return BuildPlan{}, err
+	}
+
+	units := make([]CompileUnit, 0, len(order))
+	for _, name := range order {
+		units = append(units, CompileUnit{
+			Assembly: graph.byName[name],
+			Sources:  graph.sources[name],
+			Reason:   reasons[name],
+		})
+	}
+
+	return BuildPlan{
+		DagDir:    dagDir,
+		OutputDir: filepath.Join(filepath.FromSlash(compileCheckOutputRoot), filepath.Base(dagDir)),
+		Units:     units,
+		Skipped:   len(graph.names) - len(units),
+	}, nil
+}
+
+// loadAssemblyGraph parses every response file in the dag and links the assemblies to each other.
+func loadAssemblyGraph(projectRoot string, dagDir string) (assemblyGraph, error) {
+	responseFilePaths, err := listResponseFiles(filepath.Join(projectRoot, dagDir))
+	if err != nil {
+		return assemblyGraph{}, err
+	}
+
+	graph := assemblyGraph{
+		byName:     map[string]ResponseFile{},
+		sources:    map[string][]string{},
+		references: map[string][]string{},
+		dependents: map[string][]string{},
+	}
+	for _, path := range responseFilePaths {
+		rsp, parseErr := ParseResponseFile(path)
+		if parseErr != nil {
+			return assemblyGraph{}, parseErr
+		}
+		graph.byName[rsp.AssemblyName] = rsp
+		graph.names = append(graph.names, rsp.AssemblyName)
+	}
+	sort.Strings(graph.names)
+
+	for _, name := range graph.names {
+		for _, reference := range graph.byName[name].ProjectAssemblyReferences(dagDir) {
+			if _, known := graph.byName[reference]; !known {
+				continue
+			}
+			graph.references[name] = append(graph.references[name], reference)
+			graph.dependents[reference] = append(graph.dependents[reference], name)
+		}
+	}
+
+	return graph, nil
+}
+
+// listResponseFiles names the response files in a dag directory that describe a real assembly.
+// Why .mvfrm.rsp is dropped: Bee writes those for its own framework-move step, and they carry no
+// assembly of their own.
+func listResponseFiles(dagDirectoryPath string) ([]string, error) {
+	matches, err := filepath.Glob(filepath.Join(dagDirectoryPath, "*"+responseFileExtension))
+	if err != nil {
+		return nil, fmt.Errorf("failed to list response files in %s: %w", dagDirectoryPath, err)
+	}
+
+	paths := make([]string, 0, len(matches))
+	for _, path := range matches {
+		if strings.HasSuffix(path, movedFrameworkResponseSuffix) {
+			continue
+		}
+		paths = append(paths, path)
+	}
+	if len(paths) == 0 {
+		return nil, fmt.Errorf(
+			"no Bee response files found in %s; %s", dagDirectoryPath, runCompileFirstAdvice)
+	}
+
+	return paths, nil
+}
+
+// selectChangedAssemblies rebuilds each assembly's source list and records why it needs compiling.
+func selectChangedAssemblies(
+	projectRoot string, dagDir string, graph assemblyGraph, all bool,
+) (map[string]string, error) {
+	assemblyDefinitions, err := IndexAssemblyDefinitions(projectRoot)
+	if err != nil {
+		return nil, err
+	}
+
+	reasons := map[string]string{}
+	for _, name := range graph.names {
+		rsp := graph.byName[name]
+		asmdef := lookupAssemblyDefinition(assemblyDefinitions, name)
+		if structuralErr := DetectStructuralChange(projectRoot, rsp, asmdef, dagDir); structuralErr != nil {
+			return nil, structuralErr
+		}
+
+		sources, sourceErr := RebuildSources(projectRoot, rsp, asmdef)
+		if sourceErr != nil {
+			return nil, sourceErr
+		}
+		graph.sources[name] = sources
+
+		report, changeErr := DetectSourceChange(projectRoot, rsp, sources, dagDir)
+		if changeErr != nil {
+			return nil, changeErr
+		}
+		if all || report.Changed {
+			reasons[name] = report.Reason
+		}
+	}
+
+	return reasons, nil
+}
+
+// lookupAssemblyDefinition finds the .asmdef for an assembly, if the assembly has one at all.
+func lookupAssemblyDefinition(
+	assemblyDefinitions map[string]AssemblyDefinition, name string,
+) *AssemblyDefinition {
+	definition, found := assemblyDefinitions[name]
+	if !found {
+		return nil
+	}
+
+	return &definition
+}
+
+// propagateToDependents adds every assembly that references a changed one.
+// Why: a changed assembly can alter the public API its dependents compile against, so compiling it
+// alone would miss the errors that only appear on the other side of the reference.
+func propagateToDependents(graph assemblyGraph, reasons map[string]string) {
+	queue := make([]string, 0, len(reasons))
+	for _, name := range graph.names {
+		if _, changed := reasons[name]; changed {
+			queue = append(queue, name)
+		}
+	}
+
+	for len(queue) > 0 {
+		current := queue[0]
+		queue = queue[1:]
+		for _, dependent := range graph.dependents[current] {
+			if _, changed := reasons[dependent]; changed {
+				continue
+			}
+			reasons[dependent] = dependencyReasonPrefix + current
+			queue = append(queue, dependent)
+		}
+	}
+}
+
+// topologicalOrder orders the selected assemblies so every reference is compiled before its user.
+func topologicalOrder(graph assemblyGraph, reasons map[string]string) ([]string, error) {
+	selected := map[string]bool{}
+	remaining := map[string]int{}
+	for name := range reasons {
+		selected[name] = true
+	}
+	for name := range selected {
+		for _, reference := range graph.references[name] {
+			if selected[reference] {
+				remaining[name]++
+			}
+		}
+	}
+
+	ready := []string{}
+	for _, name := range graph.names {
+		if selected[name] && remaining[name] == 0 {
+			ready = append(ready, name)
+		}
+	}
+
+	order := make([]string, 0, len(selected))
+	for len(ready) > 0 {
+		// Why the ready set is re-sorted: assemblies at the same depth have no order between them,
+		// and sorting keeps the plan identical from run to run.
+		sort.Strings(ready)
+		current := ready[0]
+		ready = ready[1:]
+		order = append(order, current)
+		for _, dependent := range graph.dependents[current] {
+			if !selected[dependent] {
+				continue
+			}
+			remaining[dependent]--
+			if remaining[dependent] == 0 {
+				ready = append(ready, dependent)
+			}
+		}
+	}
+
+	if len(order) != len(selected) {
+		return nil, fmt.Errorf(
+			"cyclic assembly references involving %s", strings.Join(unresolvedNames(selected, order), ", "))
+	}
+
+	return order, nil
+}
+
+// unresolvedNames lists the selected assemblies the topological sort could not place.
+func unresolvedNames(selected map[string]bool, order []string) []string {
+	placed := map[string]bool{}
+	for _, name := range order {
+		placed[name] = true
+	}
+
+	names := []string{}
+	for name := range selected {
+		if !placed[name] {
+			names = append(names, name)
+		}
+	}
+	sort.Strings(names)
+
+	return names
+}

--- a/cli/dispatcher/internal/compilecheck/plan_test.go
+++ b/cli/dispatcher/internal/compilecheck/plan_test.go
@@ -27,6 +27,20 @@ func writePlanAssembly(t *testing.T, projectRoot string, name string, references
 	writeFileAt(t, filepath.Join(projectRoot, planDagDirectory, name+".UnityAdditionalFile.txt"), "")
 	writeFileAt(t, filepath.Join(projectRoot, planDagDirectory, name+".dll"), "")
 	writeFileAt(t, filepath.Join(projectRoot, "Assets", name, name+".cs"), "")
+	writeFileAt(t, filepath.Join(projectRoot, "Assets", name, name+".asmdef"), `{"name":"`+name+`"}`)
+}
+
+// settlePlanProject dates every source and assembly definition before the build that produced the dlls.
+func settlePlanProject(t *testing.T, projectRoot string, names ...string) {
+	t.Helper()
+	buildTime := time.Now()
+	for _, name := range names {
+		setModificationTime(t,
+			filepath.Join(projectRoot, "Assets", name, name+".cs"), buildTime.Add(-time.Hour))
+		setModificationTime(t,
+			filepath.Join(projectRoot, "Assets", name, name+".asmdef"), buildTime.Add(-time.Hour))
+		setModificationTime(t, filepath.Join(projectRoot, planDagDirectory, name+".dll"), buildTime)
+	}
 }
 
 // joinLines assembles a response file body from its lines.
@@ -50,11 +64,20 @@ func newPlanProject(t *testing.T) string {
 	writePlanAssembly(t, projectRoot, "B", []string{"A"})
 	writePlanAssembly(t, projectRoot, "C", []string{"B"})
 
-	buildTime := time.Now()
-	for _, name := range []string{"A", "B", "C"} {
-		setModificationTime(t, filepath.Join(projectRoot, "Assets", name, name+".cs"), buildTime.Add(-time.Hour))
-		setModificationTime(t, filepath.Join(projectRoot, planDagDirectory, name+".dll"), buildTime)
-	}
+	settlePlanProject(t, projectRoot, "A", "B", "C")
+
+	return projectRoot
+}
+
+// newReversePlanProject builds a project whose dependency order is the reverse of its name order:
+// A references B references C, so a correct plan compiles C, B, A.
+func newReversePlanProject(t *testing.T) string {
+	t.Helper()
+	projectRoot := t.TempDir()
+	writePlanAssembly(t, projectRoot, "C", nil)
+	writePlanAssembly(t, projectRoot, "B", []string{"C"})
+	writePlanAssembly(t, projectRoot, "A", []string{"B"})
+	settlePlanProject(t, projectRoot, "A", "B", "C")
 
 	return projectRoot
 }
@@ -190,5 +213,67 @@ func TestBuildCompilePlanRejectsCyclicReferences(t *testing.T) {
 
 	if _, err := BuildCompilePlan(projectRoot, planDagDirectory, true); err == nil {
 		t.Fatal("expected cyclic assembly references to be rejected")
+	}
+}
+
+// Verifies dependency order wins over name order when a change propagates to dependents.
+func TestBuildCompilePlanOrdersAgainstNameOrder(t *testing.T) {
+	projectRoot := newReversePlanProject(t)
+	touchSource(t, projectRoot, "C")
+
+	plan, err := BuildCompilePlan(projectRoot, planDagDirectory, false)
+	if err != nil {
+		t.Fatalf("expected the plan to build, got error: %v", err)
+	}
+
+	assertStrings(t, "plan order", unitNames(plan), []string{"C", "B", "A"})
+}
+
+// Verifies --all also orders by dependency rather than by name.
+func TestBuildCompilePlanWithAllOrdersAgainstNameOrder(t *testing.T) {
+	projectRoot := newReversePlanProject(t)
+
+	plan, err := BuildCompilePlan(projectRoot, planDagDirectory, true)
+	if err != nil {
+		t.Fatalf("expected the plan to build, got error: %v", err)
+	}
+
+	assertStrings(t, "plan order", unitNames(plan), []string{"C", "B", "A"})
+}
+
+// Verifies an assembly definition added since the last build stops the run instead of being ignored.
+func TestBuildCompilePlanRejectsAnAssemblyDefinitionAddedAfterTheBuild(t *testing.T) {
+	projectRoot := newPlanProject(t)
+	writeFileAt(t, filepath.Join(projectRoot, "Assets", "D", "D.asmdef"), `{"name":"D"}`)
+	setModificationTime(t,
+		filepath.Join(projectRoot, "Assets", "D", "D.asmdef"), time.Now().Add(time.Hour))
+
+	if _, err := BuildCompilePlan(projectRoot, planDagDirectory, false); err == nil {
+		t.Fatal("expected a newly added assembly definition to be refused")
+	}
+}
+
+// Verifies an assembly definition Bee never built is accepted while it predates the build.
+// Platform-excluded and test-only assemblies legitimately have no response file.
+func TestBuildCompilePlanAcceptsAnAssemblyDefinitionOlderThanTheBuild(t *testing.T) {
+	projectRoot := newPlanProject(t)
+	writeFileAt(t, filepath.Join(projectRoot, "Assets", "D", "D.asmdef"), `{"name":"D"}`)
+	setModificationTime(t,
+		filepath.Join(projectRoot, "Assets", "D", "D.asmdef"), time.Now().Add(-2*time.Hour))
+
+	if _, err := BuildCompilePlan(projectRoot, planDagDirectory, false); err != nil {
+		t.Fatalf("expected an assembly definition older than the build to be accepted, got: %v", err)
+	}
+}
+
+// Verifies an assembly definition deleted since the last build stops the run.
+func TestBuildCompilePlanRejectsARemovedAssemblyDefinition(t *testing.T) {
+	projectRoot := newPlanProject(t)
+	if err := os.Remove(filepath.Join(projectRoot, "Assets", "C", "C.asmdef")); err != nil {
+		t.Fatalf("failed to remove the assembly definition: %v", err)
+	}
+
+	if _, err := BuildCompilePlan(projectRoot, planDagDirectory, false); err == nil {
+		t.Fatal("expected a removed assembly definition to be refused")
 	}
 }

--- a/cli/dispatcher/internal/compilecheck/plan_test.go
+++ b/cli/dispatcher/internal/compilecheck/plan_test.go
@@ -1,0 +1,194 @@
+package compilecheck
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+const planDagDirectory = "Library/Bee/artifacts/aaaa.dag"
+
+// writePlanAssembly writes one assembly's response file, source, built dll and Bee additional file.
+func writePlanAssembly(t *testing.T, projectRoot string, name string, references []string) {
+	t.Helper()
+	lines := []string{
+		`-out:"` + planDagDirectory + `/` + name + `.dll"`,
+		`-refout:"` + planDagDirectory + `/` + name + `.ref.dll"`,
+	}
+	for _, reference := range references {
+		lines = append(lines, `-r:"`+planDagDirectory+`/`+reference+`.ref.dll"`)
+	}
+	lines = append(lines,
+		`/additionalfile:"`+planDagDirectory+`/`+name+`.UnityAdditionalFile.txt"`,
+		`"Assets/`+name+`/`+name+`.cs"`)
+
+	writeFileAt(t, filepath.Join(projectRoot, planDagDirectory, name+".rsp"), joinLines(lines))
+	writeFileAt(t, filepath.Join(projectRoot, planDagDirectory, name+".UnityAdditionalFile.txt"), "")
+	writeFileAt(t, filepath.Join(projectRoot, planDagDirectory, name+".dll"), "")
+	writeFileAt(t, filepath.Join(projectRoot, "Assets", name, name+".cs"), "")
+}
+
+// joinLines assembles a response file body from its lines.
+func joinLines(lines []string) string {
+	body := ""
+	for index, line := range lines {
+		if index > 0 {
+			body += "\n"
+		}
+		body += line
+	}
+
+	return body
+}
+
+// newPlanProject builds a project with A <- B <- C, all built after their sources were written.
+func newPlanProject(t *testing.T) string {
+	t.Helper()
+	projectRoot := t.TempDir()
+	writePlanAssembly(t, projectRoot, "A", nil)
+	writePlanAssembly(t, projectRoot, "B", []string{"A"})
+	writePlanAssembly(t, projectRoot, "C", []string{"B"})
+
+	buildTime := time.Now()
+	for _, name := range []string{"A", "B", "C"} {
+		setModificationTime(t, filepath.Join(projectRoot, "Assets", name, name+".cs"), buildTime.Add(-time.Hour))
+		setModificationTime(t, filepath.Join(projectRoot, planDagDirectory, name+".dll"), buildTime)
+	}
+
+	return projectRoot
+}
+
+// touchSource marks one assembly's source as edited after the last Unity build.
+func touchSource(t *testing.T, projectRoot string, name string) {
+	t.Helper()
+	setModificationTime(t,
+		filepath.Join(projectRoot, "Assets", name, name+".cs"), time.Now().Add(time.Hour))
+}
+
+// unitNames lists the assemblies a plan compiles, in plan order.
+func unitNames(plan BuildPlan) []string {
+	names := make([]string, 0, len(plan.Units))
+	for _, unit := range plan.Units {
+		names = append(names, unit.Assembly.AssemblyName)
+	}
+
+	return names
+}
+
+// Verifies a change in a referenced assembly pulls its dependents in, in dependency order.
+func TestBuildCompilePlanPropagatesToDependentsInDependencyOrder(t *testing.T) {
+	projectRoot := newPlanProject(t)
+	touchSource(t, projectRoot, "A")
+
+	plan, err := BuildCompilePlan(projectRoot, planDagDirectory, false)
+	if err != nil {
+		t.Fatalf("expected the plan to build, got error: %v", err)
+	}
+
+	assertStrings(t, "units", unitNames(plan), []string{"A", "B", "C"})
+	if plan.Units[0].Reason != changeReasonSourceNewer {
+		t.Errorf("A reason = %q, want %q", plan.Units[0].Reason, changeReasonSourceNewer)
+	}
+	if plan.Units[1].Reason != dependencyReasonPrefix+"A" {
+		t.Errorf("B reason = %q, want %q", plan.Units[1].Reason, dependencyReasonPrefix+"A")
+	}
+	if plan.Units[2].Reason != dependencyReasonPrefix+"B" {
+		t.Errorf("C reason = %q, want %q", plan.Units[2].Reason, dependencyReasonPrefix+"B")
+	}
+	if plan.Skipped != 0 {
+		t.Errorf("skipped = %d, want 0", plan.Skipped)
+	}
+}
+
+// Verifies a change in a leaf assembly compiles that assembly alone.
+func TestBuildCompilePlanCompilesOnlyTheChangedLeaf(t *testing.T) {
+	projectRoot := newPlanProject(t)
+	touchSource(t, projectRoot, "C")
+
+	plan, err := BuildCompilePlan(projectRoot, planDagDirectory, false)
+	if err != nil {
+		t.Fatalf("expected the plan to build, got error: %v", err)
+	}
+
+	assertStrings(t, "units", unitNames(plan), []string{"C"})
+	if plan.Skipped != 2 {
+		t.Errorf("skipped = %d, want 2", plan.Skipped)
+	}
+}
+
+// Verifies an unchanged project produces an empty plan rather than recompiling everything.
+func TestBuildCompilePlanSkipsEverythingWhenNothingChanged(t *testing.T) {
+	projectRoot := newPlanProject(t)
+
+	plan, err := BuildCompilePlan(projectRoot, planDagDirectory, false)
+	if err != nil {
+		t.Fatalf("expected the plan to build, got error: %v", err)
+	}
+
+	if len(plan.Units) != 0 {
+		t.Errorf("units = %v, want none", unitNames(plan))
+	}
+	if plan.Skipped != 3 {
+		t.Errorf("skipped = %d, want 3", plan.Skipped)
+	}
+}
+
+// Verifies --all compiles every assembly and still respects dependency order.
+func TestBuildCompilePlanWithAllKeepsDependencyOrder(t *testing.T) {
+	projectRoot := newPlanProject(t)
+
+	plan, err := BuildCompilePlan(projectRoot, planDagDirectory, true)
+	if err != nil {
+		t.Fatalf("expected the plan to build, got error: %v", err)
+	}
+
+	assertStrings(t, "units", unitNames(plan), []string{"A", "B", "C"})
+	if plan.Units[0].Reason != "" {
+		t.Errorf("an --all unit should carry no change reason, got %q", plan.Units[0].Reason)
+	}
+	if plan.OutputDir != filepath.Join("Library", "uloop", "compile-check", "aaaa.dag") {
+		t.Errorf("output directory = %s", plan.OutputDir)
+	}
+}
+
+// Verifies the Bee framework-move response files are not mistaken for assemblies.
+func TestBuildCompilePlanIgnoresMovedFrameworkResponseFiles(t *testing.T) {
+	projectRoot := newPlanProject(t)
+	writeFileAt(t, filepath.Join(projectRoot, planDagDirectory, "A.dll.mvfrm.rsp"), "not a response file")
+
+	plan, err := BuildCompilePlan(projectRoot, planDagDirectory, true)
+	if err != nil {
+		t.Fatalf("expected the plan to build, got error: %v", err)
+	}
+
+	assertStrings(t, "units", unitNames(plan), []string{"A", "B", "C"})
+}
+
+// Verifies a dag directory with no response files is rejected with recovery advice.
+func TestBuildCompilePlanRejectsEmptyDagDirectory(t *testing.T) {
+	projectRoot := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(projectRoot, planDagDirectory), 0o755); err != nil {
+		t.Fatalf("failed to create the dag directory: %v", err)
+	}
+
+	if _, err := BuildCompilePlan(projectRoot, planDagDirectory, true); err == nil {
+		t.Fatal("expected an empty dag directory to be rejected")
+	}
+}
+
+// Verifies a cycle between assembly references is reported instead of silently dropping assemblies.
+func TestBuildCompilePlanRejectsCyclicReferences(t *testing.T) {
+	projectRoot := t.TempDir()
+	writePlanAssembly(t, projectRoot, "A", []string{"B"})
+	writePlanAssembly(t, projectRoot, "B", []string{"A"})
+	buildTime := time.Now()
+	for _, name := range []string{"A", "B"} {
+		setModificationTime(t, filepath.Join(projectRoot, "Assets", name, name+".cs"), buildTime.Add(-time.Hour))
+		setModificationTime(t, filepath.Join(projectRoot, planDagDirectory, name+".dll"), buildTime)
+	}
+
+	if _, err := BuildCompilePlan(projectRoot, planDagDirectory, true); err == nil {
+		t.Fatal("expected cyclic assembly references to be rejected")
+	}
+}

--- a/cli/dispatcher/internal/compilecheck/response_file.go
+++ b/cli/dispatcher/internal/compilecheck/response_file.go
@@ -1,0 +1,131 @@
+package compilecheck
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	responseFileExtension      = ".rsp"
+	referenceAssemblyExtension = ".ref.dll"
+
+	outputFlagPrefix         = "-out:"
+	referenceOutputFlagPref  = "-refout:"
+	defineFlagPrefix         = "-define:"
+	referenceFlagPrefix      = "-r:"
+	analyzerFlagPrefix       = "-analyzer:"
+	additionalFileFlagPrefix = "/additionalfile:"
+)
+
+// ResponseFile is one Bee-written csc response file, split into the parts compile-check rewrites.
+type ResponseFile struct {
+	AssemblyName   string // the response file base name without its extension
+	Path           string // absolute path of the original response file
+	OutputPath     string // -out value, relative to the project root
+	RefOutputPath  string // -refout value, relative to the project root
+	Defines        []string
+	References     []string // -r values, order preserved, duplicates kept
+	Analyzers      []string
+	Sources        []string // unquoted, relative to the project root
+	AdditionalFile string   // /additionalfile value
+	OtherFlags     []string // every other flag line, verbatim
+}
+
+// ParseResponseFile reads one Bee response file into its parts.
+func ParseResponseFile(path string) (ResponseFile, error) {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return ResponseFile{}, fmt.Errorf("failed to read response file %s: %w", path, err)
+	}
+
+	parsed := ResponseFile{
+		AssemblyName: strings.TrimSuffix(filepath.Base(path), responseFileExtension),
+		Path:         path,
+	}
+	for _, rawLine := range strings.Split(string(content), "\n") {
+		line := strings.TrimRight(rawLine, "\r")
+		if line == "" {
+			continue
+		}
+		if err := parsed.appendLine(line); err != nil {
+			return ResponseFile{}, fmt.Errorf("%w in %s", err, path)
+		}
+	}
+
+	if parsed.OutputPath == "" {
+		return ResponseFile{}, fmt.Errorf("response file %s has no -out flag", path)
+	}
+	if len(parsed.Sources) == 0 {
+		return ResponseFile{}, fmt.Errorf("response file %s lists no source files", path)
+	}
+
+	return parsed, nil
+}
+
+// appendLine sorts one response file line into the field it belongs to.
+func (r *ResponseFile) appendLine(line string) error {
+	switch {
+	case strings.HasPrefix(line, outputFlagPrefix):
+		r.OutputPath = unquotePath(strings.TrimPrefix(line, outputFlagPrefix))
+	case strings.HasPrefix(line, referenceOutputFlagPref):
+		r.RefOutputPath = unquotePath(strings.TrimPrefix(line, referenceOutputFlagPref))
+	case strings.HasPrefix(line, defineFlagPrefix):
+		r.Defines = append(r.Defines, strings.TrimPrefix(line, defineFlagPrefix))
+	case strings.HasPrefix(line, referenceFlagPrefix):
+		r.References = append(r.References, unquotePath(strings.TrimPrefix(line, referenceFlagPrefix)))
+	case strings.HasPrefix(line, analyzerFlagPrefix):
+		r.Analyzers = append(r.Analyzers, unquotePath(strings.TrimPrefix(line, analyzerFlagPrefix)))
+	case strings.HasPrefix(line, additionalFileFlagPrefix):
+		r.AdditionalFile = unquotePath(strings.TrimPrefix(line, additionalFileFlagPrefix))
+	case line[0] == '"':
+		r.Sources = append(r.Sources, unquotePath(line))
+	case line[0] == '-' || line[0] == '/':
+		r.OtherFlags = append(r.OtherFlags, line)
+	default:
+		return fmt.Errorf("unrecognized response file line %q", line)
+	}
+
+	return nil
+}
+
+// ProjectAssemblyReferences names the other project assemblies this one references by reference
+// assembly. dagDir must be spelled the way the response file spells it, which is relative to the
+// project root: Bee writes every project-local path relative to the root the compiler runs from.
+func (r ResponseFile) ProjectAssemblyReferences(dagDir string) []string {
+	names := make([]string, 0, len(r.References))
+	for _, reference := range r.References {
+		name, ok := projectAssemblyReferenceName(reference, dagDir)
+		if ok {
+			names = append(names, name)
+		}
+	}
+
+	return names
+}
+
+// projectAssemblyReferenceName reads the assembly name out of a "<dagDir>/<name>.ref.dll" reference.
+// Why the separators are normalized: the response file and the caller's dag directory can spell the
+// same path with different separators on Windows, and a raw comparison would silently match nothing.
+func projectAssemblyReferenceName(reference string, dagDir string) (string, bool) {
+	normalizedReference := filepath.ToSlash(reference)
+	prefix := strings.TrimSuffix(filepath.ToSlash(dagDir), "/") + "/"
+	if !strings.HasPrefix(normalizedReference, prefix) {
+		return "", false
+	}
+
+	name := strings.TrimPrefix(normalizedReference, prefix)
+	if !strings.HasSuffix(name, referenceAssemblyExtension) || strings.Contains(name, "/") {
+		return "", false
+	}
+
+	return strings.TrimSuffix(name, referenceAssemblyExtension), true
+}
+
+// unquotePath strips the one pair of quotes Bee writes around a path and adapts its separators.
+func unquotePath(value string) string {
+	unquoted := strings.TrimSuffix(strings.TrimPrefix(value, `"`), `"`)
+
+	return filepath.FromSlash(unquoted)
+}

--- a/cli/dispatcher/internal/compilecheck/response_file_test.go
+++ b/cli/dispatcher/internal/compilecheck/response_file_test.go
@@ -1,0 +1,153 @@
+package compilecheck
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const sampleDagDirectory = "Library/Bee/artifacts/aaaa.dag"
+
+// sampleResponseFileLines is one Bee response file shrunk to one line per shape the parser handles.
+func sampleResponseFileLines() []string {
+	return []string{
+		`-target:library`,
+		`-out:"` + sampleDagDirectory + `/Sample.dll"`,
+		`-refout:"` + sampleDagDirectory + `/Sample.ref.dll"`,
+		`-define:UNITY_2022_3_62`,
+		`-define:UNITY_EDITOR`,
+		`-r:"/Applications/Unity/Editor/Data/Managed/UnityEngine.dll"`,
+		`-r:"` + sampleDagDirectory + `/Other.ref.dll"`,
+		`-r:"Library/ScriptAssemblies/External.dll"`,
+		`-analyzer:"/Applications/Unity/Editor/Data/Tools/Unity.SourceGenerators.dll"`,
+		`"Assets/Scripts/First.cs"`,
+		`"Assets/Scripts/Second.cs"`,
+		`-langversion:9.0`,
+		`/deterministic`,
+		`/nowarn:0169`,
+		`/additionalfile:"` + sampleDagDirectory + `/Sample.UnityAdditionalFile.txt"`,
+	}
+}
+
+// writeResponseFile writes the given lines joined by the given terminator, with no trailing newline.
+func writeResponseFile(t *testing.T, lines []string, lineTerminator string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "Sample.rsp")
+	if err := os.WriteFile(path, []byte(strings.Join(lines, lineTerminator)), 0o600); err != nil {
+		t.Fatalf("failed to write the response file: %v", err)
+	}
+
+	return path
+}
+
+// assertSampleFields checks every field the parser fills from the sample response file.
+func assertSampleFields(t *testing.T, parsed ResponseFile) {
+	t.Helper()
+	if parsed.AssemblyName != "Sample" {
+		t.Errorf("assembly name = %s, want Sample", parsed.AssemblyName)
+	}
+	if parsed.OutputPath != filepath.FromSlash(sampleDagDirectory+"/Sample.dll") {
+		t.Errorf("output path = %s", parsed.OutputPath)
+	}
+	if parsed.RefOutputPath != filepath.FromSlash(sampleDagDirectory+"/Sample.ref.dll") {
+		t.Errorf("ref output path = %s", parsed.RefOutputPath)
+	}
+	assertStrings(t, "defines", parsed.Defines, []string{"UNITY_2022_3_62", "UNITY_EDITOR"})
+	assertStrings(t, "references", parsed.References, []string{
+		filepath.FromSlash("/Applications/Unity/Editor/Data/Managed/UnityEngine.dll"),
+		filepath.FromSlash(sampleDagDirectory + "/Other.ref.dll"),
+		filepath.FromSlash("Library/ScriptAssemblies/External.dll"),
+	})
+	assertStrings(t, "analyzers", parsed.Analyzers, []string{
+		filepath.FromSlash("/Applications/Unity/Editor/Data/Tools/Unity.SourceGenerators.dll"),
+	})
+	assertStrings(t, "sources", parsed.Sources, []string{
+		filepath.FromSlash("Assets/Scripts/First.cs"),
+		filepath.FromSlash("Assets/Scripts/Second.cs"),
+	})
+	if parsed.AdditionalFile != filepath.FromSlash(sampleDagDirectory+"/Sample.UnityAdditionalFile.txt") {
+		t.Errorf("additional file = %s", parsed.AdditionalFile)
+	}
+	assertStrings(t, "other flags", parsed.OtherFlags, []string{
+		"-target:library", "-langversion:9.0", "/deterministic", "/nowarn:0169",
+	})
+}
+
+// assertStrings reports the first difference between a parsed slice and what the sample expects.
+func assertStrings(t *testing.T, label string, got []string, want []string) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Errorf("%s = %v, want %v", label, got, want)
+
+		return
+	}
+	for index := range want {
+		if got[index] != want[index] {
+			t.Errorf("%s[%d] = %s, want %s", label, index, got[index], want[index])
+		}
+	}
+}
+
+// Verifies every flag shape in a Bee response file lands in the field it belongs to.
+func TestParseResponseFileSplitsEveryFlagShape(t *testing.T) {
+	parsed, err := ParseResponseFile(writeResponseFile(t, sampleResponseFileLines(), "\n"))
+	if err != nil {
+		t.Fatalf("expected the sample to parse, got error: %v", err)
+	}
+
+	assertSampleFields(t, parsed)
+}
+
+// Verifies a response file written with Windows line endings parses identically.
+func TestParseResponseFileAcceptsCarriageReturnLineEndings(t *testing.T) {
+	parsed, err := ParseResponseFile(writeResponseFile(t, sampleResponseFileLines(), "\r\n"))
+	if err != nil {
+		t.Fatalf("expected the sample to parse, got error: %v", err)
+	}
+
+	assertSampleFields(t, parsed)
+}
+
+// Verifies only the references that name a reference assembly in the dag directory become dependencies.
+func TestParseResponseFileReportsProjectAssemblyReferences(t *testing.T) {
+	parsed, err := ParseResponseFile(writeResponseFile(t, sampleResponseFileLines(), "\n"))
+	if err != nil {
+		t.Fatalf("expected the sample to parse, got error: %v", err)
+	}
+
+	assertStrings(t, "project references", parsed.ProjectAssemblyReferences(sampleDagDirectory), []string{"Other"})
+}
+
+// Verifies a line that is neither a flag nor a quoted source is rejected instead of silently dropped.
+func TestParseResponseFileRejectsUnrecognizedLine(t *testing.T) {
+	lines := append(sampleResponseFileLines(), "foo")
+
+	_, err := ParseResponseFile(writeResponseFile(t, lines, "\n"))
+	if err == nil {
+		t.Fatal("expected an unrecognized line to fail the parse")
+	}
+	if !strings.Contains(err.Error(), `"foo"`) {
+		t.Errorf("error should name the offending line, got: %v", err)
+	}
+}
+
+// Verifies a response file with no -out flag is rejected rather than producing an unusable plan.
+func TestParseResponseFileRequiresOutputFlag(t *testing.T) {
+	lines := []string{`"Assets/Scripts/First.cs"`}
+
+	_, err := ParseResponseFile(writeResponseFile(t, lines, "\n"))
+	if err == nil {
+		t.Fatal("expected a response file without -out to fail the parse")
+	}
+}
+
+// Verifies a response file that lists no sources is rejected.
+func TestParseResponseFileRequiresSources(t *testing.T) {
+	lines := []string{`-out:"` + sampleDagDirectory + `/Sample.dll"`}
+
+	_, err := ParseResponseFile(writeResponseFile(t, lines, "\n"))
+	if err == nil {
+		t.Fatal("expected a response file without sources to fail the parse")
+	}
+}

--- a/cli/dispatcher/internal/compilecheck/session.go
+++ b/cli/dispatcher/internal/compilecheck/session.go
@@ -1,0 +1,216 @@
+package compilecheck
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+const (
+	beeDirectoryName            = "Bee"
+	beeArtifactsDirectoryName   = "artifacts"
+	tundraLogFileName           = "tundra.log.json"
+	editorScriptingSettingsFile = "EditorOnlyScriptingSettings.json"
+	dagDirectorySuffix          = ".dag"
+	debugDagDirectorySuffix     = "Dbg.dag"
+
+	unitCompileTimeout = 120 * time.Second
+)
+
+// Options are the inputs of one compile-check run.
+type Options struct {
+	ProjectRoot          string
+	EditorExecutablePath string
+	All                  bool
+}
+
+// Result is everything one compile-check run produced.
+type Result struct {
+	DagDir       string
+	Units        []UnitResult
+	Skipped      int
+	ChangedCount int
+}
+
+// Run compiles the assemblies that need checking and collects their diagnostics.
+func Run(ctx context.Context, options Options) (Result, error) {
+	dagDir, err := ResolveActiveDagDir(options.ProjectRoot)
+	if err != nil {
+		return Result{}, err
+	}
+
+	paths, err := ResolveEditorCompilerPaths(options.EditorExecutablePath)
+	if err != nil {
+		return Result{}, err
+	}
+
+	plan, err := BuildCompilePlan(options.ProjectRoot, dagDir, options.All)
+	if err != nil {
+		return Result{}, err
+	}
+
+	compiler := Compiler{
+		Paths:       paths,
+		ProjectRoot: options.ProjectRoot,
+		Timeout:     unitCompileTimeout,
+		Run:         defaultRun,
+	}
+
+	units := make([]UnitResult, 0, len(plan.Units))
+	for _, unit := range plan.Units {
+		// Why the run continues after a failure: an assembly that failed leaves its dependents
+		// reading Unity's older reference assembly, which can add follow-on errors, but reporting
+		// every assembly's diagnostics in one pass is the point of the command.
+		result, compileErr := compiler.CompileUnit(ctx, plan, unit)
+		if compileErr != nil {
+			return Result{}, compileErr
+		}
+		units = append(units, result)
+	}
+
+	return Result{
+		DagDir:       dagDir,
+		Units:        units,
+		Skipped:      plan.Skipped,
+		ChangedCount: len(plan.Units),
+	}, nil
+}
+
+// defaultRun runs one compiler invocation and reports its output and exit code.
+func defaultRun(_ context.Context, cmd *exec.Cmd) (string, string, int, error) {
+	stdout := bytes.Buffer{}
+	stderr := bytes.Buffer{}
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+	exitCode := 0
+	var exitError *exec.ExitError
+	if errors.As(err, &exitError) {
+		exitCode = exitError.ExitCode()
+	}
+
+	return stdout.String(), stderr.String(), exitCode, err
+}
+
+// ResolveActiveDagDir names the Bee dag directory Unity used for its most recent build.
+func ResolveActiveDagDir(projectRoot string) (string, error) {
+	beeDirectory := filepath.Join(projectRoot, libraryDirectoryName, beeDirectoryName)
+	artifactsDirectory := filepath.Join(beeDirectory, beeArtifactsDirectoryName)
+
+	candidates, err := dagDirectoryNames(artifactsDirectory)
+	if err != nil {
+		return "", err
+	}
+
+	if name, found := dagNameFromTundraLog(beeDirectory); found && containsName(candidates, name) {
+		return relativeDagDir(name), nil
+	}
+	if len(candidates) == 1 {
+		return relativeDagDir(candidates[0]), nil
+	}
+
+	name, found := dagNameFromScriptDebugSetting(projectRoot, candidates)
+	if !found {
+		return "", fmt.Errorf(
+			"cannot tell which Bee build to check in %s; %s", artifactsDirectory, runCompileFirstAdvice)
+	}
+
+	return relativeDagDir(name), nil
+}
+
+// relativeDagDir spells one dag directory the way the response files inside it spell project paths.
+func relativeDagDir(name string) string {
+	return filepath.Join(libraryDirectoryName, beeDirectoryName, beeArtifactsDirectoryName, name)
+}
+
+// dagDirectoryNames lists the dag directories Bee has written for this project.
+func dagDirectoryNames(artifactsDirectory string) ([]string, error) {
+	entries, err := os.ReadDir(artifactsDirectory)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"no Bee build artifacts found in %s; %s", artifactsDirectory, runCompileFirstAdvice)
+	}
+
+	names := []string{}
+	for _, entry := range entries {
+		if !strings.HasSuffix(entry.Name(), dagDirectorySuffix) {
+			continue
+		}
+		if directoryExists(filepath.Join(artifactsDirectory, entry.Name())) {
+			names = append(names, entry.Name())
+		}
+	}
+	if len(names) == 0 {
+		return nil, fmt.Errorf(
+			"no Bee build artifacts found in %s; %s", artifactsDirectory, runCompileFirstAdvice)
+	}
+	sort.Strings(names)
+
+	return names, nil
+}
+
+// dagNameFromTundraLog reads the dag Unity opened for its last build out of the Bee log.
+// Why the log rather than modification times: both dag directories are touched by unrelated Bee
+// work, so their timestamps do not say which one the Editor actually built.
+func dagNameFromTundraLog(beeDirectory string) (string, bool) {
+	file, err := os.Open(filepath.Join(beeDirectory, tundraLogFileName))
+	if err != nil {
+		return "", false
+	}
+	defer func() { _ = file.Close() }()
+
+	var firstLine struct {
+		DagFile string `json:"dagFile"`
+	}
+	if err := json.NewDecoder(file).Decode(&firstLine); err != nil || firstLine.DagFile == "" {
+		return "", false
+	}
+
+	return filepath.Base(filepath.FromSlash(firstLine.DagFile)), true
+}
+
+// dagNameFromScriptDebugSetting picks between the debug and release dag using the project setting.
+func dagNameFromScriptDebugSetting(projectRoot string, candidates []string) (string, bool) {
+	content, err := os.ReadFile(
+		filepath.Join(projectRoot, libraryDirectoryName, editorScriptingSettingsFile))
+	if err != nil {
+		return "", false
+	}
+
+	var settings struct {
+		ScriptDebugInfoEnabled struct {
+			Value bool `json:"m_Value"`
+		} `json:"m_ScriptDebugInfoEnabled"`
+	}
+	if err := json.Unmarshal(content, &settings); err != nil {
+		return "", false
+	}
+
+	for _, name := range candidates {
+		if strings.HasSuffix(name, debugDagDirectorySuffix) == settings.ScriptDebugInfoEnabled.Value {
+			return name, true
+		}
+	}
+
+	return "", false
+}
+
+// containsName reports whether a name is in a list.
+func containsName(names []string, name string) bool {
+	for _, candidate := range names {
+		if candidate == name {
+			return true
+		}
+	}
+
+	return false
+}

--- a/cli/dispatcher/internal/compilecheck/session_test.go
+++ b/cli/dispatcher/internal/compilecheck/session_test.go
@@ -1,0 +1,120 @@
+package compilecheck
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// newDagProject lays out a project whose Bee artifacts hold the named dag directories.
+func newDagProject(t *testing.T, dagNames ...string) string {
+	t.Helper()
+
+	projectRoot := t.TempDir()
+	for _, name := range dagNames {
+		makeDirAt(t, filepath.Join(
+			projectRoot, libraryDirectoryName, beeDirectoryName, beeArtifactsDirectoryName, name))
+	}
+
+	return projectRoot
+}
+
+// writeTundraLog writes a Bee log whose first object names the dag file of the last build.
+func writeTundraLog(t *testing.T, projectRoot string, dagName string) {
+	t.Helper()
+
+	writeFileAt(t,
+		filepath.Join(projectRoot, libraryDirectoryName, beeDirectoryName, tundraLogFileName),
+		`{"dagFile":"Library/Bee/`+dagName+`","other":1}`+"\n{\"msg\":\"later line\"}\n")
+}
+
+// writeScriptDebugSetting writes the project setting that says whether debug scripting is on.
+func writeScriptDebugSetting(t *testing.T, projectRoot string, enabled bool) {
+	t.Helper()
+
+	value := "false"
+	if enabled {
+		value = "true"
+	}
+	writeFileAt(t,
+		filepath.Join(projectRoot, libraryDirectoryName, editorScriptingSettingsFile),
+		`{"m_ScriptDebugInfoEnabled":{"m_Value":`+value+`}}`)
+}
+
+// Verifies the Bee log decides the dag even when several dag directories exist.
+func TestResolveActiveDagDirPrefersTheDagNamedByTheBeeLog(t *testing.T) {
+	projectRoot := newDagProject(t, "aaaa.dag", "aaaaDbg.dag")
+	writeTundraLog(t, projectRoot, "aaaaDbg.dag")
+	// The setting disagrees with the log, so only a resolver that reads the log passes.
+	writeScriptDebugSetting(t, projectRoot, false)
+
+	dagDir, err := ResolveActiveDagDir(projectRoot)
+	if err != nil {
+		t.Fatalf("expected the dag to resolve, got error: %v", err)
+	}
+
+	want := filepath.Join(libraryDirectoryName, beeDirectoryName, beeArtifactsDirectoryName, "aaaaDbg.dag")
+	if dagDir != want {
+		t.Errorf("expected %q, got %q", want, dagDir)
+	}
+}
+
+// Verifies a log naming a dag Bee never wrote is ignored rather than trusted.
+func TestResolveActiveDagDirIgnoresABeeLogNamingAMissingDag(t *testing.T) {
+	projectRoot := newDagProject(t, "aaaa.dag", "aaaaDbg.dag")
+	writeTundraLog(t, projectRoot, "gone.dag")
+	writeScriptDebugSetting(t, projectRoot, true)
+
+	dagDir, err := ResolveActiveDagDir(projectRoot)
+	if err != nil {
+		t.Fatalf("expected the dag to resolve, got error: %v", err)
+	}
+
+	if filepath.Base(dagDir) != "aaaaDbg.dag" {
+		t.Errorf("expected the setting to decide, got %q", dagDir)
+	}
+}
+
+// Verifies a single dag directory is used even with no Bee log at all.
+func TestResolveActiveDagDirUsesTheOnlyDagWithoutABeeLog(t *testing.T) {
+	projectRoot := newDagProject(t, "aaaa.dag")
+
+	dagDir, err := ResolveActiveDagDir(projectRoot)
+	if err != nil {
+		t.Fatalf("expected the dag to resolve, got error: %v", err)
+	}
+
+	if filepath.Base(dagDir) != "aaaa.dag" {
+		t.Errorf("expected the only dag, got %q", dagDir)
+	}
+}
+
+// Verifies the script-debug setting picks the release dag when it is off and no log exists.
+func TestResolveActiveDagDirFallsBackToTheScriptDebugSetting(t *testing.T) {
+	projectRoot := newDagProject(t, "aaaa.dag", "aaaaDbg.dag")
+	writeScriptDebugSetting(t, projectRoot, false)
+
+	dagDir, err := ResolveActiveDagDir(projectRoot)
+	if err != nil {
+		t.Fatalf("expected the dag to resolve, got error: %v", err)
+	}
+
+	if filepath.Base(dagDir) != "aaaa.dag" {
+		t.Errorf("expected the release dag, got %q", dagDir)
+	}
+}
+
+// Verifies an ambiguous project with no log and no setting fails instead of guessing.
+func TestResolveActiveDagDirFailsWhenNothingDistinguishesTheDags(t *testing.T) {
+	projectRoot := newDagProject(t, "aaaa.dag", "aaaaDbg.dag")
+
+	if _, err := ResolveActiveDagDir(projectRoot); err == nil {
+		t.Fatal("expected an ambiguous project to fail")
+	}
+}
+
+// Verifies a project Unity has never built reports that instead of an empty dag.
+func TestResolveActiveDagDirFailsWhenNoArtifactsExist(t *testing.T) {
+	if _, err := ResolveActiveDagDir(t.TempDir()); err == nil {
+		t.Fatal("expected a project without Bee artifacts to fail")
+	}
+}

--- a/cli/dispatcher/internal/compilecheck/source_set.go
+++ b/cli/dispatcher/internal/compilecheck/source_set.go
@@ -1,0 +1,212 @@
+package compilecheck
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+const (
+	assetsDirectoryName          = "Assets"
+	packagesDirectoryName        = "Packages"
+	libraryDirectoryName         = "Library"
+	packageCacheDirectoryName    = "PackageCache"
+	assemblyDefinitionExtension  = ".asmdef"
+	assemblyReferenceExtension   = ".asmref"
+	cSharpSourceExtension        = ".cs"
+	unityIgnoredDirectorySuffix  = "~"
+	unityHiddenDirectoryPrefix   = "."
+	assemblyDefinitionIndexError = "failed to index assembly definitions under %s: %w"
+)
+
+// AssemblyDefinition is one .asmdef file, keyed by the assembly name it declares.
+type AssemblyDefinition struct {
+	Name      string
+	Path      string // absolute path of the .asmdef file
+	Directory string // absolute path of the directory that owns the assembly
+}
+
+// IndexAssemblyDefinitions maps every assembly name in the project to the .asmdef that declares it.
+func IndexAssemblyDefinitions(projectRoot string) (map[string]AssemblyDefinition, error) {
+	index := map[string]AssemblyDefinition{}
+	roots := []string{
+		filepath.Join(projectRoot, assetsDirectoryName),
+		filepath.Join(projectRoot, packagesDirectoryName),
+		filepath.Join(projectRoot, libraryDirectoryName, packageCacheDirectoryName),
+	}
+	for _, root := range roots {
+		if !directoryExists(root) {
+			continue
+		}
+		if err := indexAssemblyDefinitionsUnder(root, index); err != nil {
+			return nil, fmt.Errorf(assemblyDefinitionIndexError, root, err)
+		}
+	}
+
+	return index, nil
+}
+
+// indexAssemblyDefinitionsUnder adds every .asmdef found below one project root to the index.
+func indexAssemblyDefinitionsUnder(root string, index map[string]AssemblyDefinition) error {
+	return filepath.WalkDir(root, func(path string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() {
+			if path != root && isUnityIgnoredDirectory(entry.Name()) {
+				return filepath.SkipDir
+			}
+
+			return nil
+		}
+		if filepath.Ext(path) != assemblyDefinitionExtension {
+			return nil
+		}
+		name, readErr := readAssemblyDefinitionName(path)
+		if readErr != nil {
+			return readErr
+		}
+		// Why the first wins: Unity itself rejects duplicate assembly names, so a second one means a
+		// stale copy, and taking it would point the rebuild at the wrong directory.
+		if _, exists := index[name]; !exists {
+			index[name] = AssemblyDefinition{Name: name, Path: path, Directory: filepath.Dir(path)}
+		}
+
+		return nil
+	})
+}
+
+// readAssemblyDefinitionName reads the assembly name an .asmdef declares.
+func readAssemblyDefinitionName(path string) (string, error) {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+
+	var definition struct {
+		Name string `json:"name"`
+	}
+	if err := json.Unmarshal(content, &definition); err != nil {
+		return "", fmt.Errorf("failed to read %s: %w", path, err)
+	}
+	if definition.Name == "" {
+		return "", fmt.Errorf("%s declares no assembly name", path)
+	}
+
+	return definition.Name, nil
+}
+
+// RebuildSources lists the sources to compile now, reflecting .cs files added or deleted since Bee ran.
+func RebuildSources(projectRoot string, rsp ResponseFile, asmdef *AssemblyDefinition) ([]string, error) {
+	existing := make([]string, 0, len(rsp.Sources))
+	for _, source := range rsp.Sources {
+		if fileExists(filepath.Join(projectRoot, source)) {
+			existing = append(existing, source)
+		}
+	}
+
+	// Why package-cache assemblies are not re-globbed: their contents are restored from the package
+	// manager and never edited in place, so the walk would only cost time.
+	if asmdef == nil || isUnderPackageCache(projectRoot, asmdef.Directory) {
+		sort.Strings(existing)
+
+		return existing, nil
+	}
+
+	globbed, err := globAssemblySources(projectRoot, asmdef.Directory)
+	if err != nil {
+		return nil, err
+	}
+
+	// Why sources outside the directory survive: an .asmref pulls files from elsewhere into this
+	// assembly, and only the response file records where they came from.
+	result := globbed
+	for _, source := range existing {
+		if !isUnderDirectory(filepath.Join(projectRoot, source), asmdef.Directory) {
+			result = append(result, source)
+		}
+	}
+	sort.Strings(result)
+
+	return result, nil
+}
+
+// globAssemblySources lists the .cs files an assembly owns, stopping at nested assembly boundaries.
+func globAssemblySources(projectRoot string, assemblyDirectory string) ([]string, error) {
+	sources := []string{}
+	err := filepath.WalkDir(assemblyDirectory, func(path string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() {
+			if path == assemblyDirectory {
+				return nil
+			}
+			if isUnityIgnoredDirectory(entry.Name()) || directoryOwnsOwnAssembly(path) {
+				return filepath.SkipDir
+			}
+
+			return nil
+		}
+		if filepath.Ext(path) != cSharpSourceExtension {
+			return nil
+		}
+		relativePath, relErr := filepath.Rel(projectRoot, path)
+		if relErr != nil {
+			return relErr
+		}
+		sources = append(sources, relativePath)
+
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list sources under %s: %w", assemblyDirectory, err)
+	}
+
+	return sources, nil
+}
+
+// directoryOwnsOwnAssembly reports whether a directory starts a different assembly.
+func directoryOwnsOwnAssembly(path string) bool {
+	entries, err := os.ReadDir(path)
+	if err != nil {
+		return false
+	}
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		extension := filepath.Ext(entry.Name())
+		if extension == assemblyDefinitionExtension || extension == assemblyReferenceExtension {
+			return true
+		}
+	}
+
+	return false
+}
+
+// isUnityIgnoredDirectory reports whether Unity excludes a directory from compilation by its name.
+func isUnityIgnoredDirectory(name string) bool {
+	return strings.HasSuffix(name, unityIgnoredDirectorySuffix) ||
+		strings.HasPrefix(name, unityHiddenDirectoryPrefix)
+}
+
+// isUnderPackageCache reports whether a directory belongs to the read-only package cache.
+func isUnderPackageCache(projectRoot string, directory string) bool {
+	return isUnderDirectory(
+		directory, filepath.Join(projectRoot, libraryDirectoryName, packageCacheDirectoryName))
+}
+
+// isUnderDirectory reports whether a path sits inside a directory.
+func isUnderDirectory(path string, directory string) bool {
+	relativePath, err := filepath.Rel(directory, path)
+	if err != nil {
+		return false
+	}
+
+	return relativePath != ".." && !strings.HasPrefix(relativePath, ".."+string(filepath.Separator))
+}

--- a/cli/dispatcher/internal/compilecheck/source_set_test.go
+++ b/cli/dispatcher/internal/compilecheck/source_set_test.go
@@ -1,0 +1,140 @@
+package compilecheck
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// newAssemblyProject lays out one project with a nested assembly, an ignored folder and a subfolder.
+func newAssemblyProject(t *testing.T) string {
+	t.Helper()
+	projectRoot := t.TempDir()
+	writeFileAt(t, filepath.Join(projectRoot, "Assets", "Foo", "Foo.asmdef"), `{"name":"Foo"}`)
+	writeFileAt(t, filepath.Join(projectRoot, "Assets", "Foo", "A.cs"), "")
+	writeFileAt(t, filepath.Join(projectRoot, "Assets", "Foo", "Sub", "B.cs"), "")
+	writeFileAt(t, filepath.Join(projectRoot, "Assets", "Foo", "Nested", "Nested.asmdef"), `{"name":"Nested"}`)
+	writeFileAt(t, filepath.Join(projectRoot, "Assets", "Foo", "Nested", "C.cs"), "")
+	writeFileAt(t, filepath.Join(projectRoot, "Assets", "Foo", "Tmp~", "D.cs"), "")
+
+	return projectRoot
+}
+
+// Verifies deleted sources drop out, new sources appear, and nested or ignored folders stay excluded.
+func TestRebuildSourcesReflectsFilesAddedAndDeletedSinceTheLastBuild(t *testing.T) {
+	projectRoot := newAssemblyProject(t)
+	rsp := ResponseFile{Sources: []string{
+		filepath.Join("Assets", "Foo", "A.cs"),
+		filepath.Join("Assets", "Foo", "Deleted.cs"),
+	}}
+	asmdef := AssemblyDefinition{
+		Name:      "Foo",
+		Path:      filepath.Join(projectRoot, "Assets", "Foo", "Foo.asmdef"),
+		Directory: filepath.Join(projectRoot, "Assets", "Foo"),
+	}
+
+	sources, err := RebuildSources(projectRoot, rsp, &asmdef)
+	if err != nil {
+		t.Fatalf("expected the rebuild to succeed, got error: %v", err)
+	}
+
+	assertStrings(t, "sources", sources, []string{
+		filepath.Join("Assets", "Foo", "A.cs"),
+		filepath.Join("Assets", "Foo", "Sub", "B.cs"),
+	})
+}
+
+// Verifies a source pulled in from outside the assembly directory survives the re-glob.
+func TestRebuildSourcesKeepsSourcesOutsideTheAssemblyDirectory(t *testing.T) {
+	projectRoot := newAssemblyProject(t)
+	writeFileAt(t, filepath.Join(projectRoot, "Assets", "Shared", "E.cs"), "")
+	rsp := ResponseFile{Sources: []string{
+		filepath.Join("Assets", "Foo", "A.cs"),
+		filepath.Join("Assets", "Shared", "E.cs"),
+	}}
+	asmdef := AssemblyDefinition{
+		Name:      "Foo",
+		Path:      filepath.Join(projectRoot, "Assets", "Foo", "Foo.asmdef"),
+		Directory: filepath.Join(projectRoot, "Assets", "Foo"),
+	}
+
+	sources, err := RebuildSources(projectRoot, rsp, &asmdef)
+	if err != nil {
+		t.Fatalf("expected the rebuild to succeed, got error: %v", err)
+	}
+
+	assertStrings(t, "sources", sources, []string{
+		filepath.Join("Assets", "Foo", "A.cs"),
+		filepath.Join("Assets", "Foo", "Sub", "B.cs"),
+		filepath.Join("Assets", "Shared", "E.cs"),
+	})
+}
+
+// Verifies an assembly with no .asmdef keeps only the response file sources that still exist.
+func TestRebuildSourcesWithoutAssemblyDefinitionKeepsExistingSourcesOnly(t *testing.T) {
+	projectRoot := newAssemblyProject(t)
+	rsp := ResponseFile{Sources: []string{
+		filepath.Join("Assets", "Foo", "A.cs"),
+		filepath.Join("Assets", "Foo", "Deleted.cs"),
+	}}
+
+	sources, err := RebuildSources(projectRoot, rsp, nil)
+	if err != nil {
+		t.Fatalf("expected the rebuild to succeed, got error: %v", err)
+	}
+
+	assertStrings(t, "sources", sources, []string{filepath.Join("Assets", "Foo", "A.cs")})
+}
+
+// Verifies a package-cache assembly is taken from the response file instead of being walked.
+func TestRebuildSourcesSkipsGlobbingForPackageCacheAssemblies(t *testing.T) {
+	projectRoot := t.TempDir()
+	packageDirectory := filepath.Join(projectRoot, "Library", "PackageCache", "com.example.pkg")
+	writeFileAt(t, filepath.Join(packageDirectory, "Pkg.asmdef"), `{"name":"Pkg"}`)
+	writeFileAt(t, filepath.Join(packageDirectory, "A.cs"), "")
+	writeFileAt(t, filepath.Join(packageDirectory, "Untracked.cs"), "")
+	rsp := ResponseFile{Sources: []string{
+		filepath.Join("Library", "PackageCache", "com.example.pkg", "A.cs"),
+	}}
+	asmdef := AssemblyDefinition{
+		Name:      "Pkg",
+		Path:      filepath.Join(packageDirectory, "Pkg.asmdef"),
+		Directory: packageDirectory,
+	}
+
+	sources, err := RebuildSources(projectRoot, rsp, &asmdef)
+	if err != nil {
+		t.Fatalf("expected the rebuild to succeed, got error: %v", err)
+	}
+
+	assertStrings(t, "sources", sources, []string{
+		filepath.Join("Library", "PackageCache", "com.example.pkg", "A.cs"),
+	})
+}
+
+// Verifies assembly definitions under Assets, Packages and the package cache all reach the index.
+func TestIndexAssemblyDefinitionsCoversEveryProjectRoot(t *testing.T) {
+	projectRoot := newAssemblyProject(t)
+	writeFileAt(t, filepath.Join(projectRoot, "Packages", "local", "Local.asmdef"), `{"name":"Local"}`)
+	writeFileAt(t,
+		filepath.Join(projectRoot, "Library", "PackageCache", "com.example.pkg", "Pkg.asmdef"),
+		`{"name":"Pkg"}`)
+	writeFileAt(t, filepath.Join(projectRoot, "Assets", "Foo", "Tmp~", "Hidden.asmdef"), `{"name":"Hidden"}`)
+
+	index, err := IndexAssemblyDefinitions(projectRoot)
+	if err != nil {
+		t.Fatalf("expected the index to build, got error: %v", err)
+	}
+
+	for _, name := range []string{"Foo", "Nested", "Local", "Pkg"} {
+		if _, found := index[name]; !found {
+			t.Errorf("assembly %s is missing from the index", name)
+		}
+	}
+	if _, found := index["Hidden"]; found {
+		t.Error("an assembly definition under an ignored folder must not be indexed")
+	}
+	foo := index["Foo"]
+	if foo.Directory != filepath.Join(projectRoot, "Assets", "Foo") {
+		t.Errorf("Foo directory = %s", foo.Directory)
+	}
+}

--- a/cli/dispatcher/internal/compilecheck/staleness.go
+++ b/cli/dispatcher/internal/compilecheck/staleness.go
@@ -1,0 +1,128 @@
+package compilecheck
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+const (
+	assemblyExtension = ".dll"
+
+	changeReasonSourceNewer   = "source newer than last build"
+	changeReasonSourceAdded   = "new source file"
+	changeReasonSourceRemoved = "source removed"
+
+	runCompileFirstAdvice = "run `uloop compile` first"
+)
+
+// ChangeReport says whether an assembly's inputs moved since Unity last built it, and what moved.
+type ChangeReport struct {
+	Changed bool
+	Reason  string
+}
+
+// DetectStructuralChange fails when the response file can no longer describe the assembly.
+// Why this is fatal rather than a rebuild: references, defineConstraints and includePlatforms live
+// in the assembly definition and never reach the response file, so compiling anyway would report
+// diagnostics for a configuration the project no longer has.
+func DetectStructuralChange(
+	projectRoot string, rsp ResponseFile, asmdef *AssemblyDefinition, dagDir string,
+) error {
+	baseline, err := lastBuildTime(projectRoot, rsp, dagDir)
+	if err != nil {
+		return err
+	}
+
+	if asmdef != nil {
+		asmdefTime, statErr := modificationTime(asmdef.Path)
+		if statErr != nil {
+			return statErr
+		}
+		if asmdefTime.After(baseline) {
+			return fmt.Errorf(
+				"assembly definition %s changed after the last Unity build; %s",
+				asmdef.Name, runCompileFirstAdvice)
+		}
+	}
+
+	if rsp.AdditionalFile != "" && !fileExists(filepath.Join(projectRoot, rsp.AdditionalFile)) {
+		return fmt.Errorf("the Bee artifacts are incomplete for %s; %s", rsp.AssemblyName, runCompileFirstAdvice)
+	}
+
+	return nil
+}
+
+// DetectSourceChange reports whether the assembly's sources changed since Unity last built it.
+func DetectSourceChange(
+	projectRoot string, rsp ResponseFile, sources []string, dagDir string,
+) (ChangeReport, error) {
+	baseline, err := lastBuildTime(projectRoot, rsp, dagDir)
+	if err != nil {
+		return ChangeReport{}, err
+	}
+
+	if report, changed := compareSourceSets(rsp.Sources, sources); changed {
+		return report, nil
+	}
+
+	for _, source := range sources {
+		sourceTime, statErr := modificationTime(filepath.Join(projectRoot, source))
+		if statErr != nil {
+			return ChangeReport{}, statErr
+		}
+		if sourceTime.After(baseline) {
+			return ChangeReport{Changed: true, Reason: changeReasonSourceNewer}, nil
+		}
+	}
+
+	return ChangeReport{}, nil
+}
+
+// compareSourceSets reports whether the rebuilt source list gained or lost files.
+func compareSourceSets(recorded []string, current []string) (ChangeReport, bool) {
+	recordedSet := map[string]bool{}
+	for _, source := range recorded {
+		recordedSet[source] = true
+	}
+	for _, source := range current {
+		if !recordedSet[source] {
+			return ChangeReport{Changed: true, Reason: changeReasonSourceAdded}, true
+		}
+	}
+
+	currentSet := map[string]bool{}
+	for _, source := range current {
+		currentSet[source] = true
+	}
+	for _, source := range recorded {
+		if !currentSet[source] {
+			return ChangeReport{Changed: true, Reason: changeReasonSourceRemoved}, true
+		}
+	}
+
+	return ChangeReport{}, false
+}
+
+// lastBuildTime reads when Unity last wrote this assembly, the baseline every check compares against.
+func lastBuildTime(projectRoot string, rsp ResponseFile, dagDir string) (time.Time, error) {
+	assemblyPath := filepath.Join(projectRoot, dagDir, rsp.AssemblyName+assemblyExtension)
+	info, err := os.Stat(assemblyPath)
+	if err != nil {
+		return time.Time{}, fmt.Errorf(
+			"the Unity Editor has never built %s; %s", rsp.AssemblyName, runCompileFirstAdvice)
+	}
+
+	return info.ModTime(), nil
+}
+
+// modificationTime reads one file's modification time.
+func modificationTime(path string) (time.Time, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("failed to inspect %s: %w", path, err)
+	}
+
+	return info.ModTime(), nil
+}

--- a/cli/dispatcher/internal/compilecheck/staleness_test.go
+++ b/cli/dispatcher/internal/compilecheck/staleness_test.go
@@ -1,0 +1,152 @@
+package compilecheck
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+const stalenessDagDirectory = "Library/Bee/artifacts/aaaa.dag"
+
+// setModificationTime moves a file's timestamp so the baseline comparison can be driven exactly.
+func setModificationTime(t *testing.T, path string, when time.Time) {
+	t.Helper()
+	if err := os.Chtimes(path, when, when); err != nil {
+		t.Fatalf("failed to set the modification time of %s: %v", path, err)
+	}
+}
+
+// newStalenessProject builds a project whose assembly was built after its single source was written.
+func newStalenessProject(t *testing.T) (string, ResponseFile, AssemblyDefinition) {
+	t.Helper()
+	projectRoot := t.TempDir()
+	sourcePath := filepath.Join(projectRoot, "Assets", "Foo", "A.cs")
+	asmdefPath := filepath.Join(projectRoot, "Assets", "Foo", "Foo.asmdef")
+	additionalPath := filepath.Join(projectRoot, stalenessDagDirectory, "Foo.UnityAdditionalFile.txt")
+	assemblyPath := filepath.Join(projectRoot, stalenessDagDirectory, "Foo.dll")
+	writeFileAt(t, sourcePath, "")
+	writeFileAt(t, asmdefPath, `{"name":"Foo"}`)
+	writeFileAt(t, additionalPath, "")
+	writeFileAt(t, assemblyPath, "")
+
+	buildTime := time.Now()
+	setModificationTime(t, sourcePath, buildTime.Add(-time.Hour))
+	setModificationTime(t, asmdefPath, buildTime.Add(-time.Hour))
+	setModificationTime(t, assemblyPath, buildTime)
+
+	rsp := ResponseFile{
+		AssemblyName:   "Foo",
+		Sources:        []string{filepath.Join("Assets", "Foo", "A.cs")},
+		AdditionalFile: filepath.Join(stalenessDagDirectory, "Foo.UnityAdditionalFile.txt"),
+	}
+	asmdef := AssemblyDefinition{Name: "Foo", Path: asmdefPath, Directory: filepath.Dir(asmdefPath)}
+
+	return projectRoot, rsp, asmdef
+}
+
+// Verifies an assembly whose sources predate the last build is reported as unchanged.
+func TestDetectSourceChangeReportsNoChangeWhenNothingMoved(t *testing.T) {
+	projectRoot, rsp, _ := newStalenessProject(t)
+
+	report, err := DetectSourceChange(projectRoot, rsp, rsp.Sources, stalenessDagDirectory)
+	if err != nil {
+		t.Fatalf("expected the check to succeed, got error: %v", err)
+	}
+	if report.Changed {
+		t.Errorf("expected no change, got reason %q", report.Reason)
+	}
+}
+
+// Verifies a source edited after the last build is reported as changed with the timestamp reason.
+func TestDetectSourceChangeReportsSourceNewerThanLastBuild(t *testing.T) {
+	projectRoot, rsp, _ := newStalenessProject(t)
+	setModificationTime(t, filepath.Join(projectRoot, rsp.Sources[0]), time.Now().Add(time.Hour))
+
+	report, err := DetectSourceChange(projectRoot, rsp, rsp.Sources, stalenessDagDirectory)
+	if err != nil {
+		t.Fatalf("expected the check to succeed, got error: %v", err)
+	}
+	if !report.Changed || report.Reason != changeReasonSourceNewer {
+		t.Errorf("report = %+v, want a change with reason %q", report, changeReasonSourceNewer)
+	}
+}
+
+// Verifies a source added since the last build is reported as changed even when no file is newer.
+func TestDetectSourceChangeReportsAddedSource(t *testing.T) {
+	projectRoot, rsp, _ := newStalenessProject(t)
+	addedPath := filepath.Join(projectRoot, "Assets", "Foo", "B.cs")
+	writeFileAt(t, addedPath, "")
+	setModificationTime(t, addedPath, time.Now().Add(-time.Hour))
+	sources := append([]string{}, rsp.Sources...)
+	sources = append(sources, filepath.Join("Assets", "Foo", "B.cs"))
+
+	report, err := DetectSourceChange(projectRoot, rsp, sources, stalenessDagDirectory)
+	if err != nil {
+		t.Fatalf("expected the check to succeed, got error: %v", err)
+	}
+	if !report.Changed || report.Reason != changeReasonSourceAdded {
+		t.Errorf("report = %+v, want a change with reason %q", report, changeReasonSourceAdded)
+	}
+}
+
+// Verifies a source deleted since the last build is reported as changed.
+func TestDetectSourceChangeReportsRemovedSource(t *testing.T) {
+	projectRoot, rsp, _ := newStalenessProject(t)
+
+	report, err := DetectSourceChange(projectRoot, rsp, []string{}, stalenessDagDirectory)
+	if err != nil {
+		t.Fatalf("expected the check to succeed, got error: %v", err)
+	}
+	if !report.Changed || report.Reason != changeReasonSourceRemoved {
+		t.Errorf("report = %+v, want a change with reason %q", report, changeReasonSourceRemoved)
+	}
+}
+
+// Verifies an assembly definition edited after the last build stops the run instead of compiling.
+func TestDetectStructuralChangeRejectsEditedAssemblyDefinition(t *testing.T) {
+	projectRoot, rsp, asmdef := newStalenessProject(t)
+	setModificationTime(t, asmdef.Path, time.Now().Add(time.Hour))
+
+	err := DetectStructuralChange(projectRoot, rsp, &asmdef, stalenessDagDirectory)
+	if err == nil {
+		t.Fatal("expected an edited assembly definition to be rejected")
+	}
+	if !strings.Contains(err.Error(), "uloop compile") {
+		t.Errorf("the error should tell the user how to recover, got: %v", err)
+	}
+}
+
+// Verifies a missing Bee additional file stops the run instead of compiling without it.
+func TestDetectStructuralChangeRejectsIncompleteBeeArtifacts(t *testing.T) {
+	projectRoot, rsp, asmdef := newStalenessProject(t)
+	if err := os.Remove(filepath.Join(projectRoot, rsp.AdditionalFile)); err != nil {
+		t.Fatalf("failed to remove the additional file: %v", err)
+	}
+
+	if err := DetectStructuralChange(projectRoot, rsp, &asmdef, stalenessDagDirectory); err == nil {
+		t.Fatal("expected incomplete Bee artifacts to be rejected")
+	}
+}
+
+// Verifies an assembly Unity has never built is rejected, since there is no baseline to compare to.
+func TestDetectStructuralChangeRejectsNeverBuiltAssembly(t *testing.T) {
+	projectRoot, rsp, asmdef := newStalenessProject(t)
+	if err := os.Remove(filepath.Join(projectRoot, stalenessDagDirectory, "Foo.dll")); err != nil {
+		t.Fatalf("failed to remove the assembly: %v", err)
+	}
+
+	if err := DetectStructuralChange(projectRoot, rsp, &asmdef, stalenessDagDirectory); err == nil {
+		t.Fatal("expected a never-built assembly to be rejected")
+	}
+}
+
+// Verifies a structurally unchanged assembly passes the check.
+func TestDetectStructuralChangeAcceptsUnchangedAssembly(t *testing.T) {
+	projectRoot, rsp, asmdef := newStalenessProject(t)
+
+	if err := DetectStructuralChange(projectRoot, rsp, &asmdef, stalenessDagDirectory); err != nil {
+		t.Fatalf("expected the unchanged assembly to pass, got error: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- Builds the engine that compiles a Unity project's C# while the Editor is closed, by replaying the response files Unity's own build already wrote.
- Still no user-visible command; this PR is the compile engine that a later `uloop compile-check` will call.

## User Impact
- Nothing changes for users in this PR on its own. After it, the CLI can take a project that Unity has built at least once and recompile only the assemblies whose sources changed, plus everything that depends on them, using the same compiler and the same flags Unity used — without launching or contacting the Editor.
- Two cases are reported rather than silently mis-answered: a project Unity has never built, and a change the replay cannot honestly reproduce (an assembly definition edited since the last build), both pointing at `uloop compile` as the fix.

## Changes
All under `cli/dispatcher/internal/compilecheck`:

- **Response files** — parse a Bee `.rsp` into the parts that have to be rewritten (output, defines, references, analyzers, sources, additional file) and list which references point at another assembly of this project. Paths inside a response file are relative to the project root, because that is the directory the compiler runs from; the reference lister documents that contract because passing an absolute directory silently matches nothing.
- **Source sets** — index the project's `.asmdef` files and rebuild an assembly's source list from disk rather than trusting the stale list inside the response file, honouring Unity's own folder rules (hidden and `~`-suffixed folders, `Library`, nested assemblies, package cache).
- **Staleness** — separate the changes the replay can reproduce (a newer, added, or removed source file) from the ones it cannot (an assembly definition that moved or changed its references since Unity last built), and refuse the second kind instead of producing a wrong answer.
- **Plan** — build the assembly graph from the response files, select the changed assemblies, propagate to their dependents, and order the result topologically so a dependency is always compiled before its dependents. `--all` selects everything. Output goes to `Library/uloop/compile-check/<dag>/` and is never handed back to Unity.
- **Compiler** — rewrite one unit's response file (own output path, references pointed at this run's freshly built reference assemblies) and run `dotnet exec csc.dll` with it, then parse the `file(line,col): severity CODE: message` diagnostics back out. A non-zero exit with no error diagnostic is kept as raw output, because that is an infrastructure failure and not a compile error. A rewritten reference falls back to Unity's own reference assembly when this run produced none for that dependency, so a dependent still compiles after its dependency failed.
- **Session** — resolve which Bee build the Editor last produced and run the whole sequence. The active dag comes from the Bee log, because unrelated Bee work touches both dag directories and their timestamps do not say which one the Editor built; the script-debug project setting only breaks the tie when the log is absent or names a dag that is gone.

## Verification
- `go test ./internal/compilecheck/ -v` — 46 PASS, 0 FAIL.
- `scripts/check-go-cli.sh` — exit 0 (format, vet, lint, tests, dist rebuild).
- Mutation checks on the two contracts a passing test could otherwise miss: dropping the guard that rejects a Bee log naming a missing dag, and ignoring the Bee log entirely, each make exactly one dag-resolution test fail, then pass again once reverted.
- Parser validated against real data: all 100 non-`.mvfrm` response files in this repository's `Library/Bee/artifacts/<dag>` parse with zero errors, and the editor assembly's 42 project-assembly references are all resolved.
- No repository CI runs on this pull request: `build-and-test.yml` only triggers for pull requests targeting `main`/`v3-beta`, so `scripts/check-go-cli.sh` above is the gate here. Full CI runs on the final pull request from the integration branch to `main`.
- Running against a live Unity project end-to-end is not verified here; that is the real-machine check later in this series.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2744?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

