### PR TITLE
chore: Hold the hot-reload patch target's assembly identity in one value

### DIFF
--- a/Assets/Tests/Editor/HotReload/HotReloadEntryResolutionTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadEntryResolutionTests.cs
@@ -1,7 +1,10 @@
 using System.Collections.Generic;
+using System.IO;
 using System.Reflection;
 
 using NUnit.Framework;
+
+using UnityEngine;
 
 using io.github.hatayama.UnityCliLoop.FirstPartyTools;
 
@@ -21,6 +24,19 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         private const string FilePath = "Assets/Tests/Editor/HotReload/HotReloadCoreFixtures.cs";
 
         private static Assembly ShimAssembly => typeof(HotReloadHandwrittenShims).Assembly;
+
+        // The test assembly stands in for the patch target, so its ScriptAssemblies image is the
+        // home the preflight resolves existing methods against.
+        private static HotReloadTypeHome TestAssemblyHome
+        {
+            get
+            {
+                string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
+                string dllPath =
+                    Path.Combine(projectRoot, "Library/ScriptAssemblies", TestAssemblyName + ".dll");
+                return HotReloadTypeHome.ScriptAssemblies(TestAssemblyName, dllPath);
+            }
+        }
 
         /// <summary>
         /// What: every entry of a file resolving leaves the result all-resolved, with one resolved
