### PR TITLE
fix(cli): compile-check skips the files Unity ignores instead of failing on AppleDouble metadata

### DIFF
--- a/cli/dispatcher/internal/compilecheck/source_set.go
+++ b/cli/dispatcher/internal/compilecheck/source_set.go
@@ -21,8 +21,8 @@ const (
 	assemblyDefinitionGUIDKey    = "guid:"
 	assemblyReferenceExtension   = ".asmref"
 	cSharpSourceExtension        = ".cs"
-	unityIgnoredDirectorySuffix  = "~"
-	unityHiddenDirectoryPrefix   = "."
+	unityIgnoredNameSuffix       = "~"
+	unityHiddenNamePrefix        = "."
 	assemblyDefinitionIndexError = "failed to index assembly definitions under %s: %w"
 )
 
@@ -65,10 +65,13 @@ func indexAssemblyDefinitionsUnder(root string, index map[string]AssemblyDefinit
 			return err
 		}
 		if entry.IsDir() {
-			if path != root && isUnityIgnoredDirectory(entry.Name()) {
+			if path != root && isUnityIgnoredName(entry.Name()) {
 				return filepath.SkipDir
 			}
 
+			return nil
+		}
+		if isUnityIgnoredName(entry.Name()) {
 			return nil
 		}
 		if filepath.Ext(path) != assemblyDefinitionExtension {
@@ -187,10 +190,13 @@ func globAssemblySources(projectRoot string, assemblyDirectory string) ([]string
 			if path == assemblyDirectory {
 				return nil
 			}
-			if isUnityIgnoredDirectory(entry.Name()) || directoryOwnsOwnAssembly(path) {
+			if isUnityIgnoredName(entry.Name()) || directoryOwnsOwnAssembly(path) {
 				return filepath.SkipDir
 			}
 
+			return nil
+		}
+		if isUnityIgnoredName(entry.Name()) {
 			return nil
 		}
 		if filepath.Ext(path) != cSharpSourceExtension {
@@ -214,7 +220,7 @@ func directoryOwnsOwnAssembly(path string) bool {
 		return false
 	}
 	for _, entry := range entries {
-		if entry.IsDir() {
+		if entry.IsDir() || isUnityIgnoredName(entry.Name()) {
 			continue
 		}
 		extension := filepath.Ext(entry.Name())
@@ -226,10 +232,13 @@ func directoryOwnsOwnAssembly(path string) bool {
 	return false
 }
 
-// isUnityIgnoredDirectory reports whether Unity excludes a directory from compilation by its name.
-func isUnityIgnoredDirectory(name string) bool {
-	return strings.HasSuffix(name, unityIgnoredDirectorySuffix) ||
-		strings.HasPrefix(name, unityHiddenDirectoryPrefix)
+// isUnityIgnoredName reports whether Unity excludes a file or directory from compilation by its
+// name. Why files matter as much as directories: macOS writes AppleDouble siblings named "._X" next
+// to files on non-native volumes, so a project can hold a "._X.asmdef" whose content is binary
+// resource-fork metadata and a "._X.cs" that is not C# at all.
+func isUnityIgnoredName(name string) bool {
+	return strings.HasSuffix(name, unityIgnoredNameSuffix) ||
+		strings.HasPrefix(name, unityHiddenNamePrefix)
 }
 
 // isUnderPackageCache reports whether a directory belongs to the read-only package cache.

--- a/cli/dispatcher/internal/compilecheck/source_set_test.go
+++ b/cli/dispatcher/internal/compilecheck/source_set_test.go
@@ -138,3 +138,64 @@ func TestIndexAssemblyDefinitionsCoversEveryProjectRoot(t *testing.T) {
 		t.Errorf("Foo directory = %s", foo.Directory)
 	}
 }
+
+// Verifies an AppleDouble ".asmdef" holding binary bytes is skipped instead of failing the index.
+func TestIndexAssemblyDefinitionsSkipsFilesUnityIgnores(t *testing.T) {
+	projectRoot := newAssemblyProject(t)
+	writeFileAt(t,
+		filepath.Join(projectRoot, "Assets", "Foo", "._Foo.asmdef"),
+		"\x00\x05\x16\x07\x00\x02\x00\x00Mac OS X")
+
+	index, err := IndexAssemblyDefinitions(projectRoot)
+	if err != nil {
+		t.Fatalf("expected the index to build, got error: %v", err)
+	}
+
+	if _, found := index["Foo"]; !found {
+		t.Error("the real assembly definition must still reach the index")
+	}
+}
+
+// Verifies an AppleDouble ".cs" is not compiled while the file it shadows still is.
+func TestRebuildSourcesSkipsSourceFilesUnityIgnores(t *testing.T) {
+	projectRoot := newAssemblyProject(t)
+	writeFileAt(t, filepath.Join(projectRoot, "Assets", "Foo", "._A.cs"), "\x00\x05\x16\x07")
+	asmdef := AssemblyDefinition{
+		Name:      "Foo",
+		Path:      filepath.Join(projectRoot, "Assets", "Foo", "Foo.asmdef"),
+		Directory: filepath.Join(projectRoot, "Assets", "Foo"),
+	}
+
+	sources, err := RebuildSources(projectRoot, ResponseFile{}, &asmdef)
+	if err != nil {
+		t.Fatalf("expected the rebuild to succeed, got error: %v", err)
+	}
+
+	assertStrings(t, "sources", sources, []string{
+		filepath.Join("Assets", "Foo", "A.cs"),
+		filepath.Join("Assets", "Foo", "Sub", "B.cs"),
+	})
+}
+
+// Verifies a directory whose only assembly definition is an AppleDouble is not an assembly boundary.
+func TestRebuildSourcesDoesNotTreatIgnoredAssemblyDefinitionsAsABoundary(t *testing.T) {
+	projectRoot := newAssemblyProject(t)
+	writeFileAt(t,
+		filepath.Join(projectRoot, "Assets", "Foo", "Sub", "._Other.asmdef"),
+		"\x00\x05\x16\x07")
+	asmdef := AssemblyDefinition{
+		Name:      "Foo",
+		Path:      filepath.Join(projectRoot, "Assets", "Foo", "Foo.asmdef"),
+		Directory: filepath.Join(projectRoot, "Assets", "Foo"),
+	}
+
+	sources, err := RebuildSources(projectRoot, ResponseFile{}, &asmdef)
+	if err != nil {
+		t.Fatalf("expected the rebuild to succeed, got error: %v", err)
+	}
+
+	assertStrings(t, "sources", sources, []string{
+		filepath.Join("Assets", "Foo", "A.cs"),
+		filepath.Join("Assets", "Foo", "Sub", "B.cs"),
+	})
+}

--- a/docs/compile-check.md
+++ b/docs/compile-check.md
@@ -33,6 +33,10 @@ references, scripting defines and analyzers. `compile-check` replays those respo
    project no longer has.
 5. **Compile in dependency order** and parse the compiler's diagnostics into JSON.
 
+Files and directories Unity ignores — any name starting with a dot or ending with a tilde, which
+covers the `._*` AppleDouble siblings macOS writes on non-native volumes — are skipped everywhere
+the project tree is walked, so their binary content never reaches the index or the compiler.
+
 Assembly definitions are indexed from `Assets`, `Packages` and `Library/PackageCache`, plus every
 directory a `Packages/manifest.json` dependency points at with a `file:` path — a package a project
 develops locally lives outside the project root and would otherwise look like one whose assembly


### PR DESCRIPTION
## Problem

`uloop compile-check` aborted immediately on a large real Unity 6000.3 project on macOS:

```
INTERNAL_ERROR: failed to index assembly definitions under <PROJECT_ROOT>/Library/PackageCache:
failed to read <PROJECT_ROOT>/Library/PackageCache/<package>/Editor/._<Name>.asmdef: invalid character '\x00' looking for beginning of value
```

macOS writes AppleDouble siblings (`._X`) next to files on non-native volumes; their content is
binary resource-fork metadata. Unity ignores every file or directory whose name starts with a dot
or ends with a tilde, but `source_set.go` applied that rule to directory names only, at three walk
sites:

1. `indexAssemblyDefinitionsUnder` treated `._X.asmdef` as an assembly definition and failed the
   whole command on the first NUL byte.
2. `globAssemblySources` would have handed `._X.cs` to `csc`, so once (1) was fixed the run would
   have reported garbage diagnostics.
3. `directoryOwnsOwnAssembly` treated a directory holding only `._X.asmdef` / `._X.asmref` as an
   assembly boundary, cutting real sources out of the owning assembly.

## Change

`isUnityIgnoredDirectory` becomes `isUnityIgnoredName` and is applied to file names as well at all
three sites; directories keep returning `SkipDir`. The rule stays Unity's own — any leading dot or
trailing tilde — with no `._` special case. One line added to `docs/compile-check.md`.

## Tests

Three tests added, written first and confirmed red before the fix:

- an `._Foo.asmdef` holding binary bytes under an indexed root is skipped and indexing succeeds
- `._A.cs` is not listed by the re-glob while `A.cs` still is
- a subdirectory whose only assembly definition is `._Other.asmdef` is not an assembly boundary

## Verification

- `scripts/check-go-cli.sh` — format, vet, lint (0 issues), all module tests pass, binaries rebuilt.
- End to end: created `._Probe.asmdef` and `._Probe.cs` under `Assets` in this checkout and ran the
  rebuilt dev binary `compile-check`; it returned `Success: true` with 0 errors instead of failing,
  and the probe files were removed afterwards.

Go-only change; no Unity tests needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2747?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

