### PR TITLE
chore: Resolve a hot-reload patch target's type home in one place

### DIFF
--- a/Assets/Tests/Editor/HotReload/HotReloadDomainTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadDomainTests.cs
@@ -1,9 +1,13 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Reflection;
+using System.Reflection.Emit;
 
 using HarmonyLib;
 using NUnit.Framework;
+
+using UnityEngine;
 
 using io.github.hatayama.UnityCliLoop.FirstPartyTools;
 using io.github.hatayama.UnityCliLoop.ToolContracts;
@@ -25,6 +29,10 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         private const string HostType = "Ns.Host";
         private const string NestedCecilType = "Ns.Outer/Inner";
         private const string NestedReflectionType = "Ns.Outer+Inner";
+
+        // A project assembly name no introduced-type artifact can carry.
+        private const string ProjectAssemblyName = "DomainTypeHomeFixtureAssembly";
+        private const string ArtifactDllPath = "domain-artifact.dll";
 
         private HotReloadDomainTestAccess _access;
 
@@ -403,6 +411,74 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             _access.Domain.RecordAppliedSource(FileOne, "hash", true);
             _access.Domain.RecordAppliedSource(FileTwo, "other-hash", false);
             _access.RecordSupersededSignature(FileOne, SupersededMethodKey, "Superseded(int)");
