### PR TITLE
feat: uloop compile-check reports C# errors without launching Unity

### DIFF
--- a/.agents/skills/uloop-compile-check/SKILL.md
+++ b/.agents/skills/uloop-compile-check/SKILL.md
@@ -21,7 +21,7 @@ in `Library/uloop/compile-check/` and are never handed to the Editor.
 ## When not to use
 
 - You want the change reflected in the Editor (play mode, tests, a tool call): run `uloop compile`.
-- You just added or removed an `.asmdef`, changed its references, or changed scripting defines:
+- You just added or removed an `.asmdef`, added a reference to one, or changed scripting defines:
   run `uloop compile` once first. The response files describe the previous build only, so
   compile-check refuses the run with `COMPILE_CHECK_UNITY_BUILD_REQUIRED` instead of reporting
   diagnostics for a configuration the project no longer has.

--- a/.agents/skills/uloop-compile-check/SKILL.md
+++ b/.agents/skills/uloop-compile-check/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: uloop-compile-check
+description: "Compile C# with the Unity-bundled Roslyn compiler without launching or contacting the Unity Editor; reports errors and warnings only."
+---
+
+# uloop compile-check
+
+Compile the project's C# offline and report the diagnostics, without starting Unity or sending
+anything to a running Editor.
+
+The command replays the response files Unity wrote during its last build, using the C# compiler
+bundled with the Unity Editor install. Nothing it produces is loaded by Unity: the assemblies land
+in `Library/uloop/compile-check/` and are never handed to the Editor.
+
+## When to use
+
+- The Editor is not running and you only want to know whether the code compiles.
+- You want compiler errors quickly, without waiting for an import and a domain reload.
+- You are iterating on code whose result does not need to be live in the Editor yet.
+
+## When not to use
+
+- You want the change reflected in the Editor (play mode, tests, a tool call): run `uloop compile`.
+- You just added or removed an `.asmdef`, changed its references, or changed scripting defines:
+  run `uloop compile` once first. The response files describe the previous build only, so
+  compile-check refuses the run with `COMPILE_CHECK_UNITY_BUILD_REQUIRED` instead of reporting
+  diagnostics for a configuration the project no longer has.
+
+## Usage
+
+```bash
+uloop compile-check
+uloop compile-check --all --project-path /path/to/project
+```
+
+By default it compiles the assemblies whose sources changed since the last Unity build, plus every
+assembly that references one of them. `--all` compiles every assembly in the build.
+
+## Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `--all` | flag | Compile every assembly instead of only the changed ones and their dependents |
+| `--editor-version <version>` | string | Use this Unity Editor version's compiler instead of ProjectVersion.txt |
+| `--max-depth <N>` | number | Search depth when locating the project (default: 3, -1 for unlimited) |
+| `--project-path <path>` | string | Target another Unity project instead of the current directory |
+
+## Output
+
+A JSON payload:
+
+- `Success`: whether the compile produced no errors
+- `ErrorCount`, `WarningCount`: totals across every compiled assembly
+- `Errors`, `Warnings`: each with `Message`, `Code`, `File`, `Line`, `Column`, `Assembly`
+- `CompiledAssemblies`: the assemblies this run compiled, in dependency order
+- `SkippedAssemblies`: how many assemblies were left out because nothing they compile from changed
+- `ResponseFileSet`: the Bee build the run replayed
+- `ProjectRoot`: resolved project root
+- `Message`: one-line summary
+
+The process exits 1 when `ErrorCount` is greater than zero.
+
+## Limitations
+
+- It replays the last Unity build's response files. A new or deleted `.asmdef`, a changed `.asmdef`
+  reference, an `.asmdef` that stopped building for the Editor, or a newly required precompiled
+  reference stops the run and asks for `uloop compile`.
+- Changes to `defineConstraints` and `versionDefines` are **not** detected, because they depend on
+  scripting defines and package versions that cannot be evaluated outside the Editor. Run
+  `uloop compile` after editing them.
+- A reference **removed** from an `.asmdef` is not detected either: Unity injects references of its
+  own that no `.asmdef` declares, so only added references can be told apart from those. Diagnostics
+  may therefore miss an error that the removal would cause. Run `uloop compile` after removing one.
+- Changed scripting defines are not detected; the defines from the last build are reused.
+- The predefined assemblies (`Assembly-CSharp` and friends) keep the source list of the last build,
+  so a brand-new `.cs` file outside an `.asmdef` is not compiled until Unity imports it.
+- The produced DLLs are never loaded by Unity, and the command never contacts a running Editor.
+- Linux is not supported.

--- a/.claude/skills/uloop-compile-check/SKILL.md
+++ b/.claude/skills/uloop-compile-check/SKILL.md
@@ -21,7 +21,7 @@ in `Library/uloop/compile-check/` and are never handed to the Editor.
 ## When not to use
 
 - You want the change reflected in the Editor (play mode, tests, a tool call): run `uloop compile`.
-- You just added or removed an `.asmdef`, changed its references, or changed scripting defines:
+- You just added or removed an `.asmdef`, added a reference to one, or changed scripting defines:
   run `uloop compile` once first. The response files describe the previous build only, so
   compile-check refuses the run with `COMPILE_CHECK_UNITY_BUILD_REQUIRED` instead of reporting
   diagnostics for a configuration the project no longer has.

--- a/.claude/skills/uloop-compile-check/SKILL.md
+++ b/.claude/skills/uloop-compile-check/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: uloop-compile-check
+description: "Compile C# with the Unity-bundled Roslyn compiler without launching or contacting the Unity Editor; reports errors and warnings only."
+---
+
+# uloop compile-check
+
+Compile the project's C# offline and report the diagnostics, without starting Unity or sending
+anything to a running Editor.
+
+The command replays the response files Unity wrote during its last build, using the C# compiler
+bundled with the Unity Editor install. Nothing it produces is loaded by Unity: the assemblies land
+in `Library/uloop/compile-check/` and are never handed to the Editor.
+
+## When to use
+
+- The Editor is not running and you only want to know whether the code compiles.
+- You want compiler errors quickly, without waiting for an import and a domain reload.
+- You are iterating on code whose result does not need to be live in the Editor yet.
+
+## When not to use
+
+- You want the change reflected in the Editor (play mode, tests, a tool call): run `uloop compile`.
+- You just added or removed an `.asmdef`, changed its references, or changed scripting defines:
+  run `uloop compile` once first. The response files describe the previous build only, so
+  compile-check refuses the run with `COMPILE_CHECK_UNITY_BUILD_REQUIRED` instead of reporting
+  diagnostics for a configuration the project no longer has.
+
+## Usage
+
+```bash
+uloop compile-check
+uloop compile-check --all --project-path /path/to/project
+```
+
+By default it compiles the assemblies whose sources changed since the last Unity build, plus every
+assembly that references one of them. `--all` compiles every assembly in the build.
+
+## Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `--all` | flag | Compile every assembly instead of only the changed ones and their dependents |
+| `--editor-version <version>` | string | Use this Unity Editor version's compiler instead of ProjectVersion.txt |
+| `--max-depth <N>` | number | Search depth when locating the project (default: 3, -1 for unlimited) |
+| `--project-path <path>` | string | Target another Unity project instead of the current directory |
+
+## Output
+
+A JSON payload:
+
+- `Success`: whether the compile produced no errors
+- `ErrorCount`, `WarningCount`: totals across every compiled assembly
+- `Errors`, `Warnings`: each with `Message`, `Code`, `File`, `Line`, `Column`, `Assembly`
+- `CompiledAssemblies`: the assemblies this run compiled, in dependency order
+- `SkippedAssemblies`: how many assemblies were left out because nothing they compile from changed
+- `ResponseFileSet`: the Bee build the run replayed
+- `ProjectRoot`: resolved project root
+- `Message`: one-line summary
+
+The process exits 1 when `ErrorCount` is greater than zero.
+
+## Limitations
+
+- It replays the last Unity build's response files. A new or deleted `.asmdef`, a changed `.asmdef`
+  reference, an `.asmdef` that stopped building for the Editor, or a newly required precompiled
+  reference stops the run and asks for `uloop compile`.
+- Changes to `defineConstraints` and `versionDefines` are **not** detected, because they depend on
+  scripting defines and package versions that cannot be evaluated outside the Editor. Run
+  `uloop compile` after editing them.
+- A reference **removed** from an `.asmdef` is not detected either: Unity injects references of its
+  own that no `.asmdef` declares, so only added references can be told apart from those. Diagnostics
+  may therefore miss an error that the removal would cause. Run `uloop compile` after removing one.
+- Changed scripting defines are not detected; the defines from the last build are reused.
+- The predefined assemblies (`Assembly-CSharp` and friends) keep the source list of the last build,
+  so a brand-new `.cs` file outside an `.asmdef` is not compiled until Unity imports it.
+- The produced DLLs are never loaded by Unity, and the command never contacts a running Editor.
+- Linux is not supported.

--- a/Packages/src/Editor/CliOnlyTools~/CompileCheck/Skill/SKILL.md
+++ b/Packages/src/Editor/CliOnlyTools~/CompileCheck/Skill/SKILL.md
@@ -21,7 +21,7 @@ in `Library/uloop/compile-check/` and are never handed to the Editor.
 ## When not to use
 
 - You want the change reflected in the Editor (play mode, tests, a tool call): run `uloop compile`.
-- You just added or removed an `.asmdef`, changed its references, or changed scripting defines:
+- You just added or removed an `.asmdef`, added a reference to one, or changed scripting defines:
   run `uloop compile` once first. The response files describe the previous build only, so
   compile-check refuses the run with `COMPILE_CHECK_UNITY_BUILD_REQUIRED` instead of reporting
   diagnostics for a configuration the project no longer has.

--- a/Packages/src/Editor/CliOnlyTools~/CompileCheck/Skill/SKILL.md
+++ b/Packages/src/Editor/CliOnlyTools~/CompileCheck/Skill/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: uloop-compile-check
+description: "Compile C# with the Unity-bundled Roslyn compiler without launching or contacting the Unity Editor; reports errors and warnings only."
+---
+
+# uloop compile-check
+
+Compile the project's C# offline and report the diagnostics, without starting Unity or sending
+anything to a running Editor.
+
+The command replays the response files Unity wrote during its last build, using the C# compiler
+bundled with the Unity Editor install. Nothing it produces is loaded by Unity: the assemblies land
+in `Library/uloop/compile-check/` and are never handed to the Editor.
+
+## When to use
+
+- The Editor is not running and you only want to know whether the code compiles.
+- You want compiler errors quickly, without waiting for an import and a domain reload.
+- You are iterating on code whose result does not need to be live in the Editor yet.
+
+## When not to use
+
+- You want the change reflected in the Editor (play mode, tests, a tool call): run `uloop compile`.
+- You just added or removed an `.asmdef`, changed its references, or changed scripting defines:
+  run `uloop compile` once first. The response files describe the previous build only, so
+  compile-check refuses the run with `COMPILE_CHECK_UNITY_BUILD_REQUIRED` instead of reporting
+  diagnostics for a configuration the project no longer has.
+
+## Usage
+
+```bash
+uloop compile-check
+uloop compile-check --all --project-path /path/to/project
+```
+
+By default it compiles the assemblies whose sources changed since the last Unity build, plus every
+assembly that references one of them. `--all` compiles every assembly in the build.
+
+## Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `--all` | flag | Compile every assembly instead of only the changed ones and their dependents |
+| `--editor-version <version>` | string | Use this Unity Editor version's compiler instead of ProjectVersion.txt |
+| `--max-depth <N>` | number | Search depth when locating the project (default: 3, -1 for unlimited) |
+| `--project-path <path>` | string | Target another Unity project instead of the current directory |
+
+## Output
+
+A JSON payload:
+
+- `Success`: whether the compile produced no errors
+- `ErrorCount`, `WarningCount`: totals across every compiled assembly
+- `Errors`, `Warnings`: each with `Message`, `Code`, `File`, `Line`, `Column`, `Assembly`
+- `CompiledAssemblies`: the assemblies this run compiled, in dependency order
+- `SkippedAssemblies`: how many assemblies were left out because nothing they compile from changed
+- `ResponseFileSet`: the Bee build the run replayed
+- `ProjectRoot`: resolved project root
+- `Message`: one-line summary
+
+The process exits 1 when `ErrorCount` is greater than zero.
+
+## Limitations
+
+- It replays the last Unity build's response files. A new or deleted `.asmdef`, a changed `.asmdef`
+  reference, an `.asmdef` that stopped building for the Editor, or a newly required precompiled
+  reference stops the run and asks for `uloop compile`.
+- Changes to `defineConstraints` and `versionDefines` are **not** detected, because they depend on
+  scripting defines and package versions that cannot be evaluated outside the Editor. Run
+  `uloop compile` after editing them.
+- A reference **removed** from an `.asmdef` is not detected either: Unity injects references of its
+  own that no `.asmdef` declares, so only added references can be told apart from those. Diagnostics
+  may therefore miss an error that the removal would cause. Run `uloop compile` after removing one.
+- Changed scripting defines are not detected; the defines from the last build are reused.
+- The predefined assemblies (`Assembly-CSharp` and friends) keep the source list of the last build,
+  so a brand-new `.cs` file outside an `.asmdef` is not compiled until Unity imports it.
+- The produced DLLs are never loaded by Unity, and the command never contacts a running Editor.
+- Linux is not supported.

