### PR TITLE
chore: Ask one worker value where the patch target's compiled types live

### DIFF
--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AddedFieldClassifier.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AddedFieldClassifier.cs
@@ -25,7 +25,7 @@ internal static class AddedFieldClassifier
         TypeEmitState typeState,
         SemanticModel semanticModel,
         INamedTypeSymbol compiledType,
-        IAssemblySymbol targetTypesAssemblySymbol,
+        WorkerTypeHome home,
         AddedFieldCatalog addedFieldCatalog,
         List<string> declarationDriftWarnings)
     {
@@ -49,7 +49,7 @@ internal static class AddedFieldClassifier
                 ClassifyOneAddedField(
                     typeState,
                     semanticModel,
-                    targetTypesAssemblySymbol,
+                    home,
                     fieldDeclaration,
                     variable,
                     fieldSymbol,
@@ -63,7 +63,7 @@ internal static class AddedFieldClassifier
     internal static void ClassifyOneAddedField(
         TypeEmitState typeState,
         SemanticModel semanticModel,
-        IAssemblySymbol targetTypesAssemblySymbol,
+        WorkerTypeHome home,
         FieldDeclarationSyntax fieldDeclaration,
         VariableDeclaratorSyntax variable,
         IFieldSymbol fieldSymbol,
@@ -117,7 +117,7 @@ internal static class AddedFieldClassifier
         binding.UnavailableReason = EvaluateAddedFieldAvailability(
             typeState.TypeSymbol,
             semanticModel,
-            targetTypesAssemblySymbol,
+            home,
             fieldSymbol,
             binding,
             typeState.SourceUnit.ArtifactMap);
@@ -140,7 +140,7 @@ internal static class AddedFieldClassifier
     internal static string EvaluateAddedFieldAvailability(
         INamedTypeSymbol hostType,
         SemanticModel semanticModel,
-        IAssemblySymbol targetTypesAssemblySymbol,
+        WorkerTypeHome home,
         IFieldSymbol fieldSymbol,
         AddedFieldBinding binding,
         IntroducedTypeArtifactMap artifactMap)
@@ -160,7 +160,7 @@ internal static class AddedFieldClassifier
         AddedFieldStoreAvailability availability = EvaluateStoreAvailability(
             hostType,
             semanticModel,
-            targetTypesAssemblySymbol,
+            home,
             fieldSymbol.Type,
             binding.Initializer,
             artifactMap,
@@ -178,7 +178,7 @@ internal static class AddedFieldClassifier
     internal static AddedFieldStoreAvailability EvaluateStoreAvailability(
         INamedTypeSymbol hostType,
         SemanticModel semanticModel,
-        IAssemblySymbol targetTypesAssemblySymbol,
+        WorkerTypeHome home,
         ITypeSymbol valueType,
         ExpressionSyntax initializer,
         IntroducedTypeArtifactMap artifactMap,
@@ -207,7 +207,7 @@ internal static class AddedFieldClassifier
                 initializer,
                 semanticModel,
                 hostType,
-                targetTypesAssemblySymbol,
+                home,
                 artifactMap))
         {
             return AddedFieldStoreAvailability.InitializerNotEmittable;
@@ -360,7 +360,7 @@ internal static class AddedFieldClassifier
 
     internal static bool IsSameFileAddedMember(
         ISymbol symbol,
-        IAssemblySymbol targetTypesAssemblySymbol,
+        WorkerTypeHome home,
         SyntaxTree currentTree)
     {
         if (symbol.ContainingType == null || currentTree == null)
@@ -383,7 +383,7 @@ internal static class AddedFieldClassifier
             return false;
         }
 
-        INamedTypeSymbol compiledType = CompiledMemberMatcher.FindCompiledType(symbol.ContainingType, targetTypesAssemblySymbol);
+        INamedTypeSymbol compiledType = home.FindCompiledType(symbol.ContainingType);
         if (compiledType == null)
         {
             return true;
@@ -423,7 +423,7 @@ internal static class AddedFieldClassifier
         ExpressionSyntax initializer,
         SemanticModel semanticModel,
         INamedTypeSymbol hostType,
-        IAssemblySymbol targetTypesAssemblySymbol,
+        WorkerTypeHome home,
         IntroducedTypeArtifactMap artifactMap)
     {
         foreach (SyntaxNode node in initializer.DescendantNodesAndSelf())
@@ -454,7 +454,7 @@ internal static class AddedFieldClassifier
             if (HasDisallowedInitializerSymbol(
                 semanticModel.GetSymbolInfo(node).Symbol,
                 hostType,
-                targetTypesAssemblySymbol,
+                home,
                 initializer.SyntaxTree))
             {
                 return true;
@@ -515,7 +515,7 @@ internal static class AddedFieldClassifier
     internal static bool HasDisallowedInitializerSymbol(
         ISymbol symbol,
         INamedTypeSymbol hostType,
-        IAssemblySymbol targetTypesAssemblySymbol,
+        WorkerTypeHome home,
         SyntaxTree currentTree)
     {
         if (symbol == null
@@ -546,7 +546,7 @@ internal static class AddedFieldClassifier
             return true;
         }
 
-        if (IsSameFileAddedMember(symbol, targetTypesAssemblySymbol, currentTree))
+        if (IsSameFileAddedMember(symbol, home, currentTree))
         {
             return true;
         }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AddedPropertyClassifier.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/AddedPropertyClassifier.cs
@@ -23,7 +23,7 @@ internal static class AddedPropertyClassifier
     internal static void ClassifyAddedProperties(
         TypeEmitState typeState,
         SemanticModel semanticModel,
-        IAssemblySymbol targetTypesAssemblySymbol,
+        WorkerTypeHome home,
         WorkerInput input,
         BaselineSnapshotState baseline,
         CompilationUnitSyntax root,
@@ -35,9 +35,7 @@ internal static class AddedPropertyClassifier
         List<WorkerSkipped> skipped,
         ShimNameAllocator shimNames)
     {
-        INamedTypeSymbol compiledType = CompiledMemberMatcher.FindCompiledType(
-            typeState.TypeSymbol,
-            targetTypesAssemblySymbol);
+        INamedTypeSymbol compiledType = home.FindCompiledType(typeState.TypeSymbol);
         if (compiledType == null)
         {
             return;
@@ -52,7 +50,7 @@ internal static class AddedPropertyClassifier
                 typeState,
                 compiledType,
                 semanticModel,
-                targetTypesAssemblySymbol,
+                home,
                 input,
                 baseline,
                 root,
@@ -71,7 +69,7 @@ internal static class AddedPropertyClassifier
         TypeEmitState typeState,
         INamedTypeSymbol compiledType,
         SemanticModel semanticModel,
-        IAssemblySymbol targetTypesAssemblySymbol,
+        WorkerTypeHome home,
         WorkerInput input,
         BaselineSnapshotState baseline,
         CompilationUnitSyntax root,
@@ -88,7 +86,7 @@ internal static class AddedPropertyClassifier
             typeState,
             compiledType,
             semanticModel,
-            targetTypesAssemblySymbol,
+            home,
             baseline,
             addedMethodCatalog);
         if (candidate == null)
@@ -147,7 +145,7 @@ internal static class AddedPropertyClassifier
         TypeEmitState typeState,
         INamedTypeSymbol compiledType,
         SemanticModel semanticModel,
-        IAssemblySymbol targetTypesAssemblySymbol,
+        WorkerTypeHome home,
         BaselineSnapshotState baseline,
         AddedMethodCatalog addedMethodCatalog)
     {
@@ -188,7 +186,7 @@ internal static class AddedPropertyClassifier
                 symbol,
                 typeState.TypeSymbol,
                 semanticModel,
-                targetTypesAssemblySymbol,
+                home,
                 typeState.SourceUnit.ArtifactMap);
         }
 
@@ -359,13 +357,13 @@ internal static class AddedPropertyClassifier
         IPropertySymbol symbol,
         INamedTypeSymbol hostType,
         SemanticModel semanticModel,
-        IAssemblySymbol targetTypesAssemblySymbol,
+        WorkerTypeHome home,
         IntroducedTypeArtifactMap artifactMap)
     {
         AddedFieldStoreAvailability availability = AddedFieldClassifier.EvaluateStoreAvailability(
             hostType,
             semanticModel,
-            targetTypesAssemblySymbol,
+            home,
             symbol.Type,
             declaration.Initializer?.Value,
             artifactMap,

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/CompiledMemberKindChangeWarnings.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/CompiledMemberKindChangeWarnings.cs
@@ -36,11 +36,11 @@ internal static class CompiledMemberKindChangeWarnings
     internal static SyntaxKeys AppendCompiledPropertyOrEventKindChangeWarnings(
         CompilationUnitSyntax root,
         SemanticModel semanticModel,
-        IAssemblySymbol targetTypesAssemblySymbol,
+        WorkerTypeHome home,
         List<string> warnings)
     {
         SyntaxKeys syntaxKeys = new SyntaxKeys();
-        if (targetTypesAssemblySymbol == null)
+        if (home.AssemblySymbol == null)
         {
             return syntaxKeys;
         }
@@ -71,7 +71,7 @@ internal static class CompiledMemberKindChangeWarnings
                 continue;
             }
 
-            INamedTypeSymbol compiledType = targetTypesAssemblySymbol.GetTypeByMetadataName(
+            INamedTypeSymbol compiledType = home.FindCompiledTypeByMetadataName(
                 typeMetadataName);
             if (compiledType == null)
             {

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/CompiledMemberMatcher.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/CompiledMemberMatcher.cs
@@ -17,18 +17,6 @@ using Microsoft.CodeAnalysis.Text;
 
 internal static class CompiledMemberMatcher
 {
-    internal static INamedTypeSymbol FindCompiledType(
-        INamedTypeSymbol sourceType,
-        IAssemblySymbol targetTypesAssemblySymbol)
-    {
-        if (sourceType == null || targetTypesAssemblySymbol == null)
-        {
-            return null;
-        }
-
-        return targetTypesAssemblySymbol.GetTypeByMetadataName(ConstDriftCollector.ToReflectionMetadataName(sourceType));
-    }
-
     internal static CompiledMethodMatch MatchCompiledOrdinaryMethod(
         INamedTypeSymbol compiledType,
         IMethodSymbol sourceMethod)

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/ConstDriftCollector.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/ConstDriftCollector.cs
@@ -33,10 +33,10 @@ internal static class ConstDriftCollector
     internal static List<string> CollectConstDriftWarnings(
         CompilationUnitSyntax root,
         SemanticModel semanticModel,
-        IAssemblySymbol targetTypesAssemblySymbol)
+        WorkerTypeHome home)
     {
         List<string> warnings = new List<string>();
-        if (targetTypesAssemblySymbol == null)
+        if (home.AssemblySymbol == null)
         {
             return warnings;
         }
@@ -59,7 +59,7 @@ internal static class ConstDriftCollector
                 continue;
             }
 
-            INamedTypeSymbol compiledType = targetTypesAssemblySymbol.GetTypeByMetadataName(
+            INamedTypeSymbol compiledType = home.FindCompiledTypeByMetadataName(
                 typeMetadataName);
             if (compiledType == null)
             {

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/IntroducedTypeConstDriftDetector.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/IntroducedTypeConstDriftDetector.cs
@@ -17,7 +17,7 @@ internal static class IntroducedTypeConstDriftDetector
     internal static bool TryFindUnusableReferencedConst(
         BaseTypeDeclarationSyntax declaration,
         SemanticModel semanticModel,
-        IAssemblySymbol targetAssembly,
+        WorkerTypeHome home,
         out string identifier,
         out string reason)
     {
@@ -46,7 +46,7 @@ internal static class IntroducedTypeConstDriftDetector
                 return true;
             }
 
-            if (HasDriftedFromCompiledValue(field, targetAssembly))
+            if (HasDriftedFromCompiledValue(field, home))
             {
                 identifier = CecilTypeNames.ToMetadataName(field.ContainingType) + "." + field.Name;
                 reason = "Changed const requires a compile";
@@ -59,9 +59,9 @@ internal static class IntroducedTypeConstDriftDetector
         return false;
     }
 
-    private static bool HasDriftedFromCompiledValue(IFieldSymbol field, IAssemblySymbol targetAssembly)
+    private static bool HasDriftedFromCompiledValue(IFieldSymbol field, WorkerTypeHome home)
     {
-        INamedTypeSymbol compiledType = CompiledMemberMatcher.FindCompiledType(field.ContainingType, targetAssembly);
+        INamedTypeSymbol compiledType = home.FindCompiledType(field.ContainingType);
         if (compiledType == null)
         {
             return false;

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/IntroducedTypePlanner.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/IntroducedTypePlanner.cs
@@ -21,8 +21,7 @@ internal static class IntroducedTypePlanner
 {
     internal static void Plan(
         WorkerSourceUnit unit,
-        IAssemblySymbol targetAssembly,
-        string targetAssemblyName,
+        WorkerTypeHome home,
         string targetAssemblyMvid,
         IntroducedTypeArtifactMap artifactMap,
         IReadOnlyList<string> defineSymbols,
@@ -37,12 +36,12 @@ internal static class IntroducedTypePlanner
                 continue;
             }
 
-            if (CompiledMemberMatcher.FindCompiledType(typeSymbol, targetAssembly) != null)
+            if (home.FindCompiledType(typeSymbol) != null)
             {
                 continue;
             }
 
-            if (IsRefusedForNesting(unit, typeSymbol, declaration, targetAssembly))
+            if (IsRefusedForNesting(unit, typeSymbol, declaration, home))
             {
                 continue;
             }
@@ -56,7 +55,7 @@ internal static class IntroducedTypePlanner
             if (IntroducedTypeConstDriftDetector.TryFindUnusableReferencedConst(
                     declaration,
                     unit.ConstDriftSemanticModel ?? unit.SemanticModel,
-                    targetAssembly,
+                    home,
                     out string unusableConst,
                     out string unusableConstReason))
             {
@@ -73,14 +72,14 @@ internal static class IntroducedTypePlanner
                 defineSymbols,
                 typeSymbol,
                 unit.SemanticModel,
-                targetAssembly,
-                targetAssemblyName,
+                home.AssemblySymbol,
+                home.AssemblyName,
                 targetAssemblyMvid,
                 artifactMap);
             if (IsAlreadyIntroduced(
                     unit,
                     artifactMap,
-                    targetAssemblyName,
+                    home.AssemblyName,
                     targetAssemblyMvid,
                     metadataName,
                     declarationFingerprint))
@@ -91,7 +90,7 @@ internal static class IntroducedTypePlanner
             unit.IntroducedTypes.Add(
                 new WorkerIntroducedType
                 {
-                    OriginalAssemblyName = targetAssemblyName ?? string.Empty,
+                    OriginalAssemblyName = home.AssemblyName ?? string.Empty,
                     OriginalAssemblyMvid = targetAssemblyMvid ?? string.Empty,
                     MetadataName = metadataName,
                     OwnerProjectRelativePath = unit.Input.ProjectRelativePath,
@@ -103,7 +102,7 @@ internal static class IntroducedTypePlanner
         foreach (DelegateDeclarationSyntax declaration in unit.Root.DescendantNodes().OfType<DelegateDeclarationSyntax>())
         {
             INamedTypeSymbol delegateSymbol = unit.SemanticModel.GetDeclaredSymbol(declaration);
-            if (delegateSymbol == null || CompiledMemberMatcher.FindCompiledType(delegateSymbol, targetAssembly) != null)
+            if (delegateSymbol == null || home.FindCompiledType(delegateSymbol) != null)
             {
                 continue;
             }
@@ -120,14 +119,14 @@ internal static class IntroducedTypePlanner
         WorkerSourceUnit unit,
         INamedTypeSymbol typeSymbol,
         BaseTypeDeclarationSyntax declaration,
-        IAssemblySymbol targetAssembly)
+        WorkerTypeHome home)
     {
         if (typeSymbol.ContainingType != null)
         {
             // Why silent when the outer type is not compiled either: that outer declaration
             // is refused on its own, and its diagnostic already names this nested one as the
             // reason. Reporting both turns a single refusal into two lines about one type.
-            if (CompiledMemberMatcher.FindCompiledType(typeSymbol.ContainingType, targetAssembly) == null)
+            if (home.FindCompiledType(typeSymbol.ContainingType) == null)
             {
                 return true;
             }

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/IntroducedTypePreparation.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/IntroducedTypePreparation.cs
@@ -78,6 +78,7 @@ internal static class IntroducedTypePreparation
             options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
         AppendUnreadableReferenceErrors(compilation, references, referenceParseErrors);
         IAssemblySymbol targetAssembly = WorkerGroupPipeline.ResolveTargetTypesAssemblySymbol(compilation, targetTypesReference);
+        WorkerTypeHome home = new WorkerTypeHome(input.TargetAssemblyName, targetAssembly);
         List<CompilationUnitSyntax> analyzableRoots = new List<CompilationUnitSyntax>(analyzableUnits.Count);
         foreach (WorkerSourceUnit analyzableUnit in analyzableUnits)
         {
@@ -119,8 +120,7 @@ internal static class IntroducedTypePreparation
                         ignoreAccessibility: false);
                     IntroducedTypePlanner.Plan(
                         unit,
-                        targetAssembly,
-                        input.TargetAssemblyName,
+                        home,
                         input.TargetAssemblyMvid,
                         artifactMap,
                         input.Defines,

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/RemovedMemberCollector.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/RemovedMemberCollector.cs
@@ -22,7 +22,7 @@ internal static class RemovedMemberCollector
         CompilationUnitSyntax plainRoot,
         List<TypeEmitState> typeEmitStates,
         SemanticModel semanticModel,
-        IAssemblySymbol targetTypesAssemblySymbol,
+        WorkerTypeHome home,
         AddedMethodCatalog addedMethodCatalog,
         AddedFieldCatalog addedFieldCatalog,
         List<WorkerRemovedMember> removedMembers,
@@ -41,7 +41,7 @@ internal static class RemovedMemberCollector
         CollectRemovedMethodSignaturesForDeletedNames(
             typeEmitStates,
             semanticModel,
-            targetTypesAssemblySymbol,
+            home,
             removedMembers,
             removedMethodSignatures);
         Dictionary<string, VariableDeclaratorSyntax> snapshotFieldMap =
@@ -98,7 +98,7 @@ internal static class RemovedMemberCollector
     internal static void CollectRemovedMethodSignaturesForDeletedNames(
         List<TypeEmitState> typeEmitStates,
         SemanticModel semanticModel,
-        IAssemblySymbol targetTypesAssemblySymbol,
+        WorkerTypeHome home,
         List<WorkerRemovedMember> removedMembers,
         List<WorkerRemovedMethodSignature> removedMethodSignatures)
     {
@@ -125,7 +125,7 @@ internal static class RemovedMemberCollector
                 continue;
             }
 
-            INamedTypeSymbol compiledType = CompiledMemberMatcher.FindCompiledType(typeState.TypeSymbol, targetTypesAssemblySymbol);
+            INamedTypeSymbol compiledType = home.FindCompiledType(typeState.TypeSymbol);
             if (compiledType == null)
             {
                 continue;

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/SiblingConstDriftCollector.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/SiblingConstDriftCollector.cs
@@ -18,12 +18,12 @@ internal static class SiblingConstDriftCollector
         string[] changedSiblingSourcePaths,
         CSharpParseOptions parseOptions,
         IReadOnlyList<MetadataReference> references,
-        IAssemblySymbol targetTypesAssemblySymbol)
+        WorkerTypeHome home)
     {
         List<string> warnings = new List<string>();
         if (changedSiblingSourcePaths == null
             || changedSiblingSourcePaths.Length == 0
-            || targetTypesAssemblySymbol == null)
+            || home.AssemblySymbol == null)
         {
             return warnings;
         }
@@ -50,7 +50,7 @@ internal static class SiblingConstDriftCollector
                 ConstDriftCollector.CollectConstDriftWarnings(
                     root,
                     semanticModel,
-                    targetTypesAssemblySymbol));
+                    home));
         }
 
         return warnings;

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TypeEmitPlanner.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/TypeEmitPlanner.cs
@@ -19,7 +19,7 @@ internal static class TypeEmitPlanner
 {
     internal static List<TypeEmitState> QueueAllTypeEmitStates(
             WorkerSourceUnit sourceUnit,
-            IAssemblySymbol targetTypesAssemblySymbol,
+            WorkerTypeHome home,
             WorkerInput input,
             List<UsingDirectiveSyntax> assemblyGlobalUsings,
             List<ShimTypeBuilder> shimTypes,
@@ -57,7 +57,7 @@ internal static class TypeEmitPlanner
             AddedPropertyClassifier.ClassifyAddedProperties(
                 typeState,
                 semanticModel,
-                targetTypesAssemblySymbol,
+                home,
                 input,
                 baseline,
                 root,
@@ -111,7 +111,7 @@ internal static class TypeEmitPlanner
             QueueTypeMethods(
                 typeState,
                 semanticModel,
-                targetTypesAssemblySymbol,
+                home,
                 input,
                 baseline.HasBaseline,
                 baseline.SnapshotMethodMap,
@@ -136,7 +136,7 @@ internal static class TypeEmitPlanner
     internal static void QueueTypeMethods(
         TypeEmitState typeState,
         SemanticModel semanticModel,
-        IAssemblySymbol targetTypesAssemblySymbol,
+        WorkerTypeHome home,
         WorkerInput input,
         bool hasBaseline,
         Dictionary<string, MethodDeclarationSyntax> snapshotMethodMap,
@@ -153,7 +153,7 @@ internal static class TypeEmitPlanner
         List<WorkerRemovedMethodSignature> removedMethodSignatures,
         ShimNameAllocator shimNames)
     {
-        INamedTypeSymbol compiledType = CompiledMemberMatcher.FindCompiledType(typeState.TypeSymbol, targetTypesAssemblySymbol);
+        INamedTypeSymbol compiledType = home.FindCompiledType(typeState.TypeSymbol);
         if (compiledType == null)
         {
             OrdinaryMethodQueue.SkipAllMethodsOnUncompiledType(typeState, semanticModel, skipped, addedMethodCatalog);
@@ -166,7 +166,7 @@ internal static class TypeEmitPlanner
             typeState,
             semanticModel,
             compiledType,
-            targetTypesAssemblySymbol,
+            home,
             addedFieldCatalog,
             declarationDriftWarnings);
 

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/WorkerGroupPipeline.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/WorkerGroupPipeline.cs
@@ -98,9 +98,9 @@ internal static class WorkerGroupPipeline
             unit.SemanticModel = compilation.GetSemanticModel(unit.BindingSyntaxTree, ignoreAccessibility: true);
         }
 
-        IAssemblySymbol targetTypesAssemblySymbol = ResolveTargetTypesAssemblySymbol(
-            compilation,
-            targetTypesReference);
+        WorkerTypeHome home = new WorkerTypeHome(
+            input.TargetAssemblyName,
+            ResolveTargetTypesAssemblySymbol(compilation, targetTypesReference));
         List<CompilationUnitSyntax> editedRoots = new List<CompilationUnitSyntax>(transformUnits.Count);
         foreach (WorkerSourceUnit transformUnit in transformUnits)
         {
@@ -113,7 +113,7 @@ internal static class WorkerGroupPipeline
             input.ChangedSiblingSourcePaths,
             parseOptions,
             references,
-            targetTypesAssemblySymbol);
+            home);
 
         List<WorkerEntry> entries = new List<WorkerEntry>();
         List<WorkerSkipped> skipped = new List<WorkerSkipped>();
@@ -129,7 +129,7 @@ internal static class WorkerGroupPipeline
                 unit,
                 input,
                 parseOptions,
-                targetTypesAssemblySymbol,
+                home,
                 assemblyGlobalUsings,
                 shimTypes,
                 addedMethodCatalog,
@@ -147,7 +147,7 @@ internal static class WorkerGroupPipeline
                 unit.PlainRoot,
                 unit.TypeEmitStates,
                 unit.SemanticModel,
-                targetTypesAssemblySymbol,
+                home,
                 addedMethodCatalog,
                 addedFieldCatalog,
                 unit.RemovedMembers,
@@ -340,7 +340,7 @@ internal static class WorkerGroupPipeline
         WorkerSourceUnit unit,
         WorkerInput input,
         CSharpParseOptions parseOptions,
-        IAssemblySymbol targetTypesAssemblySymbol,
+        WorkerTypeHome home,
         List<UsingDirectiveSyntax> assemblyGlobalUsings,
         List<ShimTypeBuilder> shimTypes,
         AddedMethodCatalog addedMethodCatalog,
@@ -354,14 +354,14 @@ internal static class WorkerGroupPipeline
             ConstDriftCollector.CollectConstDriftWarnings(
                 unit.BindingRoot,
                 unit.SemanticModel,
-                targetTypesAssemblySymbol));
+                home));
         // Why here: a compiled property/event can disappear or change kind with no
         // touched body, so the generic outside-body warning would bury the name.
         unit.KindChangeSyntaxKeys =
             CompiledMemberKindChangeWarnings.AppendCompiledPropertyOrEventKindChangeWarnings(
                 unit.BindingRoot,
                 unit.SemanticModel,
-                targetTypesAssemblySymbol,
+                home,
                 unit.DeclarationDriftWarnings);
         unit.Baseline = BaselineSnapshotBuilder.BuildBaselineSnapshotState(
             unit.Input.SnapshotSource,
@@ -370,7 +370,7 @@ internal static class WorkerGroupPipeline
 
         List<TypeEmitState> typeEmitStates = TypeEmitPlanner.QueueAllTypeEmitStates(
             unit,
-            targetTypesAssemblySymbol,
+            home,
             input,
             assemblyGlobalUsings,
             shimTypes,

--- a/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/WorkerTypeHome.cs
+++ b/Packages/src/Editor/FirstPartyTools/HotReload/TransformWorker~/WorkerTypeHome.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Collections.Immutable;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Runtime.Loader;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Text;
+
+/// <summary>
+/// Where the patch target's already-compiled types live for one worker run: the assembly the
+/// request named, and the symbol that assembly binds to. Every query for "does the target
+/// already hold this type" goes through here, so the answer comes from one place instead of
+/// each classifier holding its own assembly symbol.
+///
+/// Why not search the retained artifact assemblies here as well: IntroducedTypePlanner treats
+/// a found compiled type as "already exists" and stops planning that declaration. If a lookup
+/// also saw the artifacts, a changed introduced type would be found in its own previous
+/// artifact and never reach the fingerprint comparison, so the "Changed introduced type
+/// requires a compile" diagnostic would disappear. Artifacts are indexed separately by
+/// IntroducedTypeArtifactMap.
+///
+/// Which callers take this instead of a bare IAssemblySymbol: the ones that look a compiled
+/// type up in the target. Code that only compares assembly identity or feeds a symbol into a
+/// fingerprint keeps taking IAssemblySymbol, because it needs no lookup and treats a missing
+/// target assembly as an ordinary case.
+/// </summary>
+internal sealed class WorkerTypeHome
+{
+    internal WorkerTypeHome(string assemblyName, IAssemblySymbol assemblySymbol)
+    {
+        AssemblyName = assemblyName;
+        AssemblySymbol = assemblySymbol;
+    }
+
+    internal string AssemblyName { get; }
+
+    // Null when the run could not read the target assembly; every lookup then finds nothing,
+    // which is what the callers' "not compiled yet" branches already expect.
+    internal IAssemblySymbol AssemblySymbol { get; }
+
+    /// <summary>
+    /// The compiled counterpart of a source type, or null when this home does not hold it.
+    /// </summary>
+    internal INamedTypeSymbol FindCompiledType(INamedTypeSymbol sourceType)
+    {
+        if (sourceType == null)
+        {
+            return null;
+        }
+
+        return FindCompiledTypeByMetadataName(ConstDriftCollector.ToReflectionMetadataName(sourceType));
+    }
+
+    /// <summary>
+    /// The compiled type this home holds under a reflection metadata name, or null when it
+    /// holds none. The name must already be in reflection form (nested types joined by '+').
+    /// </summary>
+    internal INamedTypeSymbol FindCompiledTypeByMetadataName(string reflectionMetadataName)
+    {
+        if (AssemblySymbol == null)
+        {
+            return null;
+        }
+
+        return AssemblySymbol.GetTypeByMetadataName(reflectionMetadataName);
+    }
+}


### PR DESCRIPTION
## Summary
- No user-visible change. Internal refactor of the hot-reload transform worker.

## User Impact
- None. Hot reload classifies, plans and patches exactly as before; the same diagnostics are produced for the same inputs.

## Changes
- Add `WorkerTypeHome`, which bundles the patch target's assembly name and assembly symbol and owns the "does the target already hold this compiled type" lookup (`FindCompiledType`, `FindCompiledTypeByMetadataName`).
- Replace the `targetTypesAssemblySymbol` parameter with the home across the classifiers, collectors, planners and the group pipeline, and delete `CompiledMemberMatcher.FindCompiledType` now that the home owns that lookup.
- Fold `IntroducedTypePlanner.Plan`'s redundant target assembly name parameter into the home, which already carries it.
- The class comment records two boundaries: why the home deliberately does not search the retained introduced-type artifacts (a lookup that saw them would report a changed introduced type as already existing and silence the compile-required diagnostic), and why files that only compare assembly identity or feed a symbol into a fingerprint keep taking `IAssemblySymbol`.

## Verification
- `uloop compile` - `ErrorCount: 0`, `WarningCount: 0`.
- `uloop run-tests --filter-type regex --filter-value "TransformWorkerIntroducedTypeTests|HotReloadCrossFileE2ETests|HotReloadNewSourceMembershipTests|HotReloadUnpatchedMethodLineShiftWarningBuilderTests"` - 83/83 passed, 0 failed. This run rebuilt the worker binary (worker sources are hash-keyed), so it is also the worker's compile gate.
- `uloop hot-reload --status` and `uloop hot-reload --revert-all` responses diff empty against the pre-change baseline.
- `check-asmdef-policy` - no violation. `check-file-length --max-length 400` - no touched file gained SLOC (12 modified files: -13 SLOC total; the new file is 42 SLOC), and none crosses the 500 hard limit.
- Repository CI does not run on pull requests targeting the integration branch; the checks above were run locally instead. The full gate runs on the final pull request into the default branch.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2752?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