+        }
+
+        /// <summary>
+        /// What: an assembly name no active artifact carries resolves to the project's compiled
+        /// assembly under Library/ScriptAssemblies.
+        /// </summary>
+        [Test]
+        public void ResolveTypeHome_NoActiveArtifactForTheName_ReturnsTheScriptAssembliesHome()
+        {
+            string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
+
+            HotReloadTypeHome home = _access.Domain.ResolveTypeHome(projectRoot, ProjectAssemblyName);
+
+            Assert.That(home.Kind, Is.EqualTo(HotReloadTypeHomeKind.ScriptAssemblies));
+            Assert.That(home.AssemblyName, Is.EqualTo(ProjectAssemblyName));
+            Assert.That(
+                home.DllPath,
+                Is.EqualTo(Path.Combine(
+                    projectRoot,
+                    HotReloadConstants.ScriptAssembliesRelativeDirectory,
+                    ProjectAssemblyName + HotReloadConstants.CompiledAssemblyExtension)));
+        }
+
+        /// <summary>
+        /// What: an assembly name an active artifact carries resolves to that artifact, so the
+        /// dll path is the artifact's image rather than a ScriptAssemblies one.
+        /// </summary>
+        [Test]
+        public void ResolveTypeHome_ActiveArtifactCarriesTheName_ReturnsTheRetainedArtifactHome()
+        {
+            string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
+            HotReloadIntroducedTypeArtifact artifact = ActivateArtifact();
+
+            HotReloadTypeHome home = _access.Domain.ResolveTypeHome(
+                projectRoot,
+                artifact.Assembly.GetName().Name);
+
+            Assert.That(home.Kind, Is.EqualTo(HotReloadTypeHomeKind.RetainedArtifact));
+            Assert.That(home.DllPath, Is.EqualTo(artifact.DllPath));
+        }
+
+        private HotReloadIntroducedTypeArtifact ActivateArtifact()
+        {
+            HotReloadIntroducedTypeArtifact artifact = new HotReloadIntroducedTypeArtifact(
+                CreateIntroducedTypeAssembly(),
+                ArtifactDllPath,
+                "domain-artifact.pdb",
+                new List<HotReloadIntroducedTypeDescriptor>
+                {
+                    new HotReloadIntroducedTypeDescriptor(
+                        "OriginalAssembly",
+                        "original-mvid",
+                        "Example.Introduced",
+                        "Assets/DomainIntroduced.cs",
+                        "domain-fingerprint",
+                        "public class Introduced { }")
+                });
+            _access.Domain.IntroducedTypes.RegisterPrepared(artifact);
+            _access.Domain.IntroducedTypes.Activate(artifact);
+            return artifact;
+        }
+
+        // Why a generated name: an artifact assembly is compiled under a name of its own, so a
+        // fixture that reused a project assembly's name would not resolve the way production does.
+        private static Assembly CreateIntroducedTypeAssembly()
+        {
+            AssemblyName assemblyName = new AssemblyName("UloopIntroducedTypes_" + Guid.NewGuid().ToString("N"));
+            return AssemblyBuilder.DefineDynamicAssembly(assemblyName, AssemblyBuilderAccess.Run);
         }
 
         private static void AssertRow(

--- a/Assets/Tests/Editor/HotReload/HotReloadGroupProcessorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadGroupProcessorTests.cs
@@ -802,7 +802,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             };
             return new HotReloadApplyContext(
                 projectRoot, AssemblyName, "coverage-test", compilationAssembly,
-                callerFile.TargetDllPath, compilationAssembly.defines ?? Array.Empty<string>(),
+                callerFile.Home, compilationAssembly.defines ?? Array.Empty<string>(),
                 new TransformWorkerInputDto
                 {
                     sources = new[]
@@ -834,7 +834,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 context.AssemblyName,
                 context.CorrelationId,
                 context.CompilationAssembly,
-                context.TargetDllPath,
+                context.Home,
                 context.Defines,
                 context.WorkerInput,
                 emptyWorkerOutput,
@@ -870,7 +870,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 "// " + path + "\n");
             HotReloadGroupFile file = new HotReloadGroupFile(
                 path, workerSourcePath, path, AssemblyName, compilationAssembly,
-                Path.Combine(projectRoot, "Library", "ScriptAssemblies", AssemblyName + ".dll"),
+                HotReloadTypeHome.ScriptAssembliesUnderProject(projectRoot, AssemblyName),
                 projectRoot, new HotReloadFileSinks(new List<string>(), null), newSourceMembershipEvidence);
             file.FileOutput = new TransformWorkerFileOutputDto
             {

--- a/Assets/Tests/Editor/HotReload/HotReloadIntroducedTypeRegistryTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadIntroducedTypeRegistryTests.cs
@@ -649,6 +649,65 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
         }
 
         /// <summary>
+        /// Verifies that an active artifact is found by the simple name of its assembly, which is
+        /// how a patch target names the assembly it belongs to.
+        /// </summary>
+        [Test]
+        public void TryFindActiveArtifactByAssemblyName_ActiveArtifact_ReturnsThatArtifact()
+        {
+            HotReloadIntroducedTypeRegistry registry = new HotReloadIntroducedTypeRegistry();
+            HotReloadIntroducedTypeArtifact artifact = CreateArtifact("by-name");
+            registry.RegisterPrepared(artifact);
+            registry.Activate(artifact);
+
+            bool found = registry.TryFindActiveArtifactByAssemblyName(
+                artifact.Assembly.GetName().Name,
+                out HotReloadIntroducedTypeArtifact foundArtifact);
+
+            Assert.That(found, Is.True);
+            Assert.That(foundArtifact, Is.SameAs(artifact));
+        }
+
+        /// <summary>
+        /// Verifies that a name no active artifact carries finds nothing, so a project assembly
+        /// keeps resolving to its compiled image.
+        /// </summary>
+        [Test]
+        public void TryFindActiveArtifactByAssemblyName_UnknownName_ReturnsFalse()
+        {
+            HotReloadIntroducedTypeRegistry registry = new HotReloadIntroducedTypeRegistry();
+            HotReloadIntroducedTypeArtifact artifact = CreateArtifact("by-name");
+            registry.RegisterPrepared(artifact);
+            registry.Activate(artifact);
+
+            bool found = registry.TryFindActiveArtifactByAssemblyName(
+                artifact.Assembly.GetName().Name + ".Absent",
+                out HotReloadIntroducedTypeArtifact foundArtifact);
+
+            Assert.That(found, Is.False);
+            Assert.That(foundArtifact, Is.Null);
+        }
+
+        /// <summary>
+        /// Verifies that a prepared artifact that was never activated is not found by name, so a
+        /// run that has not reached its commit boundary cannot be patched against it.
+        /// </summary>
+        [Test]
+        public void TryFindActiveArtifactByAssemblyName_PreparedButNotActivated_ReturnsFalse()
+        {
+            HotReloadIntroducedTypeRegistry registry = new HotReloadIntroducedTypeRegistry();
+            HotReloadIntroducedTypeArtifact artifact = CreateArtifact("prepared-only");
+            registry.RegisterPrepared(artifact);
+
+            bool found = registry.TryFindActiveArtifactByAssemblyName(
+                artifact.Assembly.GetName().Name,
+                out HotReloadIntroducedTypeArtifact foundArtifact);
+
+            Assert.That(found, Is.False);
+            Assert.That(foundArtifact, Is.Null);
+        }
+
+        /// <summary>
         /// Judges each background resolution against the identity that was requested, without
         /// keeping one entry per call in memory.
         /// </summary>

--- a/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
+++ b/Assets/Tests/Editor/HotReload/HotReloadOrchestratorTests.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
+using System.Reflection.Emit;
 using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
@@ -2039,12 +2040,23 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 "fingerprint",
                 "public class Introduced { }");
             HotReloadIntroducedTypeArtifact artifact = new HotReloadIntroducedTypeArtifact(
-                typeof(HotReloadOrchestratorTests).Assembly,
+                CreateIntroducedTypeAssembly(),
                 "artifact.dll",
                 "artifact.pdb",
                 new List<HotReloadIntroducedTypeDescriptor> { descriptor });
             HotReloadCompositionRoot.Services.Domain.IntroducedTypes.RegisterPrepared(artifact);
             HotReloadCompositionRoot.Services.Domain.IntroducedTypes.Activate(artifact);