--- a/cli/common/clicore/command_errors_test.go
+++ b/cli/common/clicore/command_errors_test.go
@@ -5,7 +5,7 @@ import "testing"
 func TestAvailableCommandNamesIncludesBuiltIns(t *testing.T) {
 	// Verifies unknown-command suggestions include built-in CLI commands before cached tools.
 	names := availableCommandNames(ToolsCache{})
-	expectedBuiltIns := []string{"launch", "list", "sync", "focus-window", "await-pause-point", "pause-point-status", "set-code-optimization", "skills", "package", "install", "update", "uninstall"}
+	expectedBuiltIns := []string{"launch", "compile-check", "list", "sync", "focus-window", "await-pause-point", "pause-point-status", "set-code-optimization", "skills", "package", "install", "update", "uninstall"}
 	for index, expected := range expectedBuiltIns {
 		if names[index] != expected {
 			t.Fatalf("built-in command mismatch: %#v", names)

--- a/cli/common/clicore/command_registry.go
+++ b/cli/common/clicore/command_registry.go
@@ -2,6 +2,7 @@ package clicore
 
 const (
 	LaunchCommandName               = "launch"
+	CompileCheckCommandName         = "compile-check"
 	InstallCommandName              = "install"
 	UpdateCommandName               = "update"
 	UninstallCommandName            = "uninstall"
@@ -31,6 +32,7 @@ const (
 
 var NativeCommands = []NativeCommandEntry{
 	{Name: LaunchCommandName, Description: "Open this Unity project with the matching Editor version", Owner: DispatcherOwned},
+	{Name: CompileCheckCommandName, Description: "Compile changed assemblies with the Editor's bundled C# compiler without launching Unity", Owner: DispatcherOwned},
 	{Name: "list", Description: "Show Unity tools currently exposed by the Editor", Owner: RunnerOwned},
 	{Name: "sync", Description: "Refresh .uloop/tools.json from the running Editor", Owner: RunnerOwned},
 	{Name: "focus-window", Description: "Bring the Unity Editor window to the foreground", Owner: RunnerOwned},

--- a/cli/common/clicore/command_registry_test.go
+++ b/cli/common/clicore/command_registry_test.go
@@ -6,6 +6,7 @@ func TestNativeCommandEntriesDeclareOwners(t *testing.T) {
 	// Verifies native command ownership lives in the command registry.
 	expectedOwners := map[string]CommandOwner{
 		LaunchCommandName:               DispatcherOwned,
+		CompileCheckCommandName:         DispatcherOwned,
 		InstallCommandName:              DispatcherOwned,
 		UpdateCommandName:               DispatcherOwned,
 		UninstallCommandName:            DispatcherOwned,

--- a/cli/common/errors/error_envelope.go
+++ b/cli/common/errors/error_envelope.go
@@ -38,7 +38,10 @@ const (
 	ErrorCodePackageManifestInvalid = "PACKAGE_MANIFEST_INVALID"
 	// ErrorCodePackageRegistryUnavailable is returned when the OpenUPM registry HTTP lookup fails.
 	ErrorCodePackageRegistryUnavailable = "PACKAGE_REGISTRY_UNAVAILABLE"
-	ErrorCodeInternalError              = "INTERNAL_ERROR"
+	// ErrorCodeCompileCheckUnityBuildRequired is returned when compile-check cannot replay the Bee
+	// response files because the project changed in a way only a Unity build can record.
+	ErrorCodeCompileCheckUnityBuildRequired = "COMPILE_CHECK_UNITY_BUILD_REQUIRED"
+	ErrorCodeInternalError                  = "INTERNAL_ERROR"
 
 	ErrorPhaseArgumentParsing = "argument_parsing"
 	ErrorPhaseProjectResolve  = "project_resolution"

--- a/cli/common/tooldocs/skill_guidance.go
+++ b/cli/common/tooldocs/skill_guidance.go
@@ -8,6 +8,7 @@ package tooldocs
 var commandSkillNames = map[string]string{
 	"clear-console":        "uloop-clear-console",
 	"compile":              "uloop-compile",
+	"compile-check":        "uloop-compile-check",
 	"control-play-mode":    "uloop-control-play-mode",
 	"execute-dynamic-code": "uloop-execute-dynamic-code",
 	"find-game-objects":    "uloop-find-game-objects",

--- a/cli/dispatcher/internal/compilecheck/asmdef_contract.go
+++ b/cli/dispatcher/internal/compilecheck/asmdef_contract.go
@@ -1,0 +1,180 @@
+package compilecheck
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	editorPlatformName  = "Editor"
+	guidReferencePrefix = "GUID:"
+	unsafeFlagName      = "unsafe"
+	unsafeOnFlagName    = "unsafe+"
+)
+
+// AssemblyContext is what the contract check needs to know about the rest of the project.
+type AssemblyContext struct {
+	BuiltAssemblies map[string]bool   // assembly names Bee wrote a response file for
+	AssemblyByGUID  map[string]string // .asmdef GUID -> the assembly name it declares
+}
+
+// NewAssemblyContext collects the project-wide lookups the contract check compares against.
+func NewAssemblyContext(
+	graph assemblyGraph, assemblyDefinitions map[string]AssemblyDefinition,
+) AssemblyContext {
+	built := make(map[string]bool, len(graph.byName))
+	for name := range graph.byName {
+		built[name] = true
+	}
+
+	byGUID := make(map[string]string, len(assemblyDefinitions))
+	for name, definition := range assemblyDefinitions {
+		if definition.GUID != "" {
+			byGUID[definition.GUID] = name
+		}
+	}
+
+	return AssemblyContext{BuiltAssemblies: built, AssemblyByGUID: byGUID}
+}
+
+// assemblyDefinitionContract is the part of an .asmdef the response file has to agree with.
+type assemblyDefinitionContract struct {
+	References            []string `json:"references"`
+	AllowUnsafeCode       bool     `json:"allowUnsafeCode"`
+	OverrideReferences    bool     `json:"overrideReferences"`
+	PrecompiledReferences []string `json:"precompiledReferences"`
+	IncludePlatforms      []string `json:"includePlatforms"`
+	ExcludePlatforms      []string `json:"excludePlatforms"`
+}
+
+// readAssemblyDefinitionContract reads the settings of one .asmdef that reach the compiler.
+func readAssemblyDefinitionContract(path string) (assemblyDefinitionContract, error) {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return assemblyDefinitionContract{}, fmt.Errorf("failed to read %s: %w", path, err)
+	}
+
+	contract := assemblyDefinitionContract{}
+	if err := json.Unmarshal(content, &contract); err != nil {
+		return assemblyDefinitionContract{}, fmt.Errorf("failed to read %s: %w", path, err)
+	}
+
+	return contract, nil
+}
+
+// buildsForEditor reports whether Unity still compiles this assembly for the Editor.
+func (c assemblyDefinitionContract) buildsForEditor() bool {
+	for _, platform := range c.ExcludePlatforms {
+		if platform == editorPlatformName {
+			return false
+		}
+	}
+	if len(c.IncludePlatforms) == 0 {
+		return true
+	}
+	for _, platform := range c.IncludePlatforms {
+		if platform == editorPlatformName {
+			return true
+		}
+	}
+
+	return false
+}
+
+// detectContractDisagreement names the first .asmdef setting the response file can no longer serve.
+// Why only these four: they are the settings that reach csc and are readable without evaluating
+// defines or package versions, so a disagreement here is certain rather than guessed.
+func detectContractDisagreement(
+	contract assemblyDefinitionContract, rsp ResponseFile, dagDir string, context AssemblyContext,
+) string {
+	if !contract.buildsForEditor() {
+		return "no longer builds for the Editor"
+	}
+	if reference, found := missingProjectReference(contract, rsp, dagDir, context); found {
+		return fmt.Sprintf("now references %s, which the last build did not compile against", reference)
+	}
+	if contract.AllowUnsafeCode && !hasUnsafeFlag(rsp.OtherFlags) {
+		return "now allows unsafe code"
+	}
+	if name, found := missingPrecompiledReference(contract, rsp); found {
+		return fmt.Sprintf("now requires the precompiled reference %s", name)
+	}
+
+	return ""
+}
+
+// missingProjectReference names an assembly the .asmdef references that the response file lacks.
+// Why the check is one-directional: Unity injects references of its own (the UI and test-runner
+// assemblies) that no .asmdef declares, so demanding equality would reject healthy projects. Only a
+// reference the .asmdef gained is detectable; a removed one is documented as undetectable instead.
+func missingProjectReference(
+	contract assemblyDefinitionContract, rsp ResponseFile, dagDir string, context AssemblyContext,
+) (string, bool) {
+	compiled := map[string]bool{}
+	for _, name := range rsp.ProjectAssemblyReferences(dagDir) {
+		compiled[name] = true
+	}
+
+	for _, reference := range contract.References {
+		name, resolved := resolveReferenceName(reference, context)
+		// Why an unresolvable reference is skipped: healthy projects carry GUIDs pointing at
+		// assemblies excluded by platform or package settings, which own no .asmdef we can index.
+		if !resolved || !context.BuiltAssemblies[name] || compiled[name] {
+			continue
+		}
+
+		return name, true
+	}
+
+	return "", false
+}
+
+// resolveReferenceName turns one .asmdef reference, in GUID or name form, into an assembly name.
+func resolveReferenceName(reference string, context AssemblyContext) (string, bool) {
+	if !strings.HasPrefix(reference, guidReferencePrefix) {
+		return reference, reference != ""
+	}
+
+	name, found := context.AssemblyByGUID[strings.TrimPrefix(reference, guidReferencePrefix)]
+
+	return name, found
+}
+
+// missingPrecompiledReference names a listed .dll that the response file does not reference.
+// Why only under overrideReferences: without it Unity references every precompiled assembly it
+// finds, and the list in the .asmdef says nothing about what the compiler was given.
+func missingPrecompiledReference(
+	contract assemblyDefinitionContract, rsp ResponseFile,
+) (string, bool) {
+	if !contract.OverrideReferences {
+		return "", false
+	}
+
+	referenced := map[string]bool{}
+	for _, reference := range rsp.References {
+		referenced[filepath.Base(reference)] = true
+	}
+	for _, name := range contract.PrecompiledReferences {
+		if !referenced[name] {
+			return name, true
+		}
+	}
+
+	return "", false
+}
+
+// hasUnsafeFlag reports whether the response file lets the compiler accept unsafe code.
+// Why several spellings: Bee writes /unsafe+, and csc accepts the - prefix and the bare form too.
+func hasUnsafeFlag(flags []string) bool {
+	for _, flag := range flags {
+		name := strings.TrimPrefix(strings.TrimPrefix(flag, "/"), "-")
+		if name == unsafeFlagName || name == unsafeOnFlagName {
+			return true
+		}
+	}
+
+	return false
+}

--- a/cli/dispatcher/internal/compilecheck/asmdef_contract.go
+++ b/cli/dispatcher/internal/compilecheck/asmdef_contract.go
@@ -1,9 +1,7 @@
 package compilecheck
 
 import (
-	"encoding/json"
 	"fmt"
-	"os"
 	"path/filepath"
 	"strings"
 )
@@ -52,13 +50,8 @@ type assemblyDefinitionContract struct {
 
 // readAssemblyDefinitionContract reads the settings of one .asmdef that reach the compiler.
 func readAssemblyDefinitionContract(path string) (assemblyDefinitionContract, error) {
-	content, err := os.ReadFile(path)
-	if err != nil {
-		return assemblyDefinitionContract{}, fmt.Errorf("failed to read %s: %w", path, err)
-	}
-
 	contract := assemblyDefinitionContract{}
-	if err := json.Unmarshal(content, &contract); err != nil {
+	if err := readUnityJSONFile(path, &contract); err != nil {
 		return assemblyDefinitionContract{}, fmt.Errorf("failed to read %s: %w", path, err)
 	}
 

--- a/cli/dispatcher/internal/compilecheck/asmdef_contract_test.go
+++ b/cli/dispatcher/internal/compilecheck/asmdef_contract_test.go
@@ -1,0 +1,218 @@
+package compilecheck
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	clierrors "github.com/hatayama/unity-cli-loop/common/errors"
+)
+
+const (
+	contractAssemblyGUID = "1111111111111111111111111111111a"
+	referencedGUID       = "2222222222222222222222222222222b"
+	unreferencedGUID     = "3333333333333333333333333333333c"
+)
+
+// writeAssemblyDefinitionMeta writes the .meta file that gives an .asmdef the GUID others reference.
+func writeAssemblyDefinitionMeta(t *testing.T, projectRoot string, name string, guid string) {
+	t.Helper()
+	writeFileAt(t,
+		filepath.Join(projectRoot, "Assets", name, name+".asmdef.meta"),
+		"fileFormatVersion: 2\nguid: "+guid+"\n")
+}
+
+// newContractProject builds a project of three built assemblies where A references B, and rewrites
+// A's assembly definition with the given body, dated after the last build so the contract check runs.
+func newContractProject(
+	t *testing.T, assemblyDefinitionBody string,
+) (string, ResponseFile, AssemblyDefinition, AssemblyContext) {
+	t.Helper()
+	projectRoot := t.TempDir()
+	writePlanAssembly(t, projectRoot, "B", nil)
+	writePlanAssembly(t, projectRoot, "C", nil)
+	writePlanAssembly(t, projectRoot, "A", []string{"B"})
+	settlePlanProject(t, projectRoot, "A", "B", "C")
+
+	writeAssemblyDefinitionMeta(t, projectRoot, "A", contractAssemblyGUID)
+	writeAssemblyDefinitionMeta(t, projectRoot, "B", referencedGUID)
+	writeAssemblyDefinitionMeta(t, projectRoot, "C", unreferencedGUID)
+
+	assemblyDefinitionPath := filepath.Join(projectRoot, "Assets", "A", "A.asmdef")
+	writeFileAt(t, assemblyDefinitionPath, assemblyDefinitionBody)
+	setModificationTime(t, assemblyDefinitionPath, time.Now().Add(time.Hour))
+
+	graph, err := loadAssemblyGraph(projectRoot, planDagDirectory)
+	if err != nil {
+		t.Fatalf("failed to load the assembly graph: %v", err)
+	}
+	assemblyDefinitions, err := IndexAssemblyDefinitions(projectRoot)
+	if err != nil {
+		t.Fatalf("failed to index the assembly definitions: %v", err)
+	}
+
+	return projectRoot,
+		graph.byName["A"],
+		assemblyDefinitions["A"],
+		NewAssemblyContext(graph, assemblyDefinitions)
+}
+
+// Verifies an assembly definition whose timestamp moved but whose content still matches the
+// response file is accepted, which is what a branch switch leaves behind.
+func TestDetectStructuralChangeAcceptsTouchedButUnchangedAssemblyDefinition(t *testing.T) {
+	projectRoot, rsp, asmdef, context := newContractProject(t, `{"name":"A","references":["B"]}`)
+
+	if err := DetectStructuralChange(
+		projectRoot, rsp, &asmdef, planDagDirectory, context); err != nil {
+		t.Fatalf("expected a timestamp-only change to be accepted, got error: %v", err)
+	}
+}
+
+// Verifies a reference added to the assembly definition by name is refused.
+func TestDetectStructuralChangeRejectsAddedNameReference(t *testing.T) {
+	projectRoot, rsp, asmdef, context := newContractProject(t, `{"name":"A","references":["B","C"]}`)
+
+	err := DetectStructuralChange(projectRoot, rsp, &asmdef, planDagDirectory, context)
+	if err == nil {
+		t.Fatal("expected an added reference to be rejected")
+	}
+	if !strings.Contains(err.Error(), "C") {
+		t.Errorf("the error should name the added reference, got: %v", err)
+	}
+}
+
+// Verifies a reference added to the assembly definition in GUID form is refused too.
+func TestDetectStructuralChangeRejectsAddedGUIDReference(t *testing.T) {
+	projectRoot, rsp, asmdef, context := newContractProject(
+		t, `{"name":"A","references":["GUID:`+referencedGUID+`","GUID:`+unreferencedGUID+`"]}`)
+
+	if err := DetectStructuralChange(
+		projectRoot, rsp, &asmdef, planDagDirectory, context); err == nil {
+		t.Fatal("expected an added GUID reference to be rejected")
+	}
+}
+
+// Verifies a GUID no assembly definition in the project owns is skipped rather than refused, since
+// healthy projects reference assemblies that own no indexable .asmdef.
+func TestDetectStructuralChangeAcceptsUnresolvableGUIDReference(t *testing.T) {
+	projectRoot, rsp, asmdef, context := newContractProject(
+		t, `{"name":"A","references":["B","GUID:00000000000000000000000000000000"]}`)
+
+	if err := DetectStructuralChange(
+		projectRoot, rsp, &asmdef, planDagDirectory, context); err != nil {
+		t.Fatalf("expected an unresolvable GUID to be skipped, got error: %v", err)
+	}
+}
+
+// Verifies an assembly definition that turned on unsafe code without the response file allowing it
+// is refused.
+func TestDetectStructuralChangeRejectsNewlyAllowedUnsafeCode(t *testing.T) {
+	projectRoot, rsp, asmdef, context := newContractProject(
+		t, `{"name":"A","references":["B"],"allowUnsafeCode":true}`)
+
+	if err := DetectStructuralChange(
+		projectRoot, rsp, &asmdef, planDagDirectory, context); err == nil {
+		t.Fatal("expected newly allowed unsafe code to be rejected")
+	}
+}
+
+// Verifies the unsafe check accepts the /unsafe+ spelling Bee actually writes.
+func TestDetectStructuralChangeAcceptsUnsafeCodeAlreadyInTheResponseFile(t *testing.T) {
+	projectRoot, rsp, asmdef, context := newContractProject(
+		t, `{"name":"A","references":["B"],"allowUnsafeCode":true}`)
+	rsp.OtherFlags = append(rsp.OtherFlags, "/unsafe+")
+
+	if err := DetectStructuralChange(
+		projectRoot, rsp, &asmdef, planDagDirectory, context); err != nil {
+		t.Fatalf("expected /unsafe+ to satisfy allowUnsafeCode, got error: %v", err)
+	}
+}
+
+// Verifies a precompiled reference the response file never received is refused.
+func TestDetectStructuralChangeRejectsMissingPrecompiledReference(t *testing.T) {
+	projectRoot, rsp, asmdef, context := newContractProject(t,
+		`{"name":"A","references":["B"],"overrideReferences":true,"precompiledReferences":["Some.dll"]}`)
+
+	err := DetectStructuralChange(projectRoot, rsp, &asmdef, planDagDirectory, context)
+	if err == nil {
+		t.Fatal("expected a missing precompiled reference to be rejected")
+	}
+	if !strings.Contains(err.Error(), "Some.dll") {
+		t.Errorf("the error should name the missing reference, got: %v", err)
+	}
+}
+
+// Verifies a precompiled reference the response file already carries is accepted.
+func TestDetectStructuralChangeAcceptsSatisfiedPrecompiledReference(t *testing.T) {
+	projectRoot, rsp, asmdef, context := newContractProject(t,
+		`{"name":"A","references":["B"],"overrideReferences":true,"precompiledReferences":["Some.dll"]}`)
+	rsp.References = append(rsp.References, filepath.Join("Assets", "Plugins", "Some.dll"))
+
+	if err := DetectStructuralChange(
+		projectRoot, rsp, &asmdef, planDagDirectory, context); err != nil {
+		t.Fatalf("expected the satisfied precompiled reference to pass, got error: %v", err)
+	}
+}
+
+// Verifies an assembly definition that no longer builds for the Editor is refused, which is the one
+// removal this check can observe.
+func TestDetectStructuralChangeRejectsAssemblyDefinitionExcludedFromTheEditor(t *testing.T) {
+	projectRoot, rsp, asmdef, context := newContractProject(
+		t, `{"name":"A","references":["B"],"includePlatforms":["iOS"]}`)
+
+	if err := DetectStructuralChange(
+		projectRoot, rsp, &asmdef, planDagDirectory, context); err == nil {
+		t.Fatal("expected an assembly definition excluded from the Editor to be rejected")
+	}
+}
+
+// Verifies an assembly definition Unity does not build for the Editor is not reported as added,
+// however recently its file was written.
+func TestBuildCompilePlanAcceptsTouchedAssemblyDefinitionThatSkipsTheEditor(t *testing.T) {
+	projectRoot := newPlanProject(t)
+	addedPath := filepath.Join(projectRoot, "Assets", "Mobile", "Mobile.asmdef")
+	writeFileAt(t, addedPath, `{"name":"Mobile","includePlatforms":["Android"]}`)
+	setModificationTime(t, addedPath, time.Now().Add(time.Hour))
+
+	if _, err := BuildCompilePlan(projectRoot, planDagDirectory, true); err != nil {
+		t.Fatalf("expected a platform-excluded assembly definition to be accepted, got error: %v", err)
+	}
+}
+
+// Verifies an assembly definition that does build for the Editor and has no response file is still
+// reported as added.
+func TestBuildCompilePlanRejectsTouchedAssemblyDefinitionThatBuildsForTheEditor(t *testing.T) {
+	projectRoot := newPlanProject(t)
+	addedPath := filepath.Join(projectRoot, "Assets", "Extra", "Extra.asmdef")
+	writeFileAt(t, addedPath, `{"name":"Extra"}`)
+	setModificationTime(t, addedPath, time.Now().Add(time.Hour))
+
+	if _, err := BuildCompilePlan(projectRoot, planDagDirectory, true); err == nil {
+		t.Fatal("expected a newly added assembly definition to be rejected")
+	}
+}
+
+// Verifies a precondition failure reaches the shared classifier as its own error code, so agents
+// can tell "build in Unity first" apart from a real internal failure.
+func TestUnityBuildRequiredErrorClassifiesToItsOwnErrorCode(t *testing.T) {
+	projectRoot, rsp, asmdef, context := newContractProject(
+		t, `{"name":"A","references":["B"],"includePlatforms":["iOS"]}`)
+
+	err := DetectStructuralChange(projectRoot, rsp, &asmdef, planDagDirectory, context)
+	if err == nil {
+		t.Fatal("expected the excluded assembly definition to be rejected")
+	}
+
+	classified := clierrors.ClassifyError(err, clierrors.ErrorContext{Command: "compile-check"})
+	if classified.ErrorCode != clierrors.ErrorCodeCompileCheckUnityBuildRequired {
+		t.Errorf("ErrorCode = %q, want %q",
+			classified.ErrorCode, clierrors.ErrorCodeCompileCheckUnityBuildRequired)
+	}
+	if classified.Retryable {
+		t.Error("a precondition only a Unity build clears must not be reported as retryable")
+	}
+	if len(classified.NextActions) == 0 {
+		t.Error("the error must tell the user to run uloop compile")
+	}
+}

--- a/cli/dispatcher/internal/compilecheck/assembly_set.go
+++ b/cli/dispatcher/internal/compilecheck/assembly_set.go
@@ -34,12 +34,10 @@ func DetectAssemblySetChange(
 	}
 
 	if name, found := addedAssemblyName(graph, assemblyDefinitions, buildTime); found {
-		return fmt.Errorf(
-			"assembly definition %s %s; %s", name, changeReasonAssemblyAdded, runCompileFirstAdvice)
+		return unityBuildRequired("assembly definition %s %s", name, changeReasonAssemblyAdded)
 	}
 	if name, found := removedAssemblyName(graph, assemblyDefinitions); found {
-		return fmt.Errorf(
-			"assembly definition %s %s; %s", name, changeReasonAssemblyRemoved, runCompileFirstAdvice)
+		return unityBuildRequired("assembly definition %s %s", name, changeReasonAssemblyRemoved)
 	}
 
 	return nil
@@ -61,6 +59,12 @@ func addedAssemblyName(
 		if _, built := graph.byName[name]; built {
 			continue
 		}
+		// Why the Editor check comes first: an assembly definition Unity does not build for the
+		// Editor legitimately has no response file however recently it was written, and switching
+		// branches rewrites every .asmdef timestamp without changing anything.
+		if !assemblyDefinitionBuildsForEditor(assemblyDefinitions[name].Path) {
+			continue
+		}
 		written, err := modificationTime(assemblyDefinitions[name].Path)
 		if err != nil || !written.After(buildTime) {
 			continue
@@ -70,6 +74,18 @@ func addedAssemblyName(
 	}
 
 	return "", false
+}
+
+// assemblyDefinitionBuildsForEditor reports whether Unity still compiles an .asmdef for the Editor.
+// An unreadable file counts as building, so a parse problem surfaces as the refusal it always was
+// rather than silently hiding an assembly that really is new.
+func assemblyDefinitionBuildsForEditor(path string) bool {
+	contract, err := readAssemblyDefinitionContract(path)
+	if err != nil {
+		return true
+	}
+
+	return contract.buildsForEditor()
 }
 
 // removedAssemblyName names an assembly Bee built whose assembly definition is gone from the project.
@@ -108,8 +124,8 @@ func newestBuildTime(projectRoot string, dagDir string) (time.Time, error) {
 		}
 	}
 	if newest.IsZero() {
-		return time.Time{}, fmt.Errorf(
-			"the Unity Editor has never built %s; %s", dagDirectoryPath, runCompileFirstAdvice)
+		return time.Time{}, unityBuildRequired(
+			"the Unity Editor has never built %s", dagDirectoryPath)
 	}
 
 	return newest, nil

--- a/cli/dispatcher/internal/compilecheck/local_packages.go
+++ b/cli/dispatcher/internal/compilecheck/local_packages.go
@@ -1,0 +1,82 @@
+package compilecheck
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+const (
+	packageManifestFileName  = "manifest.json"
+	localPackagePathPrefix   = "file:"
+	localPackagePathRelative = ".."
+)
+
+// localPackageRoots lists the directories of the packages this project develops from a local path.
+// Why they matter: a `file:` dependency lives outside the project root, so its assembly definitions
+// and sources are invisible to a walk of Assets, Packages and the package cache, and every assembly
+// the package owns then looks like one Unity built and the project since deleted.
+// A missing or unreadable manifest yields no roots rather than an error: the built-in roots still
+// describe the project, and a manifest problem must not turn into a removed-assembly refusal.
+func localPackageRoots(projectRoot string) []string {
+	packagesDirectory := filepath.Join(projectRoot, packagesDirectoryName)
+
+	var manifest struct {
+		Dependencies map[string]string `json:"dependencies"`
+	}
+	if err := readUnityJSONFile(
+		filepath.Join(packagesDirectory, packageManifestFileName), &manifest); err != nil {
+		return nil
+	}
+
+	roots := []string{}
+	for _, location := range manifest.Dependencies {
+		root, isLocal := resolveLocalPackagePath(packagesDirectory, location)
+		if !isLocal {
+			continue
+		}
+		roots = append(roots, root)
+	}
+
+	return roots
+}
+
+// resolveLocalPackagePath turns one manifest dependency into the directory it points at, when the
+// dependency is a local path at all. Unity resolves a relative path against the Packages folder.
+func resolveLocalPackagePath(packagesDirectory string, location string) (string, bool) {
+	if !strings.HasPrefix(location, localPackagePathPrefix) {
+		return "", false
+	}
+
+	path := strings.TrimPrefix(location, localPackagePathPrefix)
+	if path == "" {
+		return "", false
+	}
+	if filepath.IsAbs(path) {
+		return filepath.Clean(path), true
+	}
+
+	return filepath.Join(packagesDirectory, path), true
+}
+
+// sourcePath turns one response-file source entry into a path this process can open. Bee records a
+// source inside the project relative to the project root and one outside it as an absolute path.
+func sourcePath(projectRoot string, source string) string {
+	if filepath.IsAbs(source) {
+		return source
+	}
+
+	return filepath.Join(projectRoot, source)
+}
+
+// recordSourcePath spells one source the way Bee spells it, so a rebuilt list can be compared with
+// the recorded one. A source outside the project root has no meaningful relative form, and using
+// one would make every file of a locally developed package read as removed and added at once.
+func recordSourcePath(projectRoot string, path string) string {
+	relativePath, err := filepath.Rel(projectRoot, path)
+	if err != nil || relativePath == localPackagePathRelative ||
+		strings.HasPrefix(relativePath, localPackagePathRelative+string(filepath.Separator)) {
+		return path
+	}
+
+	return filepath.ToSlash(relativePath)
+}

--- a/cli/dispatcher/internal/compilecheck/local_packages_test.go
+++ b/cli/dispatcher/internal/compilecheck/local_packages_test.go
@@ -1,0 +1,182 @@
+package compilecheck
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+const localPackageAssemblyName = "Local.Package"
+
+// newLocalPackageProject builds a project that develops one package from a directory outside the
+// project root, the way a package author's test project consumes the package under development.
+// The package's response file records its source as an absolute path, exactly as Bee does.
+func newLocalPackageProject(t *testing.T) (string, string) {
+	t.Helper()
+	parent := t.TempDir()
+	projectRoot := filepath.Join(parent, "Project")
+	packageRoot := filepath.Join(parent, "Package")
+
+	writePlanAssembly(t, projectRoot, "A", nil)
+	writeFileAt(t, filepath.Join(projectRoot, "Packages", "manifest.json"),
+		`{"dependencies":{"com.example.local":"file:../../Package"}}`)
+
+	sourcePath := filepath.Join(packageRoot, "Runtime", localPackageAssemblyName+".cs")
+	writeFileAt(t, sourcePath, "")
+	writeFileAt(t, filepath.Join(packageRoot, "Runtime", localPackageAssemblyName+".asmdef"),
+		`{"name":"`+localPackageAssemblyName+`"}`)
+	writeFileAt(t,
+		filepath.Join(projectRoot, planDagDirectory, localPackageAssemblyName+".rsp"),
+		joinLines([]string{
+			`-out:"` + planDagDirectory + `/` + localPackageAssemblyName + `.dll"`,
+			`-refout:"` + planDagDirectory + `/` + localPackageAssemblyName + `.ref.dll"`,
+			`"` + sourcePath + `"`,
+		}))
+	writeFileAt(t, filepath.Join(projectRoot, planDagDirectory, localPackageAssemblyName+".dll"), "")
+
+	buildTime := time.Now()
+	setModificationTime(t, sourcePath, buildTime.Add(-time.Hour))
+	setModificationTime(t,
+		filepath.Join(packageRoot, "Runtime", localPackageAssemblyName+".asmdef"),
+		buildTime.Add(-time.Hour))
+	setModificationTime(t,
+		filepath.Join(projectRoot, planDagDirectory, localPackageAssemblyName+".dll"), buildTime)
+	settlePlanProject(t, projectRoot, "A")
+
+	return projectRoot, packageRoot
+}
+
+// Verifies an assembly definition of a package referenced by a local path is indexed, so its
+// assembly is not mistaken for one whose assembly definition the project deleted.
+func TestIndexAssemblyDefinitionsFindsLocallyReferencedPackages(t *testing.T) {
+	projectRoot, packageRoot := newLocalPackageProject(t)
+
+	assemblyDefinitions, err := IndexAssemblyDefinitions(projectRoot)
+	if err != nil {
+		t.Fatalf("failed to index the assembly definitions: %v", err)
+	}
+
+	definition, found := assemblyDefinitions[localPackageAssemblyName]
+	if !found {
+		t.Fatalf("the local package's assembly definition is missing from the index: %v",
+			assemblyDefinitions)
+	}
+	if !isUnderDirectory(definition.Path, packageRoot) {
+		t.Errorf("indexed path = %q, want one inside the local package", definition.Path)
+	}
+}
+
+// Verifies a project that develops a package from a local path compiles instead of being refused as
+// one whose assembly definitions were removed after the last Unity build.
+func TestBuildCompilePlanAcceptsALocallyReferencedPackage(t *testing.T) {
+	projectRoot, _ := newLocalPackageProject(t)
+
+	if _, err := BuildCompilePlan(projectRoot, planDagDirectory, true); err != nil {
+		t.Fatalf("expected a locally referenced package to be accepted, got error: %v", err)
+	}
+}
+
+// Verifies the rebuilt source list of a local package keeps the absolute spelling of the response
+// file, so unchanged sources are not reported as removed and added at once.
+func TestRebuildSourcesKeepsAbsolutePathsOfALocalPackage(t *testing.T) {
+	projectRoot, _ := newLocalPackageProject(t)
+
+	graph, err := loadAssemblyGraph(projectRoot, planDagDirectory)
+	if err != nil {
+		t.Fatalf("failed to load the assembly graph: %v", err)
+	}
+	assemblyDefinitions, err := IndexAssemblyDefinitions(projectRoot)
+	if err != nil {
+		t.Fatalf("failed to index the assembly definitions: %v", err)
+	}
+	definition := assemblyDefinitions[localPackageAssemblyName]
+	rsp := graph.byName[localPackageAssemblyName]
+
+	sources, err := RebuildSources(projectRoot, rsp, &definition)
+	if err != nil {
+		t.Fatalf("failed to rebuild the sources: %v", err)
+	}
+
+	assertStrings(t, "sources", sources, rsp.Sources)
+
+	report, err := DetectSourceChange(projectRoot, rsp, sources, planDagDirectory)
+	if err != nil {
+		t.Fatalf("failed to detect source changes: %v", err)
+	}
+	if report.Changed {
+		t.Errorf("unchanged local package sources reported a change: %q", report.Reason)
+	}
+}
+
+// Verifies a manifest that cannot be read leaves the project's own roots in place rather than
+// turning a manifest problem into a refusal to compile.
+func TestLocalPackageRootsIgnoresAnUnreadableManifest(t *testing.T) {
+	projectRoot := t.TempDir()
+	writeFileAt(t, filepath.Join(projectRoot, "Packages", "manifest.json"), "not json")
+
+	if roots := localPackageRoots(projectRoot); len(roots) != 0 {
+		t.Errorf("roots = %v, want none", roots)
+	}
+}
+
+// Verifies a dependency that names a registry version rather than a local path adds no root.
+func TestLocalPackageRootsSkipsRegistryDependencies(t *testing.T) {
+	projectRoot := t.TempDir()
+	writeFileAt(t, filepath.Join(projectRoot, "Packages", "manifest.json"),
+		`{"dependencies":{"com.unity.example":"1.2.3"}}`)
+
+	if roots := localPackageRoots(projectRoot); len(roots) != 0 {
+		t.Errorf("roots = %v, want none", roots)
+	}
+}
+
+// byteOrderMark is what an editor on Windows writes in front of UTF-8 JSON.
+const byteOrderMark = "\uFEFF"
+
+// Verifies an assembly definition saved as UTF-8 with a byte order mark is still indexed, instead
+// of failing the whole command with a JSON parse error.
+func TestIndexAssemblyDefinitionsReadsAnAssemblyDefinitionWithAByteOrderMark(t *testing.T) {
+	projectRoot := t.TempDir()
+	writeFileAt(t, filepath.Join(projectRoot, "Assets", "A", "A.asmdef"),
+		byteOrderMark+`{"name":"A"}`)
+
+	assemblyDefinitions, err := IndexAssemblyDefinitions(projectRoot)
+	if err != nil {
+		t.Fatalf("expected the byte order mark to be tolerated, got error: %v", err)
+	}
+	if _, found := assemblyDefinitions["A"]; !found {
+		t.Errorf("index = %v, want it to contain A", assemblyDefinitions)
+	}
+}
+
+// Verifies the contract reader tolerates a byte order mark too, so a Windows-authored assembly
+// definition is compared against its response file rather than reported as unreadable.
+func TestReadAssemblyDefinitionContractReadsAByteOrderMark(t *testing.T) {
+	projectRoot := t.TempDir()
+	path := filepath.Join(projectRoot, "A.asmdef")
+	writeFileAt(t, path, byteOrderMark+`{"name":"A","includePlatforms":["iOS"]}`)
+
+	contract, err := readAssemblyDefinitionContract(path)
+	if err != nil {
+		t.Fatalf("expected the byte order mark to be tolerated, got error: %v", err)
+	}
+	if contract.buildsForEditor() {
+		t.Error("the platform list should have been read, so the assembly must not build for the Editor")
+	}
+}
+
+// Verifies a package manifest saved with a byte order mark still contributes its local package
+// roots, rather than silently leaving them out of the index.
+func TestLocalPackageRootsReadsAManifestWithAByteOrderMark(t *testing.T) {
+	projectRoot := t.TempDir()
+	writeFileAt(t, filepath.Join(projectRoot, "Packages", "manifest.json"),
+		byteOrderMark+`{"dependencies":{"com.example.local":"file:../../Package"}}`)
+
+	roots := localPackageRoots(projectRoot)
+	if len(roots) != 1 {
+		t.Fatalf("roots = %v, want exactly one", roots)
+	}
+	if filepath.Base(roots[0]) != "Package" {
+		t.Errorf("root = %q, want the directory the manifest points at", roots[0])
+	}
+}

--- a/cli/dispatcher/internal/compilecheck/plan.go
+++ b/cli/dispatcher/internal/compilecheck/plan.go
@@ -125,8 +125,7 @@ func listResponseFiles(dagDirectoryPath string) ([]string, error) {
 		paths = append(paths, path)
 	}
 	if len(paths) == 0 {
-		return nil, fmt.Errorf(
-			"no Bee response files found in %s; %s", dagDirectoryPath, runCompileFirstAdvice)
+		return nil, unityBuildRequired("no Bee response files found in %s", dagDirectoryPath)
 	}
 
 	return paths, nil
@@ -145,11 +144,13 @@ func selectChangedAssemblies(
 		return nil, setErr
 	}
 
+	context := NewAssemblyContext(graph, assemblyDefinitions)
 	reasons := map[string]string{}
 	for _, name := range graph.names {
 		rsp := graph.byName[name]
 		asmdef := lookupAssemblyDefinition(assemblyDefinitions, name)
-		if structuralErr := DetectStructuralChange(projectRoot, rsp, asmdef, dagDir); structuralErr != nil {
+		if structuralErr := DetectStructuralChange(
+			projectRoot, rsp, asmdef, dagDir, context); structuralErr != nil {
 			return nil, structuralErr
 		}
 

--- a/cli/dispatcher/internal/compilecheck/session.go
+++ b/cli/dispatcher/internal/compilecheck/session.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -120,8 +119,7 @@ func ResolveActiveDagDir(projectRoot string) (string, error) {
 
 	name, found := dagNameFromScriptDebugSetting(projectRoot, candidates)
 	if !found {
-		return "", fmt.Errorf(
-			"cannot tell which Bee build to check in %s; %s", artifactsDirectory, runCompileFirstAdvice)
+		return "", unityBuildRequired("cannot tell which Bee build to check in %s", artifactsDirectory)
 	}
 
 	return relativeDagDir(name), nil
@@ -136,8 +134,7 @@ func relativeDagDir(name string) string {
 func dagDirectoryNames(artifactsDirectory string) ([]string, error) {
 	entries, err := os.ReadDir(artifactsDirectory)
 	if err != nil {
-		return nil, fmt.Errorf(
-			"no Bee build artifacts found in %s; %s", artifactsDirectory, runCompileFirstAdvice)
+		return nil, unityBuildRequired("no Bee build artifacts found in %s", artifactsDirectory)
 	}
 
 	names := []string{}
@@ -150,8 +147,7 @@ func dagDirectoryNames(artifactsDirectory string) ([]string, error) {
 		}
 	}
 	if len(names) == 0 {
-		return nil, fmt.Errorf(
-			"no Bee build artifacts found in %s; %s", artifactsDirectory, runCompileFirstAdvice)
+		return nil, unityBuildRequired("no Bee build artifacts found in %s", artifactsDirectory)
 	}
 	sort.Strings(names)
 

--- a/cli/dispatcher/internal/compilecheck/source_set.go
+++ b/cli/dispatcher/internal/compilecheck/source_set.go
@@ -16,6 +16,8 @@ const (
 	libraryDirectoryName         = "Library"
 	packageCacheDirectoryName    = "PackageCache"
 	assemblyDefinitionExtension  = ".asmdef"
+	assemblyDefinitionMetaSuffix = ".meta"
+	assemblyDefinitionGUIDKey    = "guid:"
 	assemblyReferenceExtension   = ".asmref"
 	cSharpSourceExtension        = ".cs"
 	unityIgnoredDirectorySuffix  = "~"
@@ -28,6 +30,7 @@ type AssemblyDefinition struct {
 	Name      string
 	Path      string // absolute path of the .asmdef file
 	Directory string // absolute path of the directory that owns the assembly
+	GUID      string // the GUID in the sibling .meta, empty when Unity has not written one yet
 }
 
 // IndexAssemblyDefinitions maps every assembly name in the project to the .asmdef that declares it.
@@ -73,7 +76,12 @@ func indexAssemblyDefinitionsUnder(root string, index map[string]AssemblyDefinit
 		// Why the first wins: Unity itself rejects duplicate assembly names, so a second one means a
 		// stale copy, and taking it would point the rebuild at the wrong directory.
 		if _, exists := index[name]; !exists {
-			index[name] = AssemblyDefinition{Name: name, Path: path, Directory: filepath.Dir(path)}
+			index[name] = AssemblyDefinition{
+				Name:      name,
+				Path:      path,
+				Directory: filepath.Dir(path),
+				GUID:      readAssemblyDefinitionGUID(path),
+			}
 		}
 
 		return nil
@@ -98,6 +106,27 @@ func readAssemblyDefinitionName(path string) (string, error) {
 	}
 
 	return definition.Name, nil
+}
+
+// readAssemblyDefinitionGUID reads the GUID Unity assigned an .asmdef, which is how other assembly
+// definitions spell a reference to it. An unreadable .meta yields an empty GUID rather than an
+// error: the GUID only refines a check that already tolerates references it cannot resolve.
+func readAssemblyDefinitionGUID(assemblyDefinitionPath string) string {
+	content, err := os.ReadFile(assemblyDefinitionPath + assemblyDefinitionMetaSuffix)
+	if err != nil {
+		return ""
+	}
+
+	for _, rawLine := range strings.Split(string(content), "\n") {
+		line := strings.TrimSpace(rawLine)
+		if !strings.HasPrefix(line, assemblyDefinitionGUIDKey) {
+			continue
+		}
+
+		return strings.TrimSpace(strings.TrimPrefix(line, assemblyDefinitionGUIDKey))
+	}
+
+	return ""
 }
 
 // RebuildSources lists the sources to compile now, reflecting .cs files added or deleted since Bee ran.

--- a/cli/dispatcher/internal/compilecheck/source_set.go
+++ b/cli/dispatcher/internal/compilecheck/source_set.go
@@ -1,6 +1,7 @@
 package compilecheck
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io/fs"
@@ -25,6 +26,9 @@ const (
 	assemblyDefinitionIndexError = "failed to index assembly definitions under %s: %w"
 )
 
+// utf8ByteOrderMark is the prefix editors on Windows put in front of UTF-8 text.
+var utf8ByteOrderMark = []byte{0xEF, 0xBB, 0xBF}
+
 // AssemblyDefinition is one .asmdef file, keyed by the assembly name it declares.
 type AssemblyDefinition struct {
 	Name      string
@@ -41,6 +45,7 @@ func IndexAssemblyDefinitions(projectRoot string) (map[string]AssemblyDefinition
 		filepath.Join(projectRoot, packagesDirectoryName),
 		filepath.Join(projectRoot, libraryDirectoryName, packageCacheDirectoryName),
 	}
+	roots = append(roots, localPackageRoots(projectRoot)...)
 	for _, root := range roots {
 		if !directoryExists(root) {
 			continue
@@ -88,17 +93,24 @@ func indexAssemblyDefinitionsUnder(root string, index map[string]AssemblyDefinit
 	})
 }
 
-// readAssemblyDefinitionName reads the assembly name an .asmdef declares.
-func readAssemblyDefinitionName(path string) (string, error) {
+// readUnityJSONFile reads one of Unity's JSON files into target.
+// Why the byte order mark is stripped: editors on Windows write UTF-8 with a BOM by default, and
+// encoding/json rejects it, which would turn one such .asmdef into a failure of the whole command.
+func readUnityJSONFile(path string, target any) error {
 	content, err := os.ReadFile(path)
 	if err != nil {
-		return "", err
+		return err
 	}
 
+	return json.Unmarshal(bytes.TrimPrefix(content, utf8ByteOrderMark), target)
+}
+
+// readAssemblyDefinitionName reads the assembly name an .asmdef declares.
+func readAssemblyDefinitionName(path string) (string, error) {
 	var definition struct {
 		Name string `json:"name"`
 	}
-	if err := json.Unmarshal(content, &definition); err != nil {
+	if err := readUnityJSONFile(path, &definition); err != nil {
 		return "", fmt.Errorf("failed to read %s: %w", path, err)
 	}
 	if definition.Name == "" {
@@ -133,7 +145,7 @@ func readAssemblyDefinitionGUID(assemblyDefinitionPath string) string {
 func RebuildSources(projectRoot string, rsp ResponseFile, asmdef *AssemblyDefinition) ([]string, error) {
 	existing := make([]string, 0, len(rsp.Sources))
 	for _, source := range rsp.Sources {
-		if fileExists(filepath.Join(projectRoot, source)) {
+		if fileExists(sourcePath(projectRoot, source)) {
 			existing = append(existing, source)
 		}
 	}
@@ -155,7 +167,7 @@ func RebuildSources(projectRoot string, rsp ResponseFile, asmdef *AssemblyDefini
 	// assembly, and only the response file records where they came from.
 	result := globbed
 	for _, source := range existing {
-		if !isUnderDirectory(filepath.Join(projectRoot, source), asmdef.Directory) {
+		if !isUnderDirectory(sourcePath(projectRoot, source), asmdef.Directory) {
 			result = append(result, source)
 		}
 	}
@@ -184,11 +196,7 @@ func globAssemblySources(projectRoot string, assemblyDirectory string) ([]string
 		if filepath.Ext(path) != cSharpSourceExtension {
 			return nil
 		}
-		relativePath, relErr := filepath.Rel(projectRoot, path)
-		if relErr != nil {
-			return relErr
-		}
-		sources = append(sources, relativePath)
+		sources = append(sources, recordSourcePath(projectRoot, path))
 
 		return nil
 	})

--- a/cli/dispatcher/internal/compilecheck/staleness.go
+++ b/cli/dispatcher/internal/compilecheck/staleness.go
@@ -29,6 +29,7 @@ type ChangeReport struct {
 // diagnostics for a configuration the project no longer has.
 func DetectStructuralChange(
 	projectRoot string, rsp ResponseFile, asmdef *AssemblyDefinition, dagDir string,
+	context AssemblyContext,
 ) error {
 	baseline, err := lastBuildTime(projectRoot, rsp, dagDir)
 	if err != nil {
@@ -36,19 +37,42 @@ func DetectStructuralChange(
 	}
 
 	if asmdef != nil {
-		asmdefTime, statErr := modificationTime(asmdef.Path)
-		if statErr != nil {
-			return statErr
-		}
-		if asmdefTime.After(baseline) {
-			return fmt.Errorf(
-				"assembly definition %s changed after the last Unity build; %s",
-				asmdef.Name, runCompileFirstAdvice)
+		if changeErr := detectAssemblyDefinitionChange(
+			*asmdef, rsp, dagDir, baseline, context); changeErr != nil {
+			return changeErr
 		}
 	}
 
 	if rsp.AdditionalFile != "" && !fileExists(filepath.Join(projectRoot, rsp.AdditionalFile)) {
-		return fmt.Errorf("the Bee artifacts are incomplete for %s; %s", rsp.AssemblyName, runCompileFirstAdvice)
+		return unityBuildRequired("the Bee artifacts are incomplete for %s", rsp.AssemblyName)
+	}
+
+	return nil
+}
+
+// detectAssemblyDefinitionChange compares an assembly definition against the response file once its
+// timestamp says it may have moved.
+// Why the timestamp is only a trigger: switching branches rewrites every .asmdef file without
+// changing its content, and Unity's incremental build hashes content, so it rebuilds nothing and
+// the timestamp alone would refuse the project forever.
+func detectAssemblyDefinitionChange(
+	asmdef AssemblyDefinition, rsp ResponseFile, dagDir string,
+	baseline time.Time, context AssemblyContext,
+) error {
+	asmdefTime, err := modificationTime(asmdef.Path)
+	if err != nil {
+		return err
+	}
+	if !asmdefTime.After(baseline) {
+		return nil
+	}
+
+	contract, readErr := readAssemblyDefinitionContract(asmdef.Path)
+	if readErr != nil {
+		return readErr
+	}
+	if reason := detectContractDisagreement(contract, rsp, dagDir, context); reason != "" {
+		return unityBuildRequired("assembly definition %s %s", asmdef.Name, reason)
 	}
 
 	return nil
@@ -110,8 +134,8 @@ func lastBuildTime(projectRoot string, rsp ResponseFile, dagDir string) (time.Ti
 	assemblyPath := filepath.Join(projectRoot, dagDir, rsp.AssemblyName+assemblyExtension)
 	info, err := os.Stat(assemblyPath)
 	if err != nil {
-		return time.Time{}, fmt.Errorf(
-			"the Unity Editor has never built %s; %s", rsp.AssemblyName, runCompileFirstAdvice)
+		return time.Time{}, unityBuildRequired(
+			"the Unity Editor has never built %s", rsp.AssemblyName)
 	}
 
 	return info.ModTime(), nil

--- a/cli/dispatcher/internal/compilecheck/staleness.go
+++ b/cli/dispatcher/internal/compilecheck/staleness.go
@@ -92,7 +92,7 @@ func DetectSourceChange(
 	}
 
 	for _, source := range sources {
-		sourceTime, statErr := modificationTime(filepath.Join(projectRoot, source))
+		sourceTime, statErr := modificationTime(sourcePath(projectRoot, source))
 		if statErr != nil {
 			return ChangeReport{}, statErr
 		}

--- a/cli/dispatcher/internal/compilecheck/staleness_test.go
+++ b/cli/dispatcher/internal/compilecheck/staleness_test.go
@@ -104,12 +104,14 @@ func TestDetectSourceChangeReportsRemovedSource(t *testing.T) {
 	}
 }
 
-// Verifies an assembly definition edited after the last build stops the run instead of compiling.
+// Verifies an assembly definition that gained a reference after the last build stops the run
+// instead of compiling, and says how to recover.
 func TestDetectStructuralChangeRejectsEditedAssemblyDefinition(t *testing.T) {
 	projectRoot, rsp, asmdef := newStalenessProject(t)
+	writeFileAt(t, asmdef.Path, `{"name":"Foo","includePlatforms":["iOS"]}`)
 	setModificationTime(t, asmdef.Path, time.Now().Add(time.Hour))
 
-	err := DetectStructuralChange(projectRoot, rsp, &asmdef, stalenessDagDirectory)
+	err := DetectStructuralChange(projectRoot, rsp, &asmdef, stalenessDagDirectory, AssemblyContext{})
 	if err == nil {
 		t.Fatal("expected an edited assembly definition to be rejected")
 	}
@@ -125,7 +127,8 @@ func TestDetectStructuralChangeRejectsIncompleteBeeArtifacts(t *testing.T) {
 		t.Fatalf("failed to remove the additional file: %v", err)
 	}
 
-	if err := DetectStructuralChange(projectRoot, rsp, &asmdef, stalenessDagDirectory); err == nil {
+	if err := DetectStructuralChange(
+		projectRoot, rsp, &asmdef, stalenessDagDirectory, AssemblyContext{}); err == nil {
 		t.Fatal("expected incomplete Bee artifacts to be rejected")
 	}
 }
@@ -137,7 +140,8 @@ func TestDetectStructuralChangeRejectsNeverBuiltAssembly(t *testing.T) {
 		t.Fatalf("failed to remove the assembly: %v", err)
 	}
 
-	if err := DetectStructuralChange(projectRoot, rsp, &asmdef, stalenessDagDirectory); err == nil {
+	if err := DetectStructuralChange(
+		projectRoot, rsp, &asmdef, stalenessDagDirectory, AssemblyContext{}); err == nil {
 		t.Fatal("expected a never-built assembly to be rejected")
 	}
 }
@@ -146,7 +150,8 @@ func TestDetectStructuralChangeRejectsNeverBuiltAssembly(t *testing.T) {
 func TestDetectStructuralChangeAcceptsUnchangedAssembly(t *testing.T) {
 	projectRoot, rsp, asmdef := newStalenessProject(t)
 
-	if err := DetectStructuralChange(projectRoot, rsp, &asmdef, stalenessDagDirectory); err != nil {
+	if err := DetectStructuralChange(
+		projectRoot, rsp, &asmdef, stalenessDagDirectory, AssemblyContext{}); err != nil {
 		t.Fatalf("expected the unchanged assembly to pass, got error: %v", err)
 	}
 }

--- a/cli/dispatcher/internal/compilecheck/staleness_test.go
+++ b/cli/dispatcher/internal/compilecheck/staleness_test.go
@@ -104,8 +104,8 @@ func TestDetectSourceChangeReportsRemovedSource(t *testing.T) {
 	}
 }
 
-// Verifies an assembly definition that gained a reference after the last build stops the run
-// instead of compiling, and says how to recover.
+// Verifies an assembly definition that stopped building for the Editor after the last build stops
+// the run instead of compiling, and says how to recover.
 func TestDetectStructuralChangeRejectsEditedAssemblyDefinition(t *testing.T) {
 	projectRoot, rsp, asmdef := newStalenessProject(t)
 	writeFileAt(t, asmdef.Path, `{"name":"Foo","includePlatforms":["iOS"]}`)

--- a/cli/dispatcher/internal/compilecheck/unity_build_required.go
+++ b/cli/dispatcher/internal/compilecheck/unity_build_required.go
@@ -1,0 +1,38 @@
+package compilecheck
+
+import (
+	"fmt"
+
+	clierrors "github.com/hatayama/unity-cli-loop/common/errors"
+)
+
+// UnityBuildRequiredError reports a precondition compile-check cannot repair on its own.
+// Why it is its own type: every one of these means the Bee artifacts no longer describe the
+// project, and the only fix is letting the Editor build once, which is a different action from
+// the retry an internal error invites.
+type UnityBuildRequiredError struct {
+	Reason string
+}
+
+func (err UnityBuildRequiredError) Error() string {
+	return err.Reason + "; " + runCompileFirstAdvice
+}
+
+// ToCLIError lets the shared classifier render this error without knowing the compilecheck package.
+func (err UnityBuildRequiredError) ToCLIError(context clierrors.ErrorContext) clierrors.CLIError {
+	return clierrors.CLIError{
+		ErrorCode:   clierrors.ErrorCodeCompileCheckUnityBuildRequired,
+		Phase:       clierrors.ErrorPhaseExecution,
+		Message:     err.Error(),
+		Retryable:   false,
+		SafeToRetry: false,
+		ProjectRoot: context.ProjectRoot,
+		Command:     context.Command,
+		NextActions: []string{"Run `uloop compile`, then retry `compile-check`."},
+	}
+}
+
+// unityBuildRequired states one precondition failure the user fixes by building in Unity.
+func unityBuildRequired(format string, arguments ...any) error {
+	return UnityBuildRequiredError{Reason: fmt.Sprintf(format, arguments...)}
+}

--- a/cli/dispatcher/internal/dispatcher/compile_check.go
+++ b/cli/dispatcher/internal/dispatcher/compile_check.go
@@ -1,0 +1,320 @@
+package dispatcher
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/hatayama/unity-cli-loop/common/clicore"
+	clierrors "github.com/hatayama/unity-cli-loop/common/errors"
+	"github.com/hatayama/unity-cli-loop/common/project"
+	"github.com/hatayama/unity-cli-loop/dispatcher/internal/compilecheck"
+)
+
+const (
+	compileCheckNoChangeMessage = "No assemblies changed since the last Unity build."
+	compileCheckAllFlag         = "--all"
+	compileCheckEditorFlag      = "--editor-version"
+	compileCheckMaxDepthFlag    = "--max-depth"
+)
+
+// compileCheckOptions are the command-line inputs of one compile-check run.
+type compileCheckOptions struct {
+	projectPath   string
+	all           bool
+	editorVersion string
+	maxDepth      int
+}
+
+// compileCheckIssue is one diagnostic in the response, shaped like the ones `uloop compile` returns.
+type compileCheckIssue struct {
+	Message  string `json:"Message"`
+	Code     string `json:"Code"`
+	File     string `json:"File"`
+	Line     int    `json:"Line"`
+	Column   int    `json:"Column"`
+	Assembly string `json:"Assembly"`
+}
+
+// compileCheckResponse is the JSON envelope one compile-check run prints.
+type compileCheckResponse struct {
+	Success            bool                `json:"Success"`
+	ErrorCount         int                 `json:"ErrorCount"`
+	WarningCount       int                 `json:"WarningCount"`
+	Errors             []compileCheckIssue `json:"Errors"`
+	Warnings           []compileCheckIssue `json:"Warnings"`
+	CompiledAssemblies []string            `json:"CompiledAssemblies"`
+	SkippedAssemblies  int                 `json:"SkippedAssemblies"`
+	ResponseFileSet    string              `json:"ResponseFileSet"`
+	ProjectRoot        string              `json:"ProjectRoot"`
+	Message            string              `json:"Message"`
+}
+
+// tryHandleCompileCheckRequest answers `uloop compile-check` inside the dispatcher process, because
+// the command never talks to the Editor and must work while Unity is closed.
+func tryHandleCompileCheckRequest(
+	ctx context.Context,
+	args []string,
+	startPath string,
+	globalProjectPath string,
+	stdout io.Writer,
+	stderr io.Writer,
+) (bool, int) {
+	if len(args) == 0 || args[0] != clicore.CompileCheckCommandName {
+		return false, 0
+	}
+	if clicore.ContainsHelpRequest(args[1:]) {
+		printCompileCheckHelp(stdout)
+		return true, 0
+	}
+
+	options, err := parseCompileCheckOptions(args[1:], globalProjectPath)
+	if err != nil {
+		clierrors.WriteClassifiedError(
+			stderr, err, clierrors.ErrorContext{Command: clicore.CompileCheckCommandName})
+		return true, 1
+	}
+
+	return true, runCompileCheck(ctx, options, startPath, stdout, stderr)
+}
+
+// runCompileCheck resolves the project and its Editor, then prints what the offline compile found.
+func runCompileCheck(
+	ctx context.Context,
+	options compileCheckOptions,
+	startPath string,
+	stdout io.Writer,
+	stderr io.Writer,
+) int {
+	projectRoot, err := resolveCompileCheckProjectRoot(startPath, options)
+	if err != nil {
+		clierrors.WriteClassifiedError(
+			stderr, err, clierrors.ErrorContext{Command: clicore.CompileCheckCommandName})
+		return 1
+	}
+
+	editorPath, err := resolveCompileCheckEditorPath(projectRoot, options)
+	if err != nil {
+		clierrors.WriteClassifiedError(stderr, err, clierrors.ErrorContext{
+			Command: clicore.CompileCheckCommandName, ProjectRoot: projectRoot,
+		})
+		return 1
+	}
+
+	result, err := compilecheck.Run(ctx, compilecheck.Options{
+		ProjectRoot:          projectRoot,
+		EditorExecutablePath: editorPath,
+		All:                  options.all,
+	})
+	if err != nil {
+		clierrors.WriteClassifiedError(stderr, err, clierrors.ErrorContext{
+			Command: clicore.CompileCheckCommandName, ProjectRoot: projectRoot,
+		})
+		return 1
+	}
+
+	response := buildCompileCheckResponse(result, projectRoot)
+	encoded, err := json.Marshal(response)
+	if err != nil {
+		clierrors.WriteClassifiedError(stderr, err, clierrors.ErrorContext{
+			Command: clicore.CompileCheckCommandName, ProjectRoot: projectRoot,
+		})
+		return 1
+	}
+	clicore.WriteJSON(stdout, encoded)
+
+	if response.ErrorCount > 0 {
+		return 1
+	}
+
+	return 0
+}
+
+// resolveCompileCheckProjectRoot finds the project the same way `launch` does, without connecting.
+func resolveCompileCheckProjectRoot(startPath string, options compileCheckOptions) (string, error) {
+	if options.projectPath != "" {
+		return project.ResolveExplicitProjectRoot(options.projectPath)
+	}
+
+	return project.FindUnityProjectRootWithin(startPath, options.maxDepth)
+}
+
+// resolveCompileCheckEditorPath finds the Editor whose bundled compiler this run has to use.
+func resolveCompileCheckEditorPath(projectRoot string, options compileCheckOptions) (string, error) {
+	version := options.editorVersion
+	if version == "" {
+		readVersion, err := readUnityEditorVersion(projectRoot)
+		if err != nil {
+			return "", err
+		}
+		version = readVersion
+	}
+
+	return resolveUnityExecutablePath(version)
+}
+
+// buildCompileCheckResponse turns one run's results into the JSON envelope, split out so the
+// mapping can be tested without an Editor.
+func buildCompileCheckResponse(result compilecheck.Result, projectRoot string) compileCheckResponse {
+	response := compileCheckResponse{
+		Errors:             make([]compileCheckIssue, 0),
+		Warnings:           make([]compileCheckIssue, 0),
+		CompiledAssemblies: make([]string, 0, len(result.Units)),
+		SkippedAssemblies:  result.Skipped,
+		ResponseFileSet:    filepath.Base(result.DagDir),
+		ProjectRoot:        projectRoot,
+	}
+
+	for _, unit := range result.Units {
+		response.CompiledAssemblies = append(response.CompiledAssemblies, unit.Assembly)
+		for _, diagnostic := range unit.Diagnostics {
+			issue := newCompileCheckIssue(unit.Assembly, diagnostic)
+			if diagnostic.Severity == "error" {
+				response.Errors = append(response.Errors, issue)
+				continue
+			}
+			response.Warnings = append(response.Warnings, issue)
+		}
+		// Why a failure with no error diagnostic still becomes an error: the assembly did not
+		// compile, and reporting success for it would hide a broken build behind a clean envelope.
+		if unit.RawOutput != "" {
+			response.Errors = append(response.Errors, compileCheckIssue{
+				Message: unit.RawOutput, Assembly: unit.Assembly,
+			})
+		}
+	}
+
+	response.ErrorCount = len(response.Errors)
+	response.WarningCount = len(response.Warnings)
+	response.Success = response.ErrorCount == 0
+	response.Message = compileCheckMessage(response)
+
+	return response
+}
+
+// newCompileCheckIssue shapes one diagnostic the way `uloop compile` shapes its own.
+func newCompileCheckIssue(assembly string, diagnostic compilecheck.Diagnostic) compileCheckIssue {
+	return compileCheckIssue{
+		Message:  diagnostic.Code + ": " + diagnostic.Message,
+		Code:     diagnostic.Code,
+		File:     diagnostic.File,
+		Line:     diagnostic.Line,
+		Column:   diagnostic.Column,
+		Assembly: assembly,
+	}
+}
+
+// compileCheckMessage states what the run did in one line.
+func compileCheckMessage(response compileCheckResponse) string {
+	count := len(response.CompiledAssemblies)
+	if count == 0 {
+		return compileCheckNoChangeMessage
+	}
+	if response.ErrorCount == 0 {
+		return fmt.Sprintf("Compiled %d assemblies with 0 errors.", count)
+	}
+
+	return fmt.Sprintf("Compiled %d assemblies with %d errors and %d warnings.",
+		count, response.ErrorCount, response.WarningCount)
+}
+
+// printCompileCheckHelp documents the command and the build it replays.
+func printCompileCheckHelp(stdout io.Writer) {
+	clicore.WriteLine(stdout, "Usage:")
+	clicore.WriteLine(stdout, "  uloop compile-check [options]")
+	clicore.WriteLine(stdout, "")
+	clicore.WriteLine(stdout, "Options:")
+	clicore.WriteLine(stdout, "      --all                Compile every assembly instead of only the changed ones")
+	clicore.WriteLine(stdout, "      --editor-version <version>")
+	clicore.WriteLine(stdout, "                           Use this Unity Editor version instead of ProjectVersion.txt")
+	clicore.WriteLine(stdout, "      --max-depth <n>      Max directory depth when auto-searching for the project (default: 3, -1 = unlimited)")
+	clicore.WriteLine(stdout, "      --project-path <path>")
+	clicore.WriteLine(stdout, "                           Compile this project instead of searching from the working directory")
+	clicore.WriteLine(stdout, "")
+	clicore.WriteLine(stdout, "Compiles without contacting the Unity Editor. Uses the response files Unity wrote on its")
+	clicore.WriteLine(stdout, "last build; new asmdefs or define changes require a Unity build first.")
+	clicore.WriteLine(stdout, "")
+	printGlobalOptionsHelp(stdout)
+	printSkillGuidanceHelp(clicore.CompileCheckCommandName, stdout)
+}
+
+// parseCompileCheckOptions reads the command line, rejecting anything compile-check does not accept.
+func parseCompileCheckOptions(args []string, globalProjectPath string) (compileCheckOptions, error) {
+	options := compileCheckOptions{
+		projectPath: globalProjectPath,
+		maxDepth:    defaultProjectSearchDepth,
+	}
+
+	for index := 0; index < len(args); index++ {
+		nextIndex, err := applyCompileCheckOption(&options, args, index)
+		if err != nil {
+			return compileCheckOptions{}, err
+		}
+		index = nextIndex
+	}
+
+	return options, nil
+}
+
+// applyCompileCheckOption reads one argument into the options.
+func applyCompileCheckOption(options *compileCheckOptions, args []string, index int) (int, error) {
+	arg := args[index]
+	switch {
+	case arg == compileCheckAllFlag:
+		options.all = true
+		return index, nil
+	case isCompileCheckKeyedOption(arg, compileCheckEditorFlag):
+		return applyCompileCheckEditorVersion(options, args, index)
+	case isCompileCheckKeyedOption(arg, compileCheckMaxDepthFlag):
+		return applyCompileCheckMaxDepth(options, args, index)
+	default:
+		return index, unknownCompileCheckOptionError(arg)
+	}
+}
+
+// isCompileCheckKeyedOption reports whether an argument is one option, spaced or in its equals form.
+func isCompileCheckKeyedOption(arg string, option string) bool {
+	return arg == option || strings.HasPrefix(arg, option+"=")
+}
+
+// applyCompileCheckEditorVersion reads the Editor version whose compiler this run must use.
+func applyCompileCheckEditorVersion(
+	options *compileCheckOptions, args []string, index int,
+) (int, error) {
+	value, consumed, err := readLaunchOptionValue(args[index], args, index)
+	if err != nil {
+		return index, err
+	}
+	options.editorVersion = value
+
+	return nextLaunchOptionIndex(index, consumed), nil
+}
+
+// applyCompileCheckMaxDepth reads how far the project search may descend.
+func applyCompileCheckMaxDepth(options *compileCheckOptions, args []string, index int) (int, error) {
+	value, consumed, err := readLaunchOptionValue(args[index], args, index)
+	if err != nil {
+		return index, err
+	}
+	maxDepth, convertErr := strconv.Atoi(value)
+	if convertErr != nil || maxDepth < -1 {
+		return index, clierrors.InvalidValueArgumentError(compileCheckMaxDepthFlag, value, "integer >= -1")
+	}
+	options.maxDepth = maxDepth
+
+	return nextLaunchOptionIndex(index, consumed), nil
+}
+
+// unknownCompileCheckOptionError rejects an argument compile-check has no meaning for.
+func unknownCompileCheckOptionError(arg string) error {
+	return &clierrors.ArgumentError{
+		Message:     "Unknown compile-check option: " + arg,
+		Option:      arg,
+		Command:     clicore.CompileCheckCommandName,
+		NextActions: []string{"Run `uloop compile-check --help` to inspect supported options."},
+	}
+}

--- a/cli/dispatcher/internal/dispatcher/compile_check.go
+++ b/cli/dispatcher/internal/dispatcher/compile_check.go
@@ -214,10 +214,6 @@ func compileCheckMessage(response compileCheckResponse) string {
 	if count == 0 {
 		return compileCheckNoChangeMessage
 	}
-	if response.ErrorCount == 0 {
-		return fmt.Sprintf("Compiled %d assemblies with 0 errors.", count)
-	}
-
 	return fmt.Sprintf("Compiled %d assemblies with %d errors and %d warnings.",
 		count, response.ErrorCount, response.WarningCount)
 }

--- a/cli/dispatcher/internal/dispatcher/compile_check_test.go
+++ b/cli/dispatcher/internal/dispatcher/compile_check_test.go
@@ -1,0 +1,178 @@
+package dispatcher
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/hatayama/unity-cli-loop/dispatcher/internal/compilecheck"
+)
+
+// Verifies that compile-check defaults to the changed-assembly scope and the global project path.
+func TestParseCompileCheckOptionsDefaultsToTheChangedScope(t *testing.T) {
+	options, err := parseCompileCheckOptions(nil, "/projects/sample")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if options.all {
+		t.Fatalf("expected the changed scope, got --all")
+	}
+	if options.projectPath != "/projects/sample" {
+		t.Fatalf("expected the global project path, got %q", options.projectPath)
+	}
+	if options.maxDepth != defaultProjectSearchDepth {
+		t.Fatalf("expected the default search depth, got %d", options.maxDepth)
+	}
+}
+
+// Verifies that every supported option is read, in both the spaced and the equals form.
+func TestParseCompileCheckOptionsReadsEverySupportedOption(t *testing.T) {
+	options, err := parseCompileCheckOptions(
+		[]string{"--all", "--editor-version", "6000.0.1f1", "--max-depth=-1"}, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !options.all {
+		t.Fatalf("expected --all to be read")
+	}
+	if options.editorVersion != "6000.0.1f1" {
+		t.Fatalf("expected the requested Editor version, got %q", options.editorVersion)
+	}
+	if options.maxDepth != -1 {
+		t.Fatalf("expected an unlimited search depth, got %d", options.maxDepth)
+	}
+}
+
+// Verifies that an option compile-check does not accept is rejected instead of ignored.
+func TestParseCompileCheckOptionsRejectsAnUnknownOption(t *testing.T) {
+	_, err := parseCompileCheckOptions([]string{"--restart"}, "")
+	if err == nil {
+		t.Fatalf("expected an unknown option to be rejected")
+	}
+	if !strings.Contains(err.Error(), "--restart") {
+		t.Fatalf("expected the rejected option to be named, got %q", err.Error())
+	}
+}
+
+// Verifies that a depth that is not an integer at or above -1 is rejected.
+func TestParseCompileCheckOptionsRejectsAnInvalidMaxDepth(t *testing.T) {
+	_, err := parseCompileCheckOptions([]string{"--max-depth", "-2"}, "")
+	if err == nil {
+		t.Fatalf("expected an out-of-range depth to be rejected")
+	}
+}
+
+// Verifies that another command's arguments are left for the handler that owns them.
+func TestTryHandleCompileCheckRequestIgnoresAnotherCommand(t *testing.T) {
+	stdout := bytes.Buffer{}
+	stderr := bytes.Buffer{}
+	handled, exitCode := tryHandleCompileCheckRequest(
+		context.Background(), []string{"launch"}, "/start", "", &stdout, &stderr)
+	if handled || exitCode != 0 {
+		t.Fatalf("expected the request to pass through, got handled=%v exitCode=%d", handled, exitCode)
+	}
+	if stdout.Len() != 0 || stderr.Len() != 0 {
+		t.Fatalf("expected no output, got %q %q", stdout.String(), stderr.String())
+	}
+}
+
+// Verifies that --help documents the command without compiling anything.
+func TestTryHandleCompileCheckRequestPrintsHelp(t *testing.T) {
+	stdout := bytes.Buffer{}
+	stderr := bytes.Buffer{}
+	handled, exitCode := tryHandleCompileCheckRequest(
+		context.Background(), []string{"compile-check", "--help"}, "/start", "", &stdout, &stderr)
+	if !handled || exitCode != 0 {
+		t.Fatalf("expected help to be handled, got handled=%v exitCode=%d", handled, exitCode)
+	}
+	for _, expected := range []string{"uloop compile-check", "--all", "without contacting the Unity Editor"} {
+		if !strings.Contains(stdout.String(), expected) {
+			t.Fatalf("expected the help to mention %q, got %q", expected, stdout.String())
+		}
+	}
+}
+
+// Verifies that a clean run reports success and names every assembly it compiled.
+func TestBuildCompileCheckResponseReportsACleanRun(t *testing.T) {
+	response := buildCompileCheckResponse(compilecheck.Result{
+		DagDir: "Library/Bee/artifacts/1234Dbg.dag",
+		Units: []compilecheck.UnitResult{
+			{Assembly: "A", Succeeded: true},
+			{Assembly: "B", Succeeded: true},
+		},
+		Skipped: 3,
+	}, "/projects/sample")
+
+	if !response.Success || response.ErrorCount != 0 {
+		t.Fatalf("expected a clean run, got %+v", response)
+	}
+	if len(response.Errors) != 0 || len(response.Warnings) != 0 {
+		t.Fatalf("expected empty diagnostic lists, got %+v", response)
+	}
+	if strings.Join(response.CompiledAssemblies, ",") != "A,B" {
+		t.Fatalf("expected both assemblies, got %v", response.CompiledAssemblies)
+	}
+	if response.ResponseFileSet != "1234Dbg.dag" {
+		t.Fatalf("expected the dag name, got %q", response.ResponseFileSet)
+	}
+	if response.SkippedAssemblies != 3 {
+		t.Fatalf("expected the skipped count to carry over, got %d", response.SkippedAssemblies)
+	}
+}
+
+// Verifies that errors and warnings are split, counted, and attributed to their assembly.
+func TestBuildCompileCheckResponseSplitsErrorsFromWarnings(t *testing.T) {
+	response := buildCompileCheckResponse(compilecheck.Result{
+		DagDir: "Library/Bee/artifacts/1234.dag",
+		Units: []compilecheck.UnitResult{{
+			Assembly: "A",
+			Diagnostics: []compilecheck.Diagnostic{
+				{Severity: "error", Code: "CS0029", Message: "cannot convert", File: "Assets/A.cs", Line: 4, Column: 9},
+				{Severity: "warning", Code: "CS0168", Message: "unused variable", File: "Assets/A.cs", Line: 7, Column: 2},
+			},
+		}},
+	}, "/projects/sample")
+
+	if response.Success || response.ErrorCount != 1 || response.WarningCount != 1 {
+		t.Fatalf("expected one error and one warning, got %+v", response)
+	}
+	issue := response.Errors[0]
+	if issue.Message != "CS0029: cannot convert" || issue.Assembly != "A" || issue.Line != 4 || issue.Column != 9 {
+		t.Fatalf("unexpected error issue: %+v", issue)
+	}
+	if response.Warnings[0].Code != "CS0168" {
+		t.Fatalf("unexpected warning issue: %+v", response.Warnings[0])
+	}
+}
+
+// Verifies that a compiler failure with no error diagnostic still fails the run.
+func TestBuildCompileCheckResponseFailsOnUnexplainedCompilerOutput(t *testing.T) {
+	response := buildCompileCheckResponse(compilecheck.Result{
+		DagDir: "Library/Bee/artifacts/1234.dag",
+		Units: []compilecheck.UnitResult{
+			{Assembly: "A", RawOutput: "csc exited with code 1 without reporting an error diagnostic:"},
+		},
+	}, "/projects/sample")
+
+	if response.Success || response.ErrorCount != 1 {
+		t.Fatalf("expected the unexplained failure to fail the run, got %+v", response)
+	}
+	if response.Errors[0].Assembly != "A" {
+		t.Fatalf("expected the failure to name its assembly, got %+v", response.Errors[0])
+	}
+}
+
+// Verifies that a run with nothing to compile says so instead of reporting an empty success.
+func TestBuildCompileCheckResponseReportsAnUnchangedProject(t *testing.T) {
+	response := buildCompileCheckResponse(compilecheck.Result{
+		DagDir: "Library/Bee/artifacts/1234.dag", Skipped: 12,
+	}, "/projects/sample")
+
+	if !response.Success {
+		t.Fatalf("expected an unchanged project to succeed, got %+v", response)
+	}
+	if response.Message != compileCheckNoChangeMessage {
+		t.Fatalf("expected the no-change message, got %q", response.Message)
+	}
+}

--- a/cli/dispatcher/internal/dispatcher/compile_check_test.go
+++ b/cli/dispatcher/internal/dispatcher/compile_check_test.go
@@ -176,3 +176,25 @@ func TestBuildCompileCheckResponseReportsAnUnchangedProject(t *testing.T) {
 		t.Fatalf("expected the no-change message, got %q", response.Message)
 	}
 }
+
+// Verifies that a run without errors still reports how many warnings it found, so a clean summary
+// line does not hide diagnostics the caller only sees in the full payload.
+func TestBuildCompileCheckResponseCountsWarningsOnASuccessfulRun(t *testing.T) {
+	response := buildCompileCheckResponse(compilecheck.Result{
+		DagDir: "Library/Bee/artifacts/1234.dag",
+		Units: []compilecheck.UnitResult{{
+			Assembly:  "A",
+			Succeeded: true,
+			Diagnostics: []compilecheck.Diagnostic{
+				{Severity: "warning", Code: "CS0168", Message: "unused variable", File: "Assets/A.cs"},
+			},
+		}},
+	}, "/projects/sample")
+
+	if !response.Success || response.WarningCount != 1 {
+		t.Fatalf("expected a clean run with one warning, got %+v", response)
+	}
+	if response.Message != "Compiled 1 assemblies with 0 errors and 1 warnings." {
+		t.Fatalf("the summary should report the warning count, got %q", response.Message)
+	}
+}

--- a/cli/dispatcher/internal/dispatcher/dispatcher_process.go
+++ b/cli/dispatcher/internal/dispatcher/dispatcher_process.go
@@ -67,6 +67,9 @@ func tryHandlePreConnectionRequestWithDeps(
 	if handled, code := tryHandleLaunchRequestWithDeps(ctx, remainingArgs, startPath, projectPath, stdout, stderr, deps.launch); handled {
 		return true, code
 	}
+	if handled, code := tryHandleCompileCheckRequest(ctx, remainingArgs, startPath, projectPath, stdout, stderr); handled {
+		return true, code
+	}
 	if handled, code := tryHandleSkillsRequest(remainingArgs, startPath, projectPath, stdout, stderr); handled {
 		return true, code
 	}

--- a/cli/dispatcher/internal/dispatcher/help_test.go
+++ b/cli/dispatcher/internal/dispatcher/help_test.go
@@ -24,6 +24,7 @@ func TestPrintDispatcherHelpListsNativeCommandsAndLiveToolGuidance(t *testing.T)
 		"Dispatcher. Finds the Unity project, then dispatches live Unity tool commands.",
 		"Native commands:",
 		"  launch",
+		"  compile-check",
 		"  focus-window",
 		"  list",
 		"  skills",
@@ -44,7 +45,8 @@ func TestPrintDispatcherHelpListsNativeCommandsAndLiveToolGuidance(t *testing.T)
 		}
 	}
 	for _, unexpected := range []string{
-		"  compile",
+		// Why the trailing space: "  compile-check" is a native command and shares the prefix.
+		"  compile ",
 		"  get-logs",
 		"  run-tests",
 		"uloop --list-commands",
@@ -66,6 +68,7 @@ func TestPrintProjectLocalHelpListsNativeCommandsAndLiveToolGuidance(t *testing.
 	for _, expected := range []string{
 		"Native commands:",
 		"  launch",
+		"  compile-check",
 		"  focus-window",
 		"  list",
 		"  sync",
@@ -83,7 +86,8 @@ func TestPrintProjectLocalHelpListsNativeCommandsAndLiveToolGuidance(t *testing.
 		}
 	}
 	for _, unexpected := range []string{
-		"  compile",
+		// Why the trailing space: "  compile-check" is a native command and shares the prefix.
+		"  compile ",
 		"  get-logs",
 		"  run-tests",
 		"uloop --list-commands",

--- a/cli/dispatcher/internal/dispatcher/native_command_options.go
+++ b/cli/dispatcher/internal/dispatcher/native_command_options.go
@@ -19,6 +19,12 @@ var nativeCommandOptions = map[string][]string{
 		"--quit",
 		"--restart",
 	},
+	clicore.CompileCheckCommandName: {
+		"--" + tooldocs.ProjectPathFlagName,
+		"--all",
+		"--editor-version",
+		"--max-depth",
+	},
 	clicore.InstallCommandName: {"--" + installDirFlagName},
 	clicore.UpdateCommandName:  {"--" + updateToVersionFlagName},
 	clicore.VersionCommandName: {"--json"},

--- a/cli/dispatcher/internal/dispatcher/run_dispatcher.go
+++ b/cli/dispatcher/internal/dispatcher/run_dispatcher.go
@@ -204,7 +204,8 @@ func shouldKeepDispatcherProcessCommand(args []string) bool {
 		return true
 	}
 	switch args[0] {
-	case clicore.InstallCommandName, clicore.UpdateCommandName, clicore.UninstallCommandName, clicore.LaunchCommandName, clicore.PackageCommandName:
+	case clicore.InstallCommandName, clicore.UpdateCommandName, clicore.UninstallCommandName,
+		clicore.LaunchCommandName, clicore.CompileCheckCommandName, clicore.PackageCommandName:
 		return true
 	default:
 		return false
@@ -242,6 +243,16 @@ func resolveDispatcherProjectRoot(startPath string, explicitProjectPath string, 
 			return "", err
 		}
 		return resolveLaunchProjectRoot(startPath, options)
+	}
+
+	// Why compile-check resolves like launch: it never opens an IPC connection, so requiring a
+	// running Editor to find the project root would fail the one case the command exists for.
+	if len(args) > 0 && args[0] == clicore.CompileCheckCommandName {
+		options, err := parseCompileCheckOptions(args[1:], explicitProjectPath)
+		if err != nil {
+			return "", err
+		}
+		return resolveCompileCheckProjectRoot(startPath, options)
 	}
 
 	connection, err := project.ResolveConnection(startPath, explicitProjectPath)

--- a/cli/dispatcher/shared-inputs-stamp.json
+++ b/cli/dispatcher/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "3381d7f8bb68cbf8af67e61f5d5665b982582226"
+  "sharedInputsHash": "ca2cee69308213adf17195e024359f3fbaf883e1"
 }

--- a/cli/dispatcher/shared-inputs-stamp.json
+++ b/cli/dispatcher/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "ca2cee69308213adf17195e024359f3fbaf883e1"
+  "sharedInputsHash": "d106bfe01f839500da2b066bbead48169f42c035"
 }

--- a/cli/project-runner/internal/projectrunner/list_names_test.go
+++ b/cli/project-runner/internal/projectrunner/list_names_test.go
@@ -44,7 +44,7 @@ func TestRunResolvedProjectCommandListNamesWritesNativeAndLiveToolNames(t *testi
 		t.Fatalf("list --names failed: code=%d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
 	}
 
-	const expected = "launch\nlist\nsync\nfocus-window\nawait-pause-point\npause-point-status\nset-code-optimization\nskills\npackage\ninstall\nupdate\nuninstall\nversion\nenable-watch\nclear-watch\nget-watch-values\n"
+	const expected = "launch\ncompile-check\nlist\nsync\nfocus-window\nawait-pause-point\npause-point-status\nset-code-optimization\nskills\npackage\ninstall\nupdate\nuninstall\nversion\nenable-watch\nclear-watch\nget-watch-values\n"
 	if stdout.String() != expected {
 		t.Fatalf("list --names output mismatch:\n got:\n%s\nwant:\n%s", stdout.String(), expected)
 	}
@@ -58,7 +58,7 @@ func TestRunResolvedProjectCommandListNamesWritesNativeAndLiveToolNames(t *testi
 // Verifies list accepts repeated names selectors but rejects value assignment and positional
 // arguments with the complete stable INVALID_ARGUMENT envelope.
 func TestRunListOptionBoundaries(t *testing.T) {
-	const namesOutput = "launch\nlist\nsync\nfocus-window\nawait-pause-point\npause-point-status\nset-code-optimization\nskills\npackage\ninstall\nupdate\nuninstall\nversion\n"
+	const namesOutput = "launch\ncompile-check\nlist\nsync\nfocus-window\nawait-pause-point\npause-point-status\nset-code-optimization\nskills\npackage\ninstall\nupdate\nuninstall\nversion\n"
 	const namesAssignmentError = "{\n" +
 		"  \"Success\": false,\n" +
 		"  \"Error\": {\n" +

--- a/cli/project-runner/shared-inputs-stamp.json
+++ b/cli/project-runner/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "b4ce66e2fe5e2f4d9a947d442534fc1b61f3e946"
+  "sharedInputsHash": "2eff7edd389150801e1cee55968ad8ea32820a4c"
 }

--- a/cli/project-runner/shared-inputs-stamp.json
+++ b/cli/project-runner/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "2eff7edd389150801e1cee55968ad8ea32820a4c"
+  "sharedInputsHash": "5a22472273179bf3a35ba2af13083bf0ee710168"
 }

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -46,6 +46,13 @@ Routed by `InternalBridgeCommandRouter`; names use `UnityCliLoopConstants.COMMAN
 constants. Anything an end user or third-party extension should call is a tool, not an
 internal bridge command.
 
+### Native command
+
+A command the Go CLI implements itself, without going through a Unity tool (`launch`,
+`compile-check`, `skills` and the rest). `clicore.NativeCommands` is the single list of them and
+records for each whether the dispatcher answers it (dispatcher-owned) or the project runner does
+(runner-owned).
+
 ### Server
 
 The local IPC endpoint hosted inside the Unity Editor by the package


### PR DESCRIPTION
## Summary

- `uloop compile-check` now exists as a real command: it compiles the project's C# offline with the Unity-bundled Roslyn compiler and prints the diagnostics as JSON, without launching or contacting the Editor.
- A precondition only a Unity build can clear is reported as its own error code instead of an internal error, so an agent can tell "build in Unity once" apart from a real failure.

## User Impact

Before, there was no way to ask "does this compile?" without a running Editor and a domain reload. Now `uloop compile-check` answers that in seconds from the response files Unity wrote during its last build, and its output never reaches the Editor: the assemblies land in `Library/uloop/compile-check/` and are thrown away.

By default it compiles the assemblies whose sources changed since the last Unity build plus every assembly that references one of them; `--all` compiles the whole project.

When the project changed in a way the last build's response files no longer describe (a new `.asmdef`, an added reference, an `.asmdef` that stopped building for the Editor), the run stops with `COMPILE_CHECK_UNITY_BUILD_REQUIRED`, is not marked retryable, and says to run `uloop compile` first — instead of silently reporting diagnostics for a configuration the project no longer has.

## Changes

- Register `compile-check` as a dispatcher-owned native command and answer it inside the dispatcher process.
- Plan the compile: pick the response-file set, select the changed assemblies plus their dependents, and run them in dependency order.
- Compare an assembly definition against its response file before refusing a run (see the deviation note below).
- Add `COMPILE_CHECK_UNITY_BUILD_REQUIRED` to the shared error codes, with a `compilecheck` error type that renders itself through the shared classifier.
- Add the `uloop-compile-check` skill and its generated copies, and define "Native command" in the glossary.

## Approved plan deviation: assembly-definition staleness

The plan refused a run whenever an `.asmdef` was newer than the last build's output. That cannot ship: `git switch` rewrites every `.asmdef` timestamp while Unity's content-hash incremental build never rebuilds them, so the refusal could not be cleared by running `uloop compile` (5 assembly definitions were stuck this way in this checkout). The approved fix keeps the timestamp only as a trigger; on trigger the assembly definition is parsed and compared against the response file, and the run is refused only on a real disagreement — references, `allowUnsafeCode`, `precompiledReferences` under `overrideReferences`, and whether it still builds for the Editor.

Two details differ from the approved scope, both because measuring the real project contradicted the stricter rule (102 response-file-backed assembly definitions in the active build):

- **The reference comparison is one-directional, not set equality.** Unity injects references no `.asmdef` declares (the UI and test-runner assemblies), so set equality would have refused 98 of 102 assembly definitions. Assembly definitions whose declared references are not a subset of the response file: 0. Only an *added* reference is detectable; a *removed* one is documented as a limitation in the skill.
- **An unresolvable GUID is skipped, not treated as a disagreement.** 9 unresolvable GUIDs exist in the healthy state — references to assemblies that own no indexable `.asmdef` — so treating them as disagreement would refuse healthy projects.

Also measured: the response file spells unsafe as `/unsafe+`, so all four spellings are accepted; `overrideReferences`/`precompiledReferences` and the platform rule both produced 0 mismatches on the healthy project.

`defineConstraints` and `versionDefines` are deliberately not compared, and both they and the removed-reference case are documented as limitations in the skill.

## Verification

`scripts/check-go-cli.sh` exits 0 (format, vet, lint 0 issues, tests across all four Go modules, binary rebuild).

Skill and catalog gates: `check-skill-size` reports no `SKILL.md` over the byte limit; `uloop skills install --claude --agents` installs 1 / updates 0; `sync-tool-docs --check` reports the catalog matches the skill parameter tables.

Mutation-checked the two new guards: short-circuiting the added-reference check failed exactly the two added-reference tests, and removing the Editor-platform guard in the added-assembly case failed exactly the platform-excluded test.

End-to-end on a real project (Unity 2022.3.62f3), with `Library/Bee` and `Library/ScriptAssemblies` timestamps identical before and after every run:

- Default scope: `Success: true`, `ErrorCount: 0`, `WarningCount: 7`, `SkippedAssemblies: 54`, `Message: "Compiled 50 assemblies with 0 errors."`, exit 0.
- `--all`: `Success: true`, `ErrorCount: 0`, `SkippedAssemblies: 0`, `Message: "Compiled 104 assemblies with 0 errors."`, 53.9 s wall clock.
- With a deliberate type error injected into one test source: `Success: false`, `ErrorCount: 1`, and the diagnostic `CS0029: Cannot implicitly convert type 'string' to 'int'` with file, line 10, column 22 and the owning assembly; the process exited 1. Reverted afterwards, working tree clean.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2745?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



## Follow-up in this PR: packages developed from a local path

Verifying against a second Unity project (Unity 6000.3.15f1) showed a healthy project being refused: it consumes the Unity package through a `file:` dependency in `Packages/manifest.json`, so the package directory sits outside the project root and none of its assembly definitions were indexed. Every assembly the package owned then read as one Unity had built and the project had since deleted, and the run stopped with `COMPILE_CHECK_UNITY_BUILD_REQUIRED`.

The manifest's local paths are now index roots too, resolved relative to the `Packages` folder. A missing or unparsable manifest contributes no roots rather than failing, so a manifest problem cannot become a removed-assembly refusal. Sources of such a package are recorded the way Bee records them — absolute outside the project root, project-relative with forward slashes inside — so an unchanged local package no longer reads as every file removed and added at once.

Two review items ride along: Unity's JSON files are read through one reader that drops a leading UTF-8 byte order mark (an editor on Windows writes one by default, and `encoding/json` rejects it, which failed the whole command on a single such assembly definition), and a run without errors now reports its warning count like the failing branch already did.

Verification of the follow-up: `scripts/check-go-cli.sh` exits 0 again. Mutation checks — removing the manifest roots failed exactly the three local-package tests; making the recorded source path always relative failed exactly the unchanged-sources test; skipping the byte-order-mark strip failed exactly the three encoding tests.

On that second project, `compile-check --all` now reports `Success: true`, `ErrorCount: 0`, `SkippedAssemblies: 0`, `ResponseFileSet: 200b0aEDbg.dag`, `Compiled 105 assemblies with 0 errors`, exit 0. With a deliberate type error injected into one runtime source, the default scope reports `Success: false`, `ErrorCount: 1`, `SkippedAssemblies: 103`, and the diagnostic `CS0029: Cannot implicitly convert type 'string' to 'int'` with its file, line, column and owning assembly, exit 1. Reverted afterwards.