@@ -42,7 +58,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             };
 
             HotReloadEntryResolution.Result result = HotReloadEntryResolution.ResolveEntries(
-                TestAssemblyName,
+                TestAssemblyHome,
                 FilePath,
                 ShimAssembly,
                 entries,
@@ -74,7 +90,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             };
 
             HotReloadEntryResolution.Result result = HotReloadEntryResolution.ResolveEntries(
-                TestAssemblyName,
+                TestAssemblyHome,
                 FilePath,
                 ShimAssembly,
                 entries,
@@ -119,7 +135,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             };
 
             HotReloadEntryResolution.Result result = HotReloadEntryResolution.ResolveEntries(
-                TestAssemblyName,
+                TestAssemblyHome,
                 FilePath,
                 ShimAssembly,
                 entries,

--- a/Assets/Tests/Editor/HotReload/HotReloadMethodMatcherTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadMethodMatcherTests.cs
@@ -1,6 +1,9 @@
+using System.IO;
 using System.Reflection;
 
 using NUnit.Framework;
+
+using UnityEngine;
 
 using io.github.hatayama.UnityCliLoop.FirstPartyTools;
 
@@ -15,6 +18,20 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         private const string FixtureTypeMetadataName =
             "io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload.HotReloadCoreFixture";
 
+        // The test assembly is itself a project assembly, so its compiled image is the one the
+        // matcher reads: a ScriptAssemblies home naming it is what production passes in.
+        private static HotReloadTypeHome TestAssemblyHome =>
+            HotReloadTypeHome.ScriptAssemblies(TestAssemblyName, TestAssemblyDllPath);
+
+        private static string TestAssemblyDllPath
+        {
+            get
+            {
+                string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
+                return Path.Combine(projectRoot, "Library/ScriptAssemblies", TestAssemblyName + ".dll");
+            }
+        }
+
         /// <summary>
         /// What: a known instance method resolves to the live MethodBase with matching MetadataToken identity.
         /// </summary>
@@ -22,7 +39,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         public void Resolve_KnownInstanceMethod_ReturnsLiveMethodBase()
         {
             HotReloadMethodMatchResult result = HotReloadMethodMatcher.Resolve(
-                TestAssemblyName,
+                TestAssemblyHome,
                 FixtureTypeMetadataName,
                 nameof(HotReloadCoreFixture.Add),
                 new[] { "System.Int32", "System.Int32" },
@@ -46,7 +63,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         public void Resolve_Overload_SelectsMatchingParameterTypes()
         {
             HotReloadMethodMatchResult result = HotReloadMethodMatcher.Resolve(
-                TestAssemblyName,
+                TestAssemblyHome,
                 FixtureTypeMetadataName,
                 nameof(HotReloadCoreFixture.Add),
                 new[] { "System.Int32", "System.Int32", "System.Int32" },
@@ -68,7 +85,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         public void Resolve_ParameterTypeMismatch_ReturnsMethodNotFound()
         {
             HotReloadMethodMatchResult result = HotReloadMethodMatcher.Resolve(
-                TestAssemblyName,
+                TestAssemblyHome,
                 FixtureTypeMetadataName,
                 nameof(HotReloadCoreFixture.Add),
                 new[] { "System.String", "System.Int32" },
@@ -85,7 +102,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         public void Resolve_StaticMethod_ReturnsLiveMethodBase()
         {
             HotReloadMethodMatchResult result = HotReloadMethodMatcher.Resolve(
-                TestAssemblyName,
+                TestAssemblyHome,
                 FixtureTypeMetadataName,
                 nameof(HotReloadCoreFixture.StaticPing),
                 new string[0],
@@ -109,13 +126,13 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             string[] parameterTypeFullNames = { "System.Int32" };
 
             HotReloadMethodMatchResult nonGeneric = HotReloadMethodMatcher.Resolve(
-                TestAssemblyName,
+                TestAssemblyHome,
                 typeMetadataName,
                 nameof(HotReloadSignatureChangeGenericCallerFixture.Caller),
                 parameterTypeFullNames,
                 0);
             HotReloadMethodMatchResult generic = HotReloadMethodMatcher.Resolve(
-                TestAssemblyName,
+                TestAssemblyHome,
                 typeMetadataName,
                 nameof(HotReloadSignatureChangeGenericCallerFixture.Caller),
                 parameterTypeFullNames,
@@ -144,7 +161,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             int metadataToken = knownMethod.MetadataToken;
 
             HotReloadMethodMatchResult result = HotReloadMethodMatcher.ResolveLoadedMethod(
-                TestAssemblyName,
+                TestAssemblyHome,
                 "00000000-0000-0000-0000-000000000000",
                 metadataToken);
 

--- a/Assets/Tests/Editor/HotReload/HotReloadTypeHomeTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadTypeHomeTests.cs
@@ -1,0 +1,119 @@
+using System.IO;
+using System.Reflection;
+
+using NUnit.Framework;
+
+using UnityEngine;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
+{
+    /// <summary>
+    /// EditMode coverage for <see cref="HotReloadTypeHome"/>: how each home kind finds its live
+    /// assembly and how it reports a compiled image that no longer matches it.
+    /// </summary>
+    public class HotReloadTypeHomeTests
+    {
+        private const string TestAssemblyName = "UnityCLILoop.Tests.Editor.HotReload";
+
+        // A Guid no compiled module can carry, so it always reads as a stale image.
+        private const string MismatchedMvid = "00000000-0000-0000-0000-000000000000";
+
+        private static Assembly TestAssembly => typeof(HotReloadTypeHomeTests).Assembly;
+
+        private static string LoadedTestAssemblyMvid =>
+            TestAssembly.ManifestModule.ModuleVersionId.ToString();
+
+        private static string TestAssemblyDllPath
+        {
+            get
+            {
+                string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
+                return Path.Combine(projectRoot, "Library/ScriptAssemblies", TestAssemblyName + ".dll");
+            }
+        }
+
+        /// <summary>
+        /// What: a ScriptAssemblies home whose compiled Mvid matches the live assembly resolves to that assembly.
+        /// </summary>
+        [Test]
+        public void ResolveLoadedAssembly_ScriptAssembliesHomeWithMatchingMvid_ReturnsLoadedAssembly()
+        {
+            HotReloadTypeHome home = HotReloadTypeHome.ScriptAssemblies(TestAssemblyName, TestAssemblyDllPath);
+
+            HotReloadLoadedAssemblyResolution resolution = home.ResolveLoadedAssembly(LoadedTestAssemblyMvid);
+
+            Assert.That(resolution.State, Is.EqualTo(HotReloadLoadedAssemblyState.Loaded));
+            Assert.That(resolution.Assembly, Is.EqualTo(TestAssembly));
+        }
+
+        /// <summary>
+        /// What: a ScriptAssemblies home whose compiled Mvid differs from the live assembly reports Stale.
+        /// </summary>
+        [Test]
+        public void ResolveLoadedAssembly_ScriptAssembliesHomeWithMismatchedMvid_ReturnsStale()
+        {
+            HotReloadTypeHome home = HotReloadTypeHome.ScriptAssemblies(TestAssemblyName, TestAssemblyDllPath);
+
+            HotReloadLoadedAssemblyResolution resolution = home.ResolveLoadedAssembly(MismatchedMvid);
+
+            Assert.That(resolution.State, Is.EqualTo(HotReloadLoadedAssemblyState.Stale));
+            Assert.That(resolution.Assembly, Is.Null);
+        }
+
+        /// <summary>
+        /// What: a ScriptAssemblies home naming an assembly no domain holds reports NotLoaded rather than Stale.
+        /// </summary>
+        [Test]
+        public void ResolveLoadedAssembly_ScriptAssembliesHomeForUnloadedAssembly_ReturnsNotLoaded()
+        {
+            const string unloadedAssemblyName = "UnityCLILoop.Tests.Editor.HotReload.NotLoadedFixture";
+            string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
+            string dllPath = Path.Combine(
+                projectRoot,
+                "Library/ScriptAssemblies",
+                unloadedAssemblyName + ".dll");
+            HotReloadTypeHome home = HotReloadTypeHome.ScriptAssemblies(unloadedAssemblyName, dllPath);
+
+            HotReloadLoadedAssemblyResolution resolution = home.ResolveLoadedAssembly(LoadedTestAssemblyMvid);
+
+            Assert.That(resolution.State, Is.EqualTo(HotReloadLoadedAssemblyState.NotLoaded));
+            Assert.That(resolution.Assembly, Is.Null);
+        }
+
+        /// <summary>
+        /// What: a retained-artifact home resolves through the assembly it carries instead of scanning by name.
+        /// </summary>
+        [Test]
+        public void ResolveLoadedAssembly_RetainedArtifactHomeWithMatchingMvid_ReturnsCarriedAssembly()
+        {
+            HotReloadTypeHome home = HotReloadTypeHome.RetainedArtifact(
+                TestAssemblyName,
+                TestAssemblyDllPath,
+                TestAssembly);
+
+            HotReloadLoadedAssemblyResolution resolution = home.ResolveLoadedAssembly(LoadedTestAssemblyMvid);
+
+            Assert.That(resolution.State, Is.EqualTo(HotReloadLoadedAssemblyState.Loaded));
+            Assert.That(resolution.Assembly, Is.EqualTo(TestAssembly));
+        }
+
+        /// <summary>
+        /// What: a retained-artifact home whose carried assembly no longer matches the compiled Mvid reports Stale.
+        /// </summary>
+        [Test]
+        public void ResolveLoadedAssembly_RetainedArtifactHomeWithMismatchedMvid_ReturnsStale()
+        {
+            HotReloadTypeHome home = HotReloadTypeHome.RetainedArtifact(
+                TestAssemblyName,
+                TestAssemblyDllPath,
+                TestAssembly);
+
+            HotReloadLoadedAssemblyResolution resolution = home.ResolveLoadedAssembly(MismatchedMvid);
+
+            Assert.That(resolution.State, Is.EqualTo(HotReloadLoadedAssemblyState.Stale));
+            Assert.That(resolution.Assembly, Is.Null);
+        }
+    }
+}

--- a/Assets/Tests/Editor/HotReload/HotReloadTypeHomeTests.cs.meta
+++ b/Assets/Tests/Editor/HotReload/HotReloadTypeHomeTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5d14c22277cc647728dfa37385e7aca1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadEntryApplier.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadEntryApplier.cs
@@ -95,12 +95,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         // aborting the peel, so the remaining unchanged methods still get reverted.
         // Returns how many Revert calls actually removed a live patch.
         internal int RevertUnchangedPatches(
-            string assemblyName,
+            HotReloadTypeHome home,
             TransformWorkerUnchangedMethodDto[] unchangedMethods,
             List<HotReloadMethodOutcome> outcomes,
             string assemblyResolvePath)
         {
-            Debug.Assert(!string.IsNullOrEmpty(assemblyName), "assemblyName must not be null or empty.");
+            Debug.Assert(home != null, "home must not be null.");
             Debug.Assert(unchangedMethods != null, "unchangedMethods must not be null.");
             Debug.Assert(outcomes != null, "outcomes must not be null.");
 
@@ -120,7 +120,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 // and parameters. Arity 0 would resolve the generic unchanged row to the
                 // non-generic sibling and peel its live patch.
                 HotReloadMethodMatchResult matchResult = HotReloadMethodMatcher.Resolve(
-                    assemblyName,
+                    home,
                     unchanged.typeMetadataName,
                     unchanged.methodName,
                     unchanged.parameterTypeFullNames,
@@ -172,7 +172,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 }
 
                 file.RevertedUnchangedCount = RevertUnchangedPatches(
-                    file.AssemblyName,
+                    HotReloadTypeHome.ScriptAssemblies(file.AssemblyName, file.TargetDllPath),
                     unchangedMethods,
                     file.Sinks.Outcomes,
                     file.AssemblyResolvePath);

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadEntryResolution.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadEntryResolution.cs
@@ -17,13 +17,13 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         // Why bindFailures is passed in: one shim assembly serves every file of a group, so its
         // accessor binders run once for the group instead of once per file.
         internal static Result ResolveEntries(
-            string assemblyName,
+            HotReloadTypeHome home,
             string filePath,
             Assembly shimAssembly,
             TransformWorkerEntryDto[] entriesToPatch,
             Dictionary<string, string> bindFailures)
         {
-            Debug.Assert(!string.IsNullOrEmpty(assemblyName), "assemblyName must not be null or empty.");
+            Debug.Assert(home != null, "home must not be null.");
             Debug.Assert(!string.IsNullOrEmpty(filePath), "filePath must not be empty.");
             Debug.Assert(shimAssembly != null, "shimAssembly must not be null.");
             Debug.Assert(entriesToPatch != null, "entriesToPatch must not be null.");
@@ -34,7 +34,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             {
                 ResolvedEntryOutcome entryOutcome = TryResolveEntry(
                     entriesToPatch[index],
-                    assemblyName,
+                    home,
                     shimAssembly,
                     bindFailures,
                     filePath);
@@ -104,7 +104,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
         private static ResolvedEntryOutcome TryResolveEntry(
             TransformWorkerEntryDto entry,
-            string assemblyName,
+            HotReloadTypeHome home,
             Assembly shimAssembly,
             IReadOnlyDictionary<string, string> bindFailures,
             string filePath)
@@ -118,7 +118,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return TryResolveExistingMethod(
                 entry,
                 methodLabel,
-                assemblyName,
+                home,
                 shimAssembly,
                 bindFailures,
                 filePath);
@@ -158,7 +158,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         private static ResolvedEntryOutcome TryResolveExistingMethod(
             TransformWorkerEntryDto entry,
             string methodLabel,
-            string assemblyName,
+            HotReloadTypeHome home,
             Assembly shimAssembly,
             IReadOnlyDictionary<string, string> bindFailures,
             string filePath)
@@ -175,7 +175,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             string[] parameterTypeFullNames = entry.parameterTypeFullNames ?? Array.Empty<string>();
             HotReloadMethodMatchResult matchResult = HotReloadMethodMatcher.Resolve(
-                assemblyName,
+                home,
                 entry.typeMetadataName,
                 entry.methodName,
                 parameterTypeFullNames,

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupEntryPreparation.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupEntryPreparation.cs
@@ -39,14 +39,13 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 new List<HotReloadPreparedGroupFile>(context.Files.Count);
             foreach (HotReloadGroupFile file in context.Files)
             {
-                prepared.Add(PrepareFile(context, compileResult, file, entriesByFile, bindFailures));
+                prepared.Add(PrepareFile(compileResult, file, entriesByFile, bindFailures));
             }
 
             return prepared;
         }
 
         private static HotReloadPreparedGroupFile PrepareFile(
-            HotReloadApplyContext context,
             HotReloadShimCompileResult compileResult,
             HotReloadGroupFile file,
             Dictionary<string, List<TransformWorkerEntryDto>> entriesByFile,
@@ -65,7 +64,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             TransformWorkerEntryDto[] entries = fileEntries.ToArray();
             HotReloadEntryResolution.Result resolution = HotReloadEntryResolution.ResolveEntries(
-                context.AssemblyName,
+                HotReloadTypeHome.ScriptAssemblies(file.AssemblyName, file.TargetDllPath),
                 file.AssemblyResolvePath,
                 compileResult.Assembly,
                 entries,

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadNewSourceMembershipValidator.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadNewSourceMembershipValidator.cs
@@ -169,7 +169,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     HotReloadSourceSnapshotter.ReadAssemblyMvid(targetDllPath),
                     evidence.TargetDllMvid,
                     StringComparison.Ordinal)
-                || HotReloadPatchTargetSupport.CheckMvidGuard(evidence.AssemblyName, targetDllPath) != null)
+                || HotReloadPatchTargetSupport.CheckMvidGuard(
+                    HotReloadTypeHome.ScriptAssemblies(evidence.AssemblyName, targetDllPath)) != null)
             {
                 return "The compiled assembly changed while hot reload was preparing. Compile the project and retry hot reload.";
             }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadPatchTargetSupport.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadPatchTargetSupport.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Reflection;
 
 using Mono.Cecil;
 
@@ -9,7 +8,6 @@ using UnityEditor.Compilation;
 
 using UnityEngine;
 
-using Assembly = System.Reflection.Assembly;
 using UnityCompilationAssembly = UnityEditor.Compilation.Assembly;
 
 namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
@@ -115,7 +113,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     new HotReloadFileProcessResult(outcomes, warnings, 0));
             }
 
-            string mvidGuardError = CheckMvidGuard(assemblyName, targetDllPath);
+            string mvidGuardError = CheckMvidGuard(
+                HotReloadTypeHome.ScriptAssemblies(assemblyName, targetDllPath));
             if (mvidGuardError != null)
             {
                 outcomes.Add(HotReloadMethodOutcome.Failed("(file)", mvidGuardError, assemblyResolvePath));
@@ -211,29 +210,27 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return paths;
         }
 
-        internal static string CheckMvidGuard(string assemblyName, string targetDllPath)
+        internal static string CheckMvidGuard(HotReloadTypeHome home)
         {
+            Debug.Assert(home != null, "home must not be null.");
+
             ReaderParameters readerParameters = new ReaderParameters { InMemory = true };
             using AssemblyDefinition assemblyDefinition =
-                AssemblyDefinition.ReadAssembly(targetDllPath, readerParameters);
+                AssemblyDefinition.ReadAssembly(home.DllPath, readerParameters);
             string compiledMvid = assemblyDefinition.MainModule.Mvid.ToString();
 
-            foreach (Assembly loaded in AppDomain.CurrentDomain.GetAssemblies())
+            HotReloadLoadedAssemblyState state = home.ResolveLoadedAssembly(compiledMvid).State;
+            if (state == HotReloadLoadedAssemblyState.Stale)
             {
-                if (loaded.GetName().Name != assemblyName)
-                {
-                    continue;
-                }
-
-                if (loaded.ManifestModule.ModuleVersionId.ToString() != compiledMvid)
-                {
-                    return HotReloadConstants.StaleAssemblyHint;
-                }
-
-                return null;
+                return HotReloadConstants.StaleAssemblyHint;
             }
 
-            return HotReloadConstants.AssemblyNotLoadedHint;
+            if (state == HotReloadLoadedAssemblyState.NotLoaded)
+            {
+                return HotReloadConstants.AssemblyNotLoadedHint;
+            }
+
+            return null;
         }
 
         internal static string ToProjectRelativeScriptPath(

--- a/Packages/src/Editor/FirstPartyTools/HotReload/Patching/HotReloadMethodMatcher.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/Patching/HotReloadMethodMatcher.cs
@@ -1,4 +1,3 @@
-using System;
 using System.IO;
 using System.Reflection;
 
@@ -17,28 +16,24 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     {
         /// <summary>
         /// Resolves <paramref name="methodName"/> on <paramref name="typeMetadataName"/> inside
-        /// <paramref name="assemblyName"/> whose parameters and generic arity match
+        /// the assembly <paramref name="home"/> names, whose parameters and generic arity match
         /// <paramref name="parameterTypeFullNames"/> and <paramref name="genericArity"/>
         /// exactly (Cecil FullName, no <c>this</c>).
         /// </summary>
         public static HotReloadMethodMatchResult Resolve(
-            string assemblyName,
+            HotReloadTypeHome home,
             string typeMetadataName,
             string methodName,
             string[] parameterTypeFullNames,
             int genericArity)
         {
-            Debug.Assert(!string.IsNullOrEmpty(assemblyName), "assemblyName must not be null or empty.");
+            Debug.Assert(home != null, "home must not be null.");
             Debug.Assert(!string.IsNullOrEmpty(typeMetadataName), "typeMetadataName must not be null or empty.");
             Debug.Assert(!string.IsNullOrEmpty(methodName), "methodName must not be null or empty.");
             Debug.Assert(parameterTypeFullNames != null, "parameterTypeFullNames must not be null.");
             Debug.Assert(genericArity >= 0, "genericArity must not be negative.");
 
-            string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
-            string dllPath = Path.Combine(
-                projectRoot,
-                HotReloadConstants.ScriptAssembliesRelativeDirectory,
-                assemblyName + HotReloadConstants.CompiledAssemblyExtension);
+            string dllPath = home.DllPath;
 
             if (!File.Exists(dllPath))
             {
@@ -56,7 +51,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             {
                 return HotReloadMethodMatchResult.Failure(
                     HotReloadMethodMatchFailureReason.TypeNotFound,
-                    $"Type '{typeMetadataName}' was not found in assembly '{assemblyName}'.");
+                    $"Type '{typeMetadataName}' was not found in assembly '{home.AssemblyName}'.");
             }
 
             MethodDefinition methodDefinition = FindMatchingMethod(
@@ -73,7 +68,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             int metadataToken = methodDefinition.MetadataToken.ToInt32();
             string compiledMvid = assemblyDefinition.MainModule.Mvid.ToString();
-            return ResolveLoadedMethod(assemblyName, compiledMvid, metadataToken);
+            return ResolveLoadedMethod(home, compiledMvid, metadataToken);
         }
 
         private static MethodDefinition FindMatchingMethod(
@@ -120,33 +115,31 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
         // internal so EditMode tests can exercise the Mvid guard without rewriting ScriptAssemblies.
         internal static HotReloadMethodMatchResult ResolveLoadedMethod(
-            string assemblyName,
+            HotReloadTypeHome home,
             string compiledMvid,
             int metadataToken)
         {
-            foreach (Assembly assembly in AppDomain.CurrentDomain.GetAssemblies())
+            Debug.Assert(home != null, "home must not be null.");
+
+            HotReloadLoadedAssemblyResolution resolution = home.ResolveLoadedAssembly(compiledMvid);
+            if (resolution.State == HotReloadLoadedAssemblyState.Stale)
             {
-                if (assembly.GetName().Name != assemblyName)
-                {
-                    continue;
-                }
-
-                if (assembly.ManifestModule.ModuleVersionId.ToString() != compiledMvid)
-                {
-                    return HotReloadMethodMatchResult.Failure(
-                        HotReloadMethodMatchFailureReason.StaleAssembly,
-                        $"The loaded assembly '{assemblyName}' no longer matches the compiled assembly on disk.",
-                        HotReloadConstants.StaleAssemblyHint);
-                }
-
-                MethodBase method = assembly.ManifestModule.ResolveMethod(metadataToken);
-                return HotReloadMethodMatchResult.SuccessResult(method);
+                return HotReloadMethodMatchResult.Failure(
+                    HotReloadMethodMatchFailureReason.StaleAssembly,
+                    $"The loaded assembly '{home.AssemblyName}' no longer matches the compiled assembly on disk.",
+                    HotReloadConstants.StaleAssemblyHint);
             }
 
-            return HotReloadMethodMatchResult.Failure(
-                HotReloadMethodMatchFailureReason.AssemblyNotLoaded,
-                $"Assembly '{assemblyName}' is not currently loaded in the AppDomain.",
-                HotReloadConstants.AssemblyNotLoadedHint);
+            if (resolution.State == HotReloadLoadedAssemblyState.NotLoaded)
+            {
+                return HotReloadMethodMatchResult.Failure(
+                    HotReloadMethodMatchFailureReason.AssemblyNotLoaded,
+                    $"Assembly '{home.AssemblyName}' is not currently loaded in the AppDomain.",
+                    HotReloadConstants.AssemblyNotLoadedHint);
+            }
+
+            MethodBase method = resolution.Assembly.ManifestModule.ResolveMethod(metadataToken);
+            return HotReloadMethodMatchResult.SuccessResult(method);
         }
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/Shared/HotReloadLoadedAssemblyResolution.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/Shared/HotReloadLoadedAssemblyResolution.cs
@@ -1,0 +1,50 @@
+using System.Reflection;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Whether the assembly a <see cref="HotReloadTypeHome"/> names is live in the AppDomain and
+    /// still matches the compiled image on disk.
+    /// </summary>
+    internal enum HotReloadLoadedAssemblyState
+    {
+        Loaded,
+        Stale,
+        NotLoaded
+    }
+
+    /// <summary>
+    /// The outcome of looking a <see cref="HotReloadTypeHome"/> up in the AppDomain: the live
+    /// assembly when it matches the compiled Mvid, and the state that explains why it does not.
+    /// Why no message: the diagnostic wording belongs to the callers (method matcher and the
+    /// patch-target Mvid guard), so their responses stay byte-identical.
+    /// </summary>
+    internal readonly struct HotReloadLoadedAssemblyResolution
+    {
+        /// <summary>The live assembly; non-null only when <see cref="State"/> is Loaded.</summary>
+        public Assembly Assembly { get; }
+
+        public HotReloadLoadedAssemblyState State { get; }
+
+        private HotReloadLoadedAssemblyResolution(Assembly assembly, HotReloadLoadedAssemblyState state)
+        {
+            Assembly = assembly;
+            State = state;
+        }
+
+        public static HotReloadLoadedAssemblyResolution Loaded(Assembly assembly)
+        {
+            return new HotReloadLoadedAssemblyResolution(assembly, HotReloadLoadedAssemblyState.Loaded);
+        }
+
+        public static HotReloadLoadedAssemblyResolution Stale()
+        {
+            return new HotReloadLoadedAssemblyResolution(null, HotReloadLoadedAssemblyState.Stale);
+        }
+
+        public static HotReloadLoadedAssemblyResolution NotLoaded()
+        {
+            return new HotReloadLoadedAssemblyResolution(null, HotReloadLoadedAssemblyState.NotLoaded);
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/Shared/HotReloadLoadedAssemblyResolution.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/Shared/HotReloadLoadedAssemblyResolution.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4bed868bfa7b648c5828835d7464cb78
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/Shared/HotReloadTypeHome.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/Shared/HotReloadTypeHome.cs
@@ -1,0 +1,134 @@
+using System;
+using System.Reflection;
+
+using UnityEngine;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Where the types a hot-reload patch targets live.
+    /// </summary>
+    internal enum HotReloadTypeHomeKind
+    {
+        /// <summary>A Unity project assembly under Library/ScriptAssemblies.</summary>
+        ScriptAssemblies,
+
+        /// <summary>An introduced-type artifact assembly retained by this domain.</summary>
+        RetainedArtifact
+    }
+
+    /// <summary>
+    /// One immutable answer to "where do the patch target's types live": the assembly simple name,
+    /// the compiled image on disk, and how to find the matching assembly in the AppDomain.
+    /// Why one value: the patch-target resolver, the Mvid guard, the method matcher, the
+    /// publicizer, and the worker input all used to rebuild that answer independently, so a
+    /// target that is not a ScriptAssemblies dll had to be taught to each of them separately.
+    /// </summary>
+    internal sealed class HotReloadTypeHome
+    {
+        public HotReloadTypeHomeKind Kind { get; }
+
+        /// <summary>
+        /// The assembly simple name: the Unity assembly name for ScriptAssemblies, the generated
+        /// artifact name for a retained artifact.
+        /// </summary>
+        public string AssemblyName { get; }
+
+        /// <summary>The compiled image on disk, as a full path.</summary>
+        public string DllPath { get; }
+
+        // Non-null only for RetainedArtifact: that assembly is not discoverable by simple name
+        // in the AppDomain, so the home carries the instance it was built from.
+        private readonly Assembly retainedAssembly;
+
+        private HotReloadTypeHome(
+            HotReloadTypeHomeKind kind,
+            string assemblyName,
+            string dllPath,
+            Assembly retainedAssembly)
+        {
+            Kind = kind;
+            AssemblyName = assemblyName;
+            DllPath = dllPath;
+            this.retainedAssembly = retainedAssembly;
+        }
+
+        /// <summary>
+        /// A Unity project assembly compiled into Library/ScriptAssemblies.
+        /// </summary>
+        public static HotReloadTypeHome ScriptAssemblies(string assemblyName, string dllPath)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(assemblyName), "assemblyName must not be null or empty.");
+            Debug.Assert(!string.IsNullOrEmpty(dllPath), "dllPath must not be null or empty.");
+
+            return new HotReloadTypeHome(
+                HotReloadTypeHomeKind.ScriptAssemblies,
+                assemblyName,
+                dllPath,
+                null);
+        }
+
+        /// <summary>
+        /// An introduced-type artifact assembly this domain still holds loaded.
+        /// </summary>
+        public static HotReloadTypeHome RetainedArtifact(
+            string assemblyName,
+            string dllPath,
+            Assembly loadedAssembly)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(assemblyName), "assemblyName must not be null or empty.");
+            Debug.Assert(!string.IsNullOrEmpty(dllPath), "dllPath must not be null or empty.");
+            Debug.Assert(loadedAssembly != null, "loadedAssembly must not be null.");
+            Debug.Assert(
+                string.Equals(loadedAssembly?.GetName().Name, assemblyName, StringComparison.Ordinal),
+                "loadedAssembly must be the assembly assemblyName names.");
+
+            return new HotReloadTypeHome(
+                HotReloadTypeHomeKind.RetainedArtifact,
+                assemblyName,
+                dllPath,
+                loadedAssembly);
+        }
+
+        /// <summary>
+        /// Finds the live assembly for this home and reports whether it still matches
+        /// <paramref name="compiledMvid"/>, the Mvid read from the compiled image.
+        /// </summary>
+        public HotReloadLoadedAssemblyResolution ResolveLoadedAssembly(string compiledMvid)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(compiledMvid), "compiledMvid must not be null or empty.");
+
+            if (Kind == HotReloadTypeHomeKind.RetainedArtifact)
+            {
+                return MatchMvid(retainedAssembly, compiledMvid);
+            }
+
+            foreach (Assembly assembly in AppDomain.CurrentDomain.GetAssemblies())
+            {
+                if (!string.Equals(assembly.GetName().Name, AssemblyName, StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                return MatchMvid(assembly, compiledMvid);
+            }
+
+            return HotReloadLoadedAssemblyResolution.NotLoaded();
+        }
+
+        // The Mvid stays a string: it is compared against the "D"-format Guid the Cecil reader
+        // produced, and the callers pass that string straight through.
+        private static HotReloadLoadedAssemblyResolution MatchMvid(Assembly assembly, string compiledMvid)
+        {
+            if (!string.Equals(
+                    assembly.ManifestModule.ModuleVersionId.ToString(),
+                    compiledMvid,
+                    StringComparison.Ordinal))
+            {
+                return HotReloadLoadedAssemblyResolution.Stale();
+            }
+
+            return HotReloadLoadedAssemblyResolution.Loaded(assembly);
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/HotReload/Shared/HotReloadTypeHome.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/Shared/HotReloadTypeHome.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9176982849cf443a6a3c6c727a94ddb5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary
- No user-visible change. Hot reload keeps the same behavior and the same messages.
- Groundwork so a later change can point hot reload at a patch target that is not a `Library/ScriptAssemblies` dll without teaching every step separately.

## User Impact
- None. Every failure message a user can see (stale assembly, assembly not loaded, type not found) keeps its exact current wording, and the CLI responses are unchanged.

## Changes
- Add `HotReloadTypeHome`: one immutable answer to "where do the patch target's types live" (assembly simple name, compiled image path, and how to find the matching assembly in the AppDomain), with a ScriptAssemblies factory and a retained-artifact factory.
- Add `HotReloadLoadedAssemblyResolution` / `HotReloadLoadedAssemblyState`, reporting the AppDomain lookup as `Loaded` / `Stale` / `NotLoaded`. It carries no message on purpose: the diagnostic wording stays with the callers so their responses keep their current text.
- The method matcher and the patch-target Mvid guard now take a type home instead of an assembly name, so neither rebuilds the dll path from the project root nor scans the AppDomain itself. The entry resolver, the entry applier and the group preparation step pass the home down.

## Verification
- `uloop compile`: `Success: true`, 0 errors.
- `uloop run-tests --filter-type regex --filter-value "HotReloadTypeHomeTests|HotReloadMethodMatcherTests|HotReloadEntryResolutionTests|HotReloadPatchTargetSupportPathTests|HotReloadAssemblyResolutionDiagnosticsTests"`: 28 tests, 28 passed, 0 failed.
- `uloop run-tests --filter-type class --filter-value HotReloadTypeHomeTests`: 5 tests, 5 passed, confirming the new class is discovered and executed rather than dead code.
- `check-asmdef-policy`: "No asmdef reference violated the policy."
- `check-file-length --max-length 400`: none of the touched files appear in the findings. SLOC before -> after: method matcher 120 -> 113, patch-target support 213 -> 210, group preparation 60 -> 59, entry resolution 314 -> 314, entry applier 166 -> 166, new-source membership validator 398 -> 399 (one line added by wrapping a call that no longer fits on one line). New files: type home 84, loaded-assembly resolution 32.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2749?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