+        }
+
+        // Why a generated name rather than this test assembly: an artifact assembly is compiled
+        // under a name of its own, and reusing a project assembly's name would make the artifact
+        // answer for that project assembly's types.
+        private static System.Reflection.Assembly CreateIntroducedTypeAssembly()
+        {
+            AssemblyName assemblyName = new AssemblyName("UloopIntroducedTypes_" + Guid.NewGuid().ToString("N"));
+            return System.Reflection.Emit.AssemblyBuilder.DefineDynamicAssembly(
+                assemblyName,
+                AssemblyBuilderAccess.Run);
         }
 
         /// <summary>
@@ -3180,10 +3192,6 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
             string[] addedFieldNames)
         {
             string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
-            string targetDllPath = Path.Combine(
-                projectRoot,
-                HotReloadConstants.ScriptAssembliesRelativeDirectory,
-                assemblyName + ".dll");
             UnityEditor.Compilation.Assembly compilationAssembly = null;
             foreach (UnityEditor.Compilation.Assembly assembly in CompilationPipeline.GetAssemblies())
             {
@@ -3206,7 +3214,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 projectRelativePath,
                 assemblyName,
                 compilationAssembly,
-                targetDllPath,
+                HotReloadTypeHome.ScriptAssembliesUnderProject(projectRoot, assemblyName),
                 projectRoot,
                 new HotReloadFileSinks(new List<string>(), null))
             {
@@ -3221,7 +3229,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.HotReload
                 assemblyName,
                 "direct-apply",
                 compilationAssembly,
-                targetDllPath,
+                HotReloadTypeHome.ScriptAssembliesUnderProject(projectRoot, assemblyName),
                 compilationAssembly.defines ?? Array.Empty<string>(),
                 new TransformWorkerInputDto
                 {

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadApplyContext.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadApplyContext.cs
@@ -22,7 +22,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             string assemblyName,
             string correlationId,
             UnityCompilationAssembly compilationAssembly,
-            string targetDllPath,
+            HotReloadTypeHome home,
             string[] defines,
             TransformWorkerInputDto workerInput,
             TransformWorkerOutputDto workerOutput,
@@ -31,7 +31,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         {
             Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be empty.");
             Debug.Assert(!string.IsNullOrEmpty(assemblyName), "assemblyName must not be empty.");
-            Debug.Assert(!string.IsNullOrEmpty(targetDllPath), "targetDllPath must not be empty.");
+            Debug.Assert(home != null, "home must not be null.");
             Debug.Assert(compilationAssembly != null, "compilationAssembly must not be null.");
             Debug.Assert(defines != null, "defines must not be null.");
             Debug.Assert(workerInput != null, "workerInput must not be null.");
@@ -42,7 +42,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             AssemblyName = assemblyName;
             CorrelationId = correlationId;
             CompilationAssembly = compilationAssembly;
-            TargetDllPath = targetDllPath;
+            Home = home;
             Defines = defines;
             WorkerInput = workerInput;
             WorkerOutput = workerOutput;
@@ -78,7 +78,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
         internal UnityCompilationAssembly CompilationAssembly { get; }
 
-        internal string TargetDllPath { get; }
+        // Where the group's patch target types live; every file of a group shares one.
+        internal HotReloadTypeHome Home { get; }
+
+        internal string TargetDllPath => Home.DllPath;
 
         /// <summary>
         /// What this run prepared, or null when the run introduced no type. The artifact is

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadEntryApplier.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadEntryApplier.cs
@@ -172,7 +172,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 }
 
                 file.RevertedUnchangedCount = RevertUnchangedPatches(
-                    HotReloadTypeHome.ScriptAssemblies(file.AssemblyName, file.TargetDllPath),
+                    file.Home,
                     unchangedMethods,
                     file.Sinks.Outcomes,
                     file.AssemblyResolvePath);

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupEntryPreparation.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupEntryPreparation.cs
@@ -64,7 +64,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             TransformWorkerEntryDto[] entries = fileEntries.ToArray();
             HotReloadEntryResolution.Result resolution = HotReloadEntryResolution.ResolveEntries(
-                HotReloadTypeHome.ScriptAssemblies(file.AssemblyName, file.TargetDllPath),
+                file.Home,
                 file.AssemblyResolvePath,
                 compileResult.Assembly,
                 entries,

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupFile.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupFile.cs
@@ -24,7 +24,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             string projectRelativePath,
             string assemblyName,
             UnityCompilationAssembly compilationAssembly,
-            string targetDllPath,
+            HotReloadTypeHome home,
             string projectRoot,
             HotReloadFileSinks sinks,
             HotReloadNewSourceMembershipEvidence newSourceMembershipEvidence = null)
@@ -34,7 +34,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             Debug.Assert(!string.IsNullOrEmpty(projectRelativePath), "projectRelativePath must not be empty.");
             Debug.Assert(!string.IsNullOrEmpty(assemblyName), "assemblyName must not be empty.");
             Debug.Assert(compilationAssembly != null, "compilationAssembly must not be null.");
-            Debug.Assert(!string.IsNullOrEmpty(targetDllPath), "targetDllPath must not be empty.");
+            Debug.Assert(home != null, "home must not be null.");
             Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be empty.");
             Debug.Assert(sinks != null, "sinks must not be null.");
 
@@ -43,7 +43,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             ProjectRelativePath = projectRelativePath;
             AssemblyName = assemblyName;
             CompilationAssembly = compilationAssembly;
-            TargetDllPath = targetDllPath;
+            Home = home;
             ProjectRoot = projectRoot;
             Sinks = sinks;
             NewSourceMembershipEvidence = newSourceMembershipEvidence;
@@ -62,7 +62,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 projectRelativePath,
                 template.AssemblyName,
                 template.CompilationAssembly,
-                template.TargetDllPath,
+                template.Home,
                 template.ProjectRoot,
                 sinks,
                 null);
@@ -80,7 +80,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
         internal UnityCompilationAssembly CompilationAssembly { get; }
 
-        internal string TargetDllPath { get; }
+        // Where this file's patch target types live.
+        internal HotReloadTypeHome Home { get; }
+
+        internal string TargetDllPath => Home.DllPath;
 
         internal string ProjectRoot { get; }
 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupProcessor.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadGroupProcessor.cs
@@ -213,7 +213,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 firstFile.AssemblyName,
                 correlationId,
                 firstFile.CompilationAssembly,
-                firstFile.TargetDllPath,
+                firstFile.Home,
                 firstFile.CompilationAssembly.defines ?? Array.Empty<string>(),
                 workerInput,
                 workerOutput,

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadInputFileResolver.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadInputFileResolver.cs
@@ -81,7 +81,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 resolution.ProjectRelativePath,
                 resolution.AssemblyName,
                 resolution.CompilationAssembly,
-                resolution.TargetDllPath,
+                resolution.Home,
                 resolution.ProjectRoot,
                 sinks,
                 resolution.NewSourceMembershipEvidence);

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadPatchTargetResolution.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadPatchTargetResolution.cs
@@ -14,7 +14,15 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         public string ProjectRelativePath { get; }
         public string AssemblyName { get; }
         public UnityCompilationAssembly CompilationAssembly { get; }
-        public string TargetDllPath { get; }
+
+        /// <summary>
+        /// Where the target's types live, or null on an early exit: a file that never reached a
+        /// patch target has no resolved home.
+        /// </summary>
+        public HotReloadTypeHome Home { get; }
+
+        public string TargetDllPath => Home?.DllPath;
+
         public string ProjectRoot { get; }
         public HotReloadUnchangedSourceDecision UnchangedDecision { get; }
         public HotReloadNewSourceMembershipEvidence NewSourceMembershipEvidence { get; }
@@ -26,7 +34,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             string projectRelativePath,
             string assemblyName,
             UnityCompilationAssembly compilationAssembly,
-            string targetDllPath,
+            HotReloadTypeHome home,
             string projectRoot,
             HotReloadUnchangedSourceDecision unchangedDecision,
             HotReloadNewSourceMembershipEvidence newSourceMembershipEvidence)
@@ -35,7 +43,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             ProjectRelativePath = projectRelativePath;
             AssemblyName = assemblyName;
             CompilationAssembly = compilationAssembly;
-            TargetDllPath = targetDllPath;
+            Home = home;
             ProjectRoot = projectRoot;
             UnchangedDecision = unchangedDecision;
             NewSourceMembershipEvidence = newSourceMembershipEvidence;
@@ -61,13 +69,13 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         }
 
         /// <summary>
-        /// A file whose compiled assembly, DLL and project root were all resolved.
+        /// A file whose compiled assembly, type home and project root were all resolved.
         /// </summary>
         internal static HotReloadPatchTargetResolution Resolved(
             string projectRelativePath,
             string assemblyName,
             UnityCompilationAssembly compilationAssembly,
-            string targetDllPath,
+            HotReloadTypeHome home,
             string projectRoot,
             HotReloadUnchangedSourceDecision unchangedDecision,
             HotReloadNewSourceMembershipEvidence newSourceMembershipEvidence)
@@ -75,7 +83,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             Debug.Assert(!string.IsNullOrEmpty(projectRelativePath), "projectRelativePath must not be null or empty.");
             Debug.Assert(!string.IsNullOrEmpty(assemblyName), "assemblyName must not be null or empty.");
             Debug.Assert(compilationAssembly != null, "compilationAssembly must not be null.");
-            Debug.Assert(!string.IsNullOrEmpty(targetDllPath), "targetDllPath must not be null or empty.");
+            Debug.Assert(home != null, "home must not be null.");
             Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be null or empty.");
 
             return new HotReloadPatchTargetResolution(
@@ -83,7 +91,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 projectRelativePath,
                 assemblyName,
                 compilationAssembly,
-                targetDllPath,
+                home,
                 projectRoot,
                 unchangedDecision,
                 newSourceMembershipEvidence);

--- a/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadPatchTargetSupport.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/HotReloadPatchTargetSupport.cs
@@ -97,24 +97,20 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
-            string targetDllPath = Path.Combine(
-                projectRoot,
-                HotReloadConstants.ScriptAssembliesRelativeDirectory,
-                assemblyName + HotReloadConstants.CompiledAssemblyExtension);
+            HotReloadTypeHome home = domain.ResolveTypeHome(projectRoot, assemblyName);
 
-            if (!File.Exists(targetDllPath))
+            if (!File.Exists(home.DllPath))
             {
                 outcomes.Add(
                     HotReloadMethodOutcome.Failed(
                         "(file)",
-                        "Compiled assembly not found at '" + targetDllPath + "'. Compile the project first.",
+                        "Compiled assembly not found at '" + home.DllPath + "'. Compile the project first.",
                         assemblyResolvePath));
                 return HotReloadPatchTargetResolution.EarlyExit(
                     new HotReloadFileProcessResult(outcomes, warnings, 0));
             }
 
-            string mvidGuardError = CheckMvidGuard(
-                HotReloadTypeHome.ScriptAssemblies(assemblyName, targetDllPath));
+            string mvidGuardError = CheckMvidGuard(home);
             if (mvidGuardError != null)
             {
                 outcomes.Add(HotReloadMethodOutcome.Failed("(file)", mvidGuardError, assemblyResolvePath));
@@ -131,7 +127,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     projectRelativePath,
                     assemblyName,
                     compilationAssembly,
-                    targetDllPath,
+                    home.DllPath,
                     out newSourceMembershipEvidence);
                 if (membershipFailure != null)
                 {
@@ -168,7 +164,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 projectRelativePath,
                 assemblyName,
                 compilationAssembly,
-                targetDllPath,
+                home,
                 projectRoot,
                 unchangedDecision,
                 newSourceMembershipEvidence);

--- a/Packages/src/Editor/FirstPartyTools/HotReload/IntroducedType/HotReloadIntroducedTypeRegistry.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/IntroducedType/HotReloadIntroducedTypeRegistry.cs
@@ -275,6 +275,36 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return false;
         }
 
+        /// <summary>
+        /// Finds the active artifact whose assembly carries <paramref name="assemblySimpleName"/>.
+        /// Why by simple name: a patch target names its assembly the way Unity does, without the
+        /// version and public-key parts the full name a bind request carries would have.
+        /// </summary>
+        public bool TryFindActiveArtifactByAssemblyName(
+            string assemblySimpleName,
+            out HotReloadIntroducedTypeArtifact artifact)
+        {
+            lock (gate)
+            {
+                foreach (HotReloadIntroducedTypeArtifact active in activeByAssemblyIdentity.Values)
+                {
+                    if (!string.Equals(
+                            active.Assembly.GetName().Name,
+                            assemblySimpleName,
+                            StringComparison.Ordinal))
+                    {
+                        continue;
+                    }
+
+                    artifact = active;
+                    return true;
+                }
+            }
+
+            artifact = null;
+            return false;
+        }
+
         public bool TryResolveActiveAssembly(string requestedAssemblyFullName, out HotReloadIntroducedTypeArtifact artifact)
         {
             lock (gate)

--- a/Packages/src/Editor/FirstPartyTools/HotReload/Patching/HotReloadDomain.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/Patching/HotReloadDomain.cs
@@ -58,6 +58,32 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         internal HotReloadInvocationCounts Invocations { get; } = new HotReloadInvocationCounts();
 
         /// <summary>
+        /// Where the types of <paramref name="assemblyName"/> live for this domain: the artifact
+        /// this domain retains when the name belongs to one, and the project's compiled assembly
+        /// otherwise.
+        /// </summary>
+        /// <remarks>
+        /// Why the domain answers: only it knows which artifact assemblies this domain still
+        /// holds, and an artifact is not discoverable by simple name in the AppDomain. The
+        /// artifact branch is the entry point for patching an introduced type itself; today's
+        /// callers always name a project assembly and take the ScriptAssemblies branch.
+        /// </remarks>
+        internal HotReloadTypeHome ResolveTypeHome(string projectRoot, string assemblyName)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be null or empty.");
+            Debug.Assert(!string.IsNullOrEmpty(assemblyName), "assemblyName must not be null or empty.");
+
+            if (IntroducedTypes.TryFindActiveArtifactByAssemblyName(
+                    assemblyName,
+                    out HotReloadIntroducedTypeArtifact artifact))
+            {
+                return HotReloadTypeHome.RetainedArtifact(assemblyName, artifact.DllPath, artifact.Assembly);
+            }
+
+            return HotReloadTypeHome.ScriptAssembliesUnderProject(projectRoot, assemblyName);
+        }
+
+        /// <summary>
         /// Stops this domain's resolver from answering binds. The generations are not reverted
         /// here: Harmony patches are removed through the patcher, which owns that side.
         /// </summary>

--- a/Packages/src/Editor/FirstPartyTools/HotReload/Shared/HotReloadTypeHome.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/Shared/HotReloadTypeHome.cs
@@ -1,4 +1,5 @@
 using System;
+using System.IO;
 using System.Reflection;
 
 using UnityEngine;
@@ -66,6 +67,21 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 assemblyName,
                 dllPath,
                 null);
+        }
+
+        /// <summary>
+        /// A Unity project assembly, named by the project root it is compiled under.
+        /// </summary>
+        public static HotReloadTypeHome ScriptAssembliesUnderProject(string projectRoot, string assemblyName)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be null or empty.");
+            Debug.Assert(!string.IsNullOrEmpty(assemblyName), "assemblyName must not be null or empty.");
+
+            string dllPath = Path.Combine(
+                projectRoot,
+                HotReloadConstants.ScriptAssembliesRelativeDirectory,
+                assemblyName + HotReloadConstants.CompiledAssemblyExtension);
+            return ScriptAssemblies(assemblyName, dllPath);
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- No user-visible change. Hot reload keeps the same behavior and the same messages.
- The step that resolves a patch target now asks the domain where the target's types live, instead of composing that answer from the project root itself, and the answer travels with the file through the rest of the pipeline.

## User Impact
- None. Every failure message a user can see keeps its exact current wording, and the CLI responses are unchanged.

## Changes
- Add a type-home factory that names a project assembly by the project root it is compiled under, so the compiled-assembly path is built in one place.
- Add an active-artifact lookup by assembly simple name to the introduced-type registry, which is how a patch target names its assembly.
- The domain now resolves an assembly name to the artifact it retains when one carries that name, and to the project's compiled assembly otherwise. Only the domain knows which artifact assemblies it still holds, and a retained artifact is not discoverable by simple name in the AppDomain. Today's callers always name a project assembly and take the project branch; the artifact branch is the entry point a later change needs to patch an introduced type itself.
- The patch-target resolution, the group file and the apply context carry the resolved home instead of a bare dll path, and expose the dll path from it. The three stages that used to construct a home in place (entry resolution, unchanged-patch revert, the Mvid guard) read the one their input already holds.
- The `Compiled assembly not found at '...'` failure keeps its wording and fills in the resolved path.
- Fixtures that stand in for an introduced-type artifact now build a generated assembly name of the shape the compiler produces (`UloopIntroducedTypes_<id>`), rather than reusing a test assembly whose name a project assembly also answers to. Reusing it made a stand-in artifact answer for a real project assembly, which cannot happen in production.

## Verification
- `uloop compile`: `Success: true`, 0 errors.
- `uloop run-tests --filter-type regex --filter-value "HotReloadDomainTests|HotReloadIntroducedTypeRegistryTests|HotReloadPatchTargetSupportPathTests|HotReloadGroupFilePathsTests|HotReloadGroupProcessorTests|HotReloadOrchestratorTests|HotReloadCrossFileE2ETests"`: 248 tests, 248 passed, 0 failed.
- The 5 new tests were run alone by name filter (5 tests, 5 passed), confirming they are discovered and executed rather than dead code.
- `uloop hot-reload --status` and `uloop hot-reload --revert-all`: responses captured before the change and after it diff empty.
- `check-asmdef-policy`: "No asmdef reference violated the policy."
- `check-file-length --max-length 400`: none of the touched files appear in the findings. SLOC after (before): type home 95 (84), introduced-type registry 284 (262), domain 350 (338), patch-target resolution 74 (73), group file 76 (75), apply context 72 (71), patch-target support 206 (210), input file resolver 121 (121), group processor 348 (348), group entry preparation 59 (59), entry applier 166 (166).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2750?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

