### PR TITLE
feat(cli): compile-check compiles independent assemblies in parallel

### DIFF
--- a/.agents/skills/uloop-compile-check/SKILL.md
+++ b/.agents/skills/uloop-compile-check/SKILL.md
@@ -35,7 +35,7 @@ uloop compile-check --all --project-path /path/to/project
 
 By default it compiles the assemblies whose sources changed since the last Unity build, plus every
 assembly that references one of them. `--all` compiles every assembly in the build. Assemblies that do not depend on each other compile at
-the same time; `--jobs` caps how many run at once.
+the same time; `--jobs` caps how many run at once, and `--jobs 1` compiles them one after another.
 
 ## Parameters
 
@@ -43,7 +43,7 @@ the same time; `--jobs` caps how many run at once.
 |-----------|------|-------------|
 | `--all` | flag | Compile every assembly instead of only the changed ones and their dependents |
 | `--editor-version <version>` | string | Use this Unity Editor version's compiler instead of ProjectVersion.txt |
-| `--jobs <N>` | number | Compile up to N assemblies at once (default: half the CPUs) |
+| `--jobs <N>` | number | Compile up to N assemblies at once (default: half the CPUs, at least 1; `1` compiles sequentially) |
 | `--max-depth <N>` | number | Search depth when locating the project (default: 3, -1 for unlimited) |
 | `--project-path <path>` | string | Target another Unity project instead of the current directory |
 

--- a/.agents/skills/uloop-compile-check/SKILL.md
+++ b/.agents/skills/uloop-compile-check/SKILL.md
@@ -34,7 +34,8 @@ uloop compile-check --all --project-path /path/to/project
 ```
 
 By default it compiles the assemblies whose sources changed since the last Unity build, plus every
-assembly that references one of them. `--all` compiles every assembly in the build.
+assembly that references one of them. `--all` compiles every assembly in the build. Assemblies that do not depend on each other compile at
+the same time; `--jobs` caps how many run at once.
 
 ## Parameters
 
@@ -42,6 +43,7 @@ assembly that references one of them. `--all` compiles every assembly in the bui
 |-----------|------|-------------|
 | `--all` | flag | Compile every assembly instead of only the changed ones and their dependents |
 | `--editor-version <version>` | string | Use this Unity Editor version's compiler instead of ProjectVersion.txt |
+| `--jobs <N>` | number | Compile up to N assemblies at once (default: half the CPUs) |
 | `--max-depth <N>` | number | Search depth when locating the project (default: 3, -1 for unlimited) |
 | `--project-path <path>` | string | Target another Unity project instead of the current directory |
 

--- a/.claude/skills/uloop-compile-check/SKILL.md
+++ b/.claude/skills/uloop-compile-check/SKILL.md
@@ -35,7 +35,7 @@ uloop compile-check --all --project-path /path/to/project
 
 By default it compiles the assemblies whose sources changed since the last Unity build, plus every
 assembly that references one of them. `--all` compiles every assembly in the build. Assemblies that do not depend on each other compile at
-the same time; `--jobs` caps how many run at once.
+the same time; `--jobs` caps how many run at once, and `--jobs 1` compiles them one after another.
 
 ## Parameters
 
@@ -43,7 +43,7 @@ the same time; `--jobs` caps how many run at once.
 |-----------|------|-------------|
 | `--all` | flag | Compile every assembly instead of only the changed ones and their dependents |
 | `--editor-version <version>` | string | Use this Unity Editor version's compiler instead of ProjectVersion.txt |
-| `--jobs <N>` | number | Compile up to N assemblies at once (default: half the CPUs) |
+| `--jobs <N>` | number | Compile up to N assemblies at once (default: half the CPUs, at least 1; `1` compiles sequentially) |
 | `--max-depth <N>` | number | Search depth when locating the project (default: 3, -1 for unlimited) |
 | `--project-path <path>` | string | Target another Unity project instead of the current directory |
 

--- a/.claude/skills/uloop-compile-check/SKILL.md
+++ b/.claude/skills/uloop-compile-check/SKILL.md
@@ -34,7 +34,8 @@ uloop compile-check --all --project-path /path/to/project
 ```
 
 By default it compiles the assemblies whose sources changed since the last Unity build, plus every
-assembly that references one of them. `--all` compiles every assembly in the build.
+assembly that references one of them. `--all` compiles every assembly in the build. Assemblies that do not depend on each other compile at
+the same time; `--jobs` caps how many run at once.
 
 ## Parameters
 
@@ -42,6 +43,7 @@ assembly that references one of them. `--all` compiles every assembly in the bui
 |-----------|------|-------------|
 | `--all` | flag | Compile every assembly instead of only the changed ones and their dependents |
 | `--editor-version <version>` | string | Use this Unity Editor version's compiler instead of ProjectVersion.txt |
+| `--jobs <N>` | number | Compile up to N assemblies at once (default: half the CPUs) |
 | `--max-depth <N>` | number | Search depth when locating the project (default: 3, -1 for unlimited) |
 | `--project-path <path>` | string | Target another Unity project instead of the current directory |
 

--- a/Packages/src/Editor/CliOnlyTools~/CompileCheck/Skill/SKILL.md
+++ b/Packages/src/Editor/CliOnlyTools~/CompileCheck/Skill/SKILL.md
@@ -35,7 +35,7 @@ uloop compile-check --all --project-path /path/to/project
 
 By default it compiles the assemblies whose sources changed since the last Unity build, plus every
 assembly that references one of them. `--all` compiles every assembly in the build. Assemblies that do not depend on each other compile at
-the same time; `--jobs` caps how many run at once.
+the same time; `--jobs` caps how many run at once, and `--jobs 1` compiles them one after another.
 
 ## Parameters
 
@@ -43,7 +43,7 @@ the same time; `--jobs` caps how many run at once.
 |-----------|------|-------------|
 | `--all` | flag | Compile every assembly instead of only the changed ones and their dependents |
 | `--editor-version <version>` | string | Use this Unity Editor version's compiler instead of ProjectVersion.txt |
-| `--jobs <N>` | number | Compile up to N assemblies at once (default: half the CPUs) |
+| `--jobs <N>` | number | Compile up to N assemblies at once (default: half the CPUs, at least 1; `1` compiles sequentially) |
 | `--max-depth <N>` | number | Search depth when locating the project (default: 3, -1 for unlimited) |
 | `--project-path <path>` | string | Target another Unity project instead of the current directory |
 

--- a/Packages/src/Editor/CliOnlyTools~/CompileCheck/Skill/SKILL.md
+++ b/Packages/src/Editor/CliOnlyTools~/CompileCheck/Skill/SKILL.md
@@ -34,7 +34,8 @@ uloop compile-check --all --project-path /path/to/project
 ```
 
 By default it compiles the assemblies whose sources changed since the last Unity build, plus every
-assembly that references one of them. `--all` compiles every assembly in the build.
+assembly that references one of them. `--all` compiles every assembly in the build. Assemblies that do not depend on each other compile at
+the same time; `--jobs` caps how many run at once.
 
 ## Parameters
 
@@ -42,6 +43,7 @@ assembly that references one of them. `--all` compiles every assembly in the bui
 |-----------|------|-------------|
 | `--all` | flag | Compile every assembly instead of only the changed ones and their dependents |
 | `--editor-version <version>` | string | Use this Unity Editor version's compiler instead of ProjectVersion.txt |
+| `--jobs <N>` | number | Compile up to N assemblies at once (default: half the CPUs) |
 | `--max-depth <N>` | number | Search depth when locating the project (default: 3, -1 for unlimited) |
 | `--project-path <path>` | string | Target another Unity project instead of the current directory |
 

--- a/cli/dispatcher/internal/compilecheck/compiler.go
+++ b/cli/dispatcher/internal/compilecheck/compiler.go
@@ -62,14 +62,14 @@ type Compiler struct {
 }
 
 // CompileUnit compiles one assembly and reports the diagnostics csc produced for it.
+// Why a Compiler value is safe to share between the units running at the same time: it holds no
+// mutable state, and every file this touches - the outputs it removes and the response file it
+// writes - is named after the assembly, so no two units address the same path. The output directory
+// itself is created once by the caller, before any unit starts.
 func (c Compiler) CompileUnit(
 	ctx context.Context, plan BuildPlan, unit CompileUnit,
 ) (UnitResult, error) {
 	outputDirectoryPath := filepath.Join(c.ProjectRoot, plan.OutputDir)
-	if err := os.MkdirAll(outputDirectoryPath, outputDirPermissions); err != nil {
-		return UnitResult{}, fmt.Errorf("failed to create %s: %w", outputDirectoryPath, err)
-	}
-
 	// Why the previous run's outputs go first: csc writes nothing when it fails, so a leftover
 	// reference assembly from an earlier run would keep describing an assembly that no longer
 	// compiles, and every dependent would be checked against an API that is gone.

--- a/cli/dispatcher/internal/compilecheck/compiler_test.go
+++ b/cli/dispatcher/internal/compilecheck/compiler_test.go
@@ -47,6 +47,14 @@ func stubRunner(stdout string, exitCode int, captured *exec.Cmd) CommandRunner {
 	}
 }
 
+// makeOutputDirectory creates the directory the run's outputs land in, the way one run does once.
+func makeOutputDirectory(t *testing.T, projectRoot string, plan BuildPlan) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Join(projectRoot, plan.OutputDir), outputDirPermissions); err != nil {
+		t.Fatalf("failed to create the output directory: %v", err)
+	}
+}
+
 // compileSecondUnit runs the plan's referencing unit through a stubbed compiler.
 func compileSecondUnit(t *testing.T, stdout string, exitCode int) (string, UnitResult) {
 	t.Helper()
@@ -154,6 +162,8 @@ func TestCompileUnitFallsBackWhenTheRebuiltReferenceIsMissing(t *testing.T) {
 		Timeout:     time.Minute,
 		Run:         stubRunner("", 0, &captured),
 	}
+	// The output directory is created once per run, before any unit compiles.
+	makeOutputDirectory(t, projectRoot, plan)
 
 	if _, err := compiler.CompileUnit(context.Background(), plan, plan.Units[1]); err != nil {
 		t.Fatalf("expected the unit to compile, got error: %v", err)
@@ -257,6 +267,8 @@ func TestCompileUnitOmitsRefOutWhenTheAssemblyHasNone(t *testing.T) {
 		Timeout:     time.Minute,
 		Run:         stubRunner("", 0, &captured),
 	}
+	// The output directory is created once per run, before any unit compiles.
+	makeOutputDirectory(t, projectRoot, plan)
 
 	if _, err := compiler.CompileUnit(context.Background(), plan, plan.Units[0]); err != nil {
 		t.Fatalf("expected the unit to compile, got error: %v", err)

--- a/cli/dispatcher/internal/compilecheck/plan.go
+++ b/cli/dispatcher/internal/compilecheck/plan.go
@@ -18,6 +18,10 @@ type CompileUnit struct {
 	Assembly ResponseFile
 	Sources  []string
 	Reason   string // empty when the unit was selected by --all rather than by a change
+	// PlanReferences names the assemblies this one references that this run compiles too. It is
+	// what the scheduler waits for: a reference left out of the plan was not rebuilt, so its
+	// reference assembly from the last Unity build is already on disk and nothing has to wait.
+	PlanReferences []string
 }
 
 // BuildPlan is the ordered set of assemblies to compile for one run.
@@ -58,9 +62,10 @@ func BuildCompilePlan(projectRoot string, dagDir string, all bool) (BuildPlan, e
 	units := make([]CompileUnit, 0, len(order))
 	for _, name := range order {
 		units = append(units, CompileUnit{
-			Assembly: graph.byName[name],
-			Sources:  graph.sources[name],
-			Reason:   reasons[name],
+			Assembly:       graph.byName[name],
+			Sources:        graph.sources[name],
+			Reason:         reasons[name],
+			PlanReferences: selectedReferences(graph, reasons, name),
 		})
 	}
 
@@ -70,6 +75,20 @@ func BuildCompilePlan(projectRoot string, dagDir string, all bool) (BuildPlan, e
 		Units:     units,
 		Skipped:   len(graph.names) - len(units),
 	}, nil
+}
+
+// selectedReferences lists the assemblies one unit references that this run compiles as well.
+func selectedReferences(
+	graph assemblyGraph, reasons map[string]string, name string,
+) []string {
+	selected := []string{}
+	for _, reference := range graph.references[name] {
+		if _, compiled := reasons[reference]; compiled {
+			selected = append(selected, reference)
+		}
+	}
+
+	return selected
 }
 
 // loadAssemblyGraph parses every response file in the dag and links the assemblies to each other.

--- a/cli/dispatcher/internal/compilecheck/scheduler.go
+++ b/cli/dispatcher/internal/compilecheck/scheduler.go
@@ -1,0 +1,144 @@
+package compilecheck
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+)
+
+// unitCompletion is one finished compiler invocation, carrying the position it holds in the plan so
+// the results can be reported in the plan's order rather than in the order the units happened to
+// finish.
+type unitCompletion struct {
+	index  int
+	result UnitResult
+	err    error
+}
+
+// schedule is the readiness bookkeeping of one run: how many of a unit's references are still
+// missing, and which units are waiting on each one.
+type schedule struct {
+	pending    []int
+	dependents [][]int
+	ready      []int
+}
+
+// DefaultJobs is how many assemblies compile at once when the caller names no number.
+// Why half the cores: one csc process already uses two to three cores of its own, so filling the
+// machine with one process per core makes them fight for the same cores instead of finishing sooner.
+func DefaultJobs() int {
+	half := runtime.NumCPU() / 2
+	if half < 1 {
+		return 1
+	}
+
+	return half
+}
+
+// compileUnits compiles a plan's assemblies, starting each one as soon as the assemblies it
+// references have been compiled and keeping at most jobs of them running at a time.
+// Why the units cannot simply run in the plan's order all at once: a dependent reads the reference
+// assembly its reference writes, so starting it early would compile it against the previous run's
+// output or against nothing at all.
+func compileUnits(
+	ctx context.Context, compiler Compiler, plan BuildPlan, jobs int,
+) ([]UnitResult, error) {
+	if jobs < 1 {
+		jobs = 1
+	}
+	// Why the output directory is created once here rather than per unit: the units run at the same
+	// time, and every one of them would otherwise race to create the same directory.
+	outputDirectoryPath := filepath.Join(compiler.ProjectRoot, plan.OutputDir)
+	if err := os.MkdirAll(outputDirectoryPath, outputDirPermissions); err != nil {
+		return nil, fmt.Errorf("failed to create %s: %w", outputDirectoryPath, err)
+	}
+
+	runContext, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	state := newSchedule(plan)
+	results := make([]UnitResult, len(plan.Units))
+	completions := make(chan unitCompletion, len(plan.Units))
+	running := 0
+	var failure error
+
+	for {
+		for failure == nil && running < jobs && len(state.ready) > 0 {
+			index := state.ready[0]
+			state.ready = state.ready[1:]
+			running++
+			go func(index int) {
+				result, err := compiler.CompileUnit(runContext, plan, plan.Units[index])
+				completions <- unitCompletion{index: index, result: result, err: err}
+			}(index)
+		}
+		if running == 0 {
+			break
+		}
+
+		completion := <-completions
+		running--
+		// Why the first failure stops the run: it means the compiler itself could not be started,
+		// which every remaining unit would hit as well. Compile errors are not failures here - they
+		// arrive as diagnostics and the run continues so that one pass reports all of them.
+		if completion.err != nil {
+			if failure == nil {
+				failure = completion.err
+				cancel()
+			}
+
+			continue
+		}
+		results[completion.index] = completion.result
+		state.release(completion.index)
+	}
+
+	if failure != nil {
+		return nil, failure
+	}
+
+	return results, nil
+}
+
+// newSchedule counts what every unit is waiting for and queues the units waiting for nothing.
+func newSchedule(plan BuildPlan) *schedule {
+	indexByName := make(map[string]int, len(plan.Units))
+	for index, unit := range plan.Units {
+		indexByName[unit.Assembly.AssemblyName] = index
+	}
+
+	state := &schedule{
+		pending:    make([]int, len(plan.Units)),
+		dependents: make([][]int, len(plan.Units)),
+		ready:      []int{},
+	}
+	for index, unit := range plan.Units {
+		for _, reference := range unit.PlanReferences {
+			referenceIndex, compiled := indexByName[reference]
+			if !compiled {
+				continue
+			}
+			state.pending[index]++
+			state.dependents[referenceIndex] = append(state.dependents[referenceIndex], index)
+		}
+	}
+	for index := range plan.Units {
+		if state.pending[index] == 0 {
+			state.ready = append(state.ready, index)
+		}
+	}
+
+	return state
+}
+
+// release hands the units that were waiting on a finished one to the ready queue.
+func (state *schedule) release(index int) {
+	for _, dependent := range state.dependents[index] {
+		state.pending[dependent]--
+		if state.pending[dependent] == 0 {
+			state.ready = append(state.ready, dependent)
+		}
+	}
+}

--- a/cli/dispatcher/internal/compilecheck/scheduler_test.go
+++ b/cli/dispatcher/internal/compilecheck/scheduler_test.go
@@ -36,6 +36,7 @@ type schedulerRecorder struct {
 	failingUnit  string
 	running      int
 	maxRunning   int
+	started      map[string]bool
 	finished     map[string]bool
 	finishedWhen map[string][]string // unit -> the units already finished when it started
 }
@@ -45,6 +46,7 @@ func newSchedulerRecorder(hold time.Duration) *schedulerRecorder {
 	return &schedulerRecorder{
 		hold:         hold,
 		holdByUnit:   map[string]time.Duration{},
+		started:      map[string]bool{},
 		finished:     map[string]bool{},
 		finishedWhen: map[string][]string{},
 	}
@@ -55,6 +57,7 @@ func (recorder *schedulerRecorder) runner() CommandRunner {
 	return func(_ context.Context, cmd *exec.Cmd) (string, string, int, error) {
 		name := assemblyOfFakeCommand(cmd)
 		recorder.mutex.Lock()
+		recorder.started[name] = true
 		recorder.running++
 		if recorder.running > recorder.maxRunning {
 			recorder.maxRunning = recorder.running
@@ -178,6 +181,11 @@ func TestCompileUnitsStopsTheRunWhenTheCompilerCannotBeStarted(t *testing.T) {
 	}
 	if recorder.finished["C"] {
 		t.Error("a unit depending on the failed one should not have been compiled")
+	}
+	// Why B rather than C alone: C waits for A whatever the scheduler does, so only an independent
+	// unit shows that the failure stopped the run instead of merely blocking what depended on it.
+	if recorder.started["B"] {
+		t.Error("a unit independent of the failed one should not have been started")
 	}
 }
 

--- a/cli/dispatcher/internal/compilecheck/scheduler_test.go
+++ b/cli/dispatcher/internal/compilecheck/scheduler_test.go
@@ -1,0 +1,195 @@
+package compilecheck
+
+import (
+	"context"
+	"errors"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// newSchedulerPlan builds a plan of named units, each referencing the units named for it.
+func newSchedulerPlan(references map[string][]string, names ...string) BuildPlan {
+	units := make([]CompileUnit, 0, len(names))
+	for _, name := range names {
+		units = append(units, CompileUnit{
+			Assembly:       ResponseFile{AssemblyName: name},
+			PlanReferences: references[name],
+		})
+	}
+
+	return BuildPlan{
+		DagDir:    planDagDirectory,
+		OutputDir: filepath.Join("Library", "uloop", "compile-check", "aaaa.dag"),
+		Units:     units,
+	}
+}
+
+// schedulerRecorder stands in for csc: it reports what ran, when, and how much ran at once.
+type schedulerRecorder struct {
+	mutex        sync.Mutex
+	hold         time.Duration
+	holdByUnit   map[string]time.Duration
+	failingUnit  string
+	running      int
+	maxRunning   int
+	finished     map[string]bool
+	finishedWhen map[string][]string // unit -> the units already finished when it started
+}
+
+// newSchedulerRecorder prepares a recorder whose units each take the same time to compile.
+func newSchedulerRecorder(hold time.Duration) *schedulerRecorder {
+	return &schedulerRecorder{
+		hold:         hold,
+		holdByUnit:   map[string]time.Duration{},
+		finished:     map[string]bool{},
+		finishedWhen: map[string][]string{},
+	}
+}
+
+// runner reports the fake compiler invocation, recording concurrency and dependency order.
+func (recorder *schedulerRecorder) runner() CommandRunner {
+	return func(_ context.Context, cmd *exec.Cmd) (string, string, int, error) {
+		name := assemblyOfFakeCommand(cmd)
+		recorder.mutex.Lock()
+		recorder.running++
+		if recorder.running > recorder.maxRunning {
+			recorder.maxRunning = recorder.running
+		}
+		already := []string{}
+		for finishedName := range recorder.finished {
+			already = append(already, finishedName)
+		}
+		recorder.finishedWhen[name] = already
+		hold := recorder.hold
+		if unitHold, found := recorder.holdByUnit[name]; found {
+			hold = unitHold
+		}
+		failing := recorder.failingUnit == name
+		recorder.mutex.Unlock()
+
+		time.Sleep(hold)
+
+		recorder.mutex.Lock()
+		recorder.running--
+		recorder.finished[name] = true
+		recorder.mutex.Unlock()
+
+		if failing {
+			return "", "no compiler here", 0, errors.New("failed to start the compiler")
+		}
+
+		return "", "", 0, nil
+	}
+}
+
+// assemblyOfFakeCommand reads the assembly name out of the response file the invocation was given.
+func assemblyOfFakeCommand(cmd *exec.Cmd) string {
+	last := cmd.Args[len(cmd.Args)-1]
+
+	return strings.TrimSuffix(filepath.Base(strings.TrimPrefix(last, "@")), responseFileExtension)
+}
+
+// newSchedulerCompiler wires a compiler that runs the recorder instead of csc.
+func newSchedulerCompiler(t *testing.T, recorder *schedulerRecorder) Compiler {
+	t.Helper()
+
+	return Compiler{
+		Paths:       EditorCompilerPaths{DotnetHostPath: "/dotnet", CompilerDllPath: "/csc.dll"},
+		ProjectRoot: t.TempDir(),
+		Timeout:     time.Minute,
+		Run:         recorder.runner(),
+	}
+}
+
+// Verifies a unit waits for every assembly it references in the plan before it starts.
+func TestCompileUnitsStartsAUnitOnlyAfterItsReferencesFinished(t *testing.T) {
+	plan := newSchedulerPlan(
+		map[string][]string{"B": {"A"}, "C": {"B"}}, "A", "B", "C")
+	recorder := newSchedulerRecorder(10 * time.Millisecond)
+
+	if _, err := compileUnits(
+		context.Background(), newSchedulerCompiler(t, recorder), plan, 4); err != nil {
+		t.Fatalf("expected the chain to compile, got error: %v", err)
+	}
+
+	for _, unit := range []string{"B", "C"} {
+		for _, reference := range plan.Units[indexOfUnit(t, plan, unit)].PlanReferences {
+			if !containsName(recorder.finishedWhen[unit], reference) {
+				t.Errorf("%s started before %s finished", unit, reference)
+			}
+		}
+	}
+}
+
+// Verifies no more than the requested number of assemblies compile at the same time.
+func TestCompileUnitsRunsNoMoreThanTheRequestedNumberAtOnce(t *testing.T) {
+	plan := newSchedulerPlan(nil, "A", "B", "C", "D", "E")
+	recorder := newSchedulerRecorder(20 * time.Millisecond)
+
+	if _, err := compileUnits(
+		context.Background(), newSchedulerCompiler(t, recorder), plan, 2); err != nil {
+		t.Fatalf("expected the independent units to compile, got error: %v", err)
+	}
+
+	if recorder.maxRunning != 2 {
+		t.Errorf("at most 2 units should run at once and 2 should be reached, got %d",
+			recorder.maxRunning)
+	}
+}
+
+// Verifies the results keep the plan's order even when the units finish in another one.
+func TestCompileUnitsReturnsResultsInPlanOrder(t *testing.T) {
+	plan := newSchedulerPlan(nil, "A", "B", "C")
+	recorder := newSchedulerRecorder(0)
+	recorder.holdByUnit = map[string]time.Duration{
+		"A": 40 * time.Millisecond,
+		"B": 20 * time.Millisecond,
+	}
+
+	results, err := compileUnits(
+		context.Background(), newSchedulerCompiler(t, recorder), plan, 3)
+	if err != nil {
+		t.Fatalf("expected the independent units to compile, got error: %v", err)
+	}
+
+	compiled := []string{}
+	for _, result := range results {
+		compiled = append(compiled, result.Assembly)
+	}
+	assertStrings(t, "results", compiled, []string{"A", "B", "C"})
+}
+
+// Verifies a unit whose compiler cannot be started stops the run and reports that failure.
+func TestCompileUnitsStopsTheRunWhenTheCompilerCannotBeStarted(t *testing.T) {
+	plan := newSchedulerPlan(map[string][]string{"C": {"A"}}, "A", "B", "C")
+	recorder := newSchedulerRecorder(10 * time.Millisecond)
+	recorder.failingUnit = "A"
+
+	_, err := compileUnits(context.Background(), newSchedulerCompiler(t, recorder), plan, 1)
+	if err == nil {
+		t.Fatal("expected the failure to start the compiler to be reported")
+	}
+	if !strings.Contains(err.Error(), "A") {
+		t.Errorf("the error should name the assembly that failed, got: %v", err)
+	}
+	if recorder.finished["C"] {
+		t.Error("a unit depending on the failed one should not have been compiled")
+	}
+}
+
+// indexOfUnit finds one named unit in a plan.
+func indexOfUnit(t *testing.T, plan BuildPlan, name string) int {
+	t.Helper()
+	for index, unit := range plan.Units {
+		if unit.Assembly.AssemblyName == name {
+			return index
+		}
+	}
+	t.Fatalf("the plan has no unit named %s", name)
+
+	return -1
+}

--- a/cli/dispatcher/internal/compilecheck/session.go
+++ b/cli/dispatcher/internal/compilecheck/session.go
@@ -29,6 +29,7 @@ type Options struct {
 	ProjectRoot          string
 	EditorExecutablePath string
 	All                  bool
+	Jobs                 int // how many assemblies compile at once; 0 asks for the default
 }
 
 // Result is everything one compile-check run produced.
@@ -63,16 +64,14 @@ func Run(ctx context.Context, options Options) (Result, error) {
 		Run:         defaultRun,
 	}
 
-	units := make([]UnitResult, 0, len(plan.Units))
-	for _, unit := range plan.Units {
-		// Why the run continues after a failure: an assembly that failed leaves its dependents
-		// reading Unity's older reference assembly, which can add follow-on errors, but reporting
-		// every assembly's diagnostics in one pass is the point of the command.
-		result, compileErr := compiler.CompileUnit(ctx, plan, unit)
-		if compileErr != nil {
-			return Result{}, compileErr
-		}
-		units = append(units, result)
+	jobs := options.Jobs
+	if jobs < 1 {
+		jobs = DefaultJobs()
+	}
+
+	units, err := compileUnits(ctx, compiler, plan, jobs)
+	if err != nil {
+		return Result{}, err
 	}
 
 	return Result{

--- a/cli/dispatcher/internal/dispatcher/compile_check.go
+++ b/cli/dispatcher/internal/dispatcher/compile_check.go
@@ -20,6 +20,7 @@ const (
 	compileCheckAllFlag         = "--all"
 	compileCheckEditorFlag      = "--editor-version"
 	compileCheckMaxDepthFlag    = "--max-depth"
+	compileCheckJobsFlag        = "--jobs"
 )
 
 // compileCheckOptions are the command-line inputs of one compile-check run.
@@ -28,6 +29,7 @@ type compileCheckOptions struct {
 	all           bool
 	editorVersion string
 	maxDepth      int
+	jobs          int // how many assemblies compile at once; 0 leaves the choice to the compiler
 }
 
 // compileCheckIssue is one diagnostic in the response, shaped like the ones `uloop compile` returns.
@@ -109,6 +111,7 @@ func runCompileCheck(
 		ProjectRoot:          projectRoot,
 		EditorExecutablePath: editorPath,
 		All:                  options.all,
+		Jobs:                 options.jobs,
 	})
 	if err != nil {
 		clierrors.WriteClassifiedError(stderr, err, clierrors.ErrorContext{
@@ -227,6 +230,7 @@ func printCompileCheckHelp(stdout io.Writer) {
 	clicore.WriteLine(stdout, "      --all                Compile every assembly instead of only the changed ones")
 	clicore.WriteLine(stdout, "      --editor-version <version>")
 	clicore.WriteLine(stdout, "                           Use this Unity Editor version instead of ProjectVersion.txt")
+	clicore.WriteLine(stdout, "      --jobs <n>           Compile up to n assemblies at once (default: half the CPUs)")
 	clicore.WriteLine(stdout, "      --max-depth <n>      Max directory depth when auto-searching for the project (default: 3, -1 = unlimited)")
 	clicore.WriteLine(stdout, "      --project-path <path>")
 	clicore.WriteLine(stdout, "                           Compile this project instead of searching from the working directory")
@@ -267,6 +271,8 @@ func applyCompileCheckOption(options *compileCheckOptions, args []string, index 
 		return applyCompileCheckEditorVersion(options, args, index)
 	case isCompileCheckKeyedOption(arg, compileCheckMaxDepthFlag):
 		return applyCompileCheckMaxDepth(options, args, index)
+	case isCompileCheckKeyedOption(arg, compileCheckJobsFlag):
+		return applyCompileCheckJobs(options, args, index)
 	default:
 		return index, unknownCompileCheckOptionError(arg)
 	}
@@ -301,6 +307,21 @@ func applyCompileCheckMaxDepth(options *compileCheckOptions, args []string, inde
 		return index, clierrors.InvalidValueArgumentError(compileCheckMaxDepthFlag, value, "integer >= -1")
 	}
 	options.maxDepth = maxDepth
+
+	return nextLaunchOptionIndex(index, consumed), nil
+}
+
+// applyCompileCheckJobs reads how many assemblies may compile at the same time.
+func applyCompileCheckJobs(options *compileCheckOptions, args []string, index int) (int, error) {
+	value, consumed, err := readLaunchOptionValue(args[index], args, index)
+	if err != nil {
+		return index, err
+	}
+	jobs, convertErr := strconv.Atoi(value)
+	if convertErr != nil || jobs < 1 {
+		return index, clierrors.InvalidValueArgumentError(compileCheckJobsFlag, value, "integer >= 1")
+	}
+	options.jobs = jobs
 
 	return nextLaunchOptionIndex(index, consumed), nil
 }

--- a/cli/dispatcher/internal/dispatcher/compile_check.go
+++ b/cli/dispatcher/internal/dispatcher/compile_check.go
@@ -230,7 +230,7 @@ func printCompileCheckHelp(stdout io.Writer) {
 	clicore.WriteLine(stdout, "      --all                Compile every assembly instead of only the changed ones")
 	clicore.WriteLine(stdout, "      --editor-version <version>")
 	clicore.WriteLine(stdout, "                           Use this Unity Editor version instead of ProjectVersion.txt")
-	clicore.WriteLine(stdout, "      --jobs <n>           Compile up to n assemblies at once (default: half the CPUs)")
+	clicore.WriteLine(stdout, "      --jobs <n>           Compile up to n assemblies at once, 1 = sequential (default: half the CPUs, at least 1)")
 	clicore.WriteLine(stdout, "      --max-depth <n>      Max directory depth when auto-searching for the project (default: 3, -1 = unlimited)")
 	clicore.WriteLine(stdout, "      --project-path <path>")
 	clicore.WriteLine(stdout, "                           Compile this project instead of searching from the working directory")

--- a/cli/dispatcher/internal/dispatcher/compile_check_test.go
+++ b/cli/dispatcher/internal/dispatcher/compile_check_test.go
@@ -24,12 +24,15 @@ func TestParseCompileCheckOptionsDefaultsToTheChangedScope(t *testing.T) {
 	if options.maxDepth != defaultProjectSearchDepth {
 		t.Fatalf("expected the default search depth, got %d", options.maxDepth)
 	}
+	if options.jobs != 0 {
+		t.Fatalf("expected the compiler default to decide the job count, got %d", options.jobs)
+	}
 }
 
 // Verifies that every supported option is read, in both the spaced and the equals form.
 func TestParseCompileCheckOptionsReadsEverySupportedOption(t *testing.T) {
 	options, err := parseCompileCheckOptions(
-		[]string{"--all", "--editor-version", "6000.0.1f1", "--max-depth=-1"}, "")
+		[]string{"--all", "--editor-version", "6000.0.1f1", "--max-depth=-1", "--jobs", "4"}, "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -41,6 +44,28 @@ func TestParseCompileCheckOptionsReadsEverySupportedOption(t *testing.T) {
 	}
 	if options.maxDepth != -1 {
 		t.Fatalf("expected an unlimited search depth, got %d", options.maxDepth)
+	}
+	if options.jobs != 4 {
+		t.Fatalf("expected the requested job count, got %d", options.jobs)
+	}
+}
+
+// Verifies that a job count below one is rejected, since it would compile nothing.
+func TestParseCompileCheckOptionsRejectsAJobCountBelowOne(t *testing.T) {
+	_, err := parseCompileCheckOptions([]string{"--jobs", "0"}, "")
+	if err == nil {
+		t.Fatalf("expected a job count below one to be rejected")
+	}
+	if !strings.Contains(err.Error(), compileCheckJobsFlag) {
+		t.Fatalf("expected the rejected option to be named, got %q", err.Error())
+	}
+}
+
+// Verifies that a job count that is not a number is rejected instead of silently becoming zero.
+func TestParseCompileCheckOptionsRejectsANonNumericJobCount(t *testing.T) {
+	_, err := parseCompileCheckOptions([]string{"--jobs=many"}, "")
+	if err == nil {
+		t.Fatalf("expected a non-numeric job count to be rejected")
 	}
 }
 

--- a/docs/compile-check.md
+++ b/docs/compile-check.md
@@ -43,7 +43,12 @@ references, scripting defines and analyzers. `compile-check` replays those respo
    reference that was added to one, invalidate the recorded build. The run then stops with
    `COMPILE_CHECK_UNITY_BUILD_REQUIRED` rather than reporting diagnostics for a configuration the
    project no longer has.
-5. **Compile in dependency order** and parse the compiler's diagnostics into JSON.
+5. **Compile in dependency order** and parse the compiler's diagnostics into JSON. An assembly starts
+   as soon as every assembly it references that this run also compiles has finished, so independent
+   assemblies compile at the same time. `--jobs <n>` caps how many run at once; the default is half
+   the machine's CPUs, because one `csc` process already keeps two to three cores busy on its own.
+   The reported order does not depend on the job count: results are collected in dependency order
+   whatever finishes first.
 
 Files and directories Unity ignores — any name starting with a dot or ending with a tilde, which
 covers the `._*` AppleDouble siblings macOS writes on non-native volumes — are skipped everywhere
@@ -58,6 +63,9 @@ definitions were deleted.
 
 The compiled DLLs land in `Library/uloop/compile-check/<dag>/` and are never handed to Unity. The
 directory is disposable; deleting it only costs the next run some time.
+
+`--jobs <n>` bounds how many assemblies compile at the same time; the default is half the machine's
+CPUs, and `--jobs 1` compiles them one after another.
 
 The command prints a JSON payload with `Success`, `ErrorCount`, `WarningCount`, `Errors`,
 `Warnings` (each diagnostic carrying `Message`, `Code`, `File`, `Line`, `Column`, `Assembly`),

--- a/docs/compile-check.md
+++ b/docs/compile-check.md
@@ -46,7 +46,8 @@ references, scripting defines and analyzers. `compile-check` replays those respo
 5. **Compile in dependency order** and parse the compiler's diagnostics into JSON. An assembly starts
    as soon as every assembly it references that this run also compiles has finished, so independent
    assemblies compile at the same time. `--jobs <n>` caps how many run at once; the default is half
-   the machine's CPUs, because one `csc` process already keeps two to three cores busy on its own.
+   the machine's CPUs and never less than one, because one `csc` process already keeps two to three
+   cores busy on its own. `--jobs 1` compiles the assemblies one after another.
    The reported order does not depend on the job count: results are collected in dependency order
    whatever finishes first.
 
@@ -65,7 +66,7 @@ The compiled DLLs land in `Library/uloop/compile-check/<dag>/` and are never han
 directory is disposable; deleting it only costs the next run some time.
 
 `--jobs <n>` bounds how many assemblies compile at the same time; the default is half the machine's
-CPUs, and `--jobs 1` compiles them one after another.
+CPUs and never less than one, and `--jobs 1` compiles them one after another.
 
 The command prints a JSON payload with `Success`, `ErrorCount`, `WarningCount`, `Errors`,
 `Warnings` (each diagnostic carrying `Message`, `Code`, `File`, `Line`, `Column`, `Assembly`),


### PR DESCRIPTION
## What

`compile-check` replayed the response files one assembly at a time. A scheduler now starts a unit as soon as every assembly it references *that this run also compiles* has finished, so independent assemblies compile at the same time.

- `CompileUnit` gained `PlanReferences`: the references the plan itself rebuilds. A reference left out of the plan was not rebuilt, so its reference assembly from the last Unity build is already on disk and nothing has to wait for it.
- New `--jobs <n>` caps how many run at once. The default is `max(1, NumCPU/2)`, because one `csc` process already keeps two to three cores busy on its own. `n < 1` is a usage error.
- Results are collected into `plan.Units` order whatever finishes first, so the reported `CompiledAssemblies` does not depend on the job count.
- The first launch failure cancels the remaining units. Compile *errors* are diagnostics, not failures, so they do not stop the run.
- The output directory is created once before any unit starts; units would otherwise race to create the same path.

## Verification

`go test -race ./internal/compilecheck/`, `scripts/check-go-cli.sh`, the complexity lint, the file-length checker and `check-skill-size` are all green. `sync-tool-docs --check` reports no drift: `compile-check` is a dispatcher-owned Go command and has no entry in the embedded tool catalog, so this changes no release input and needs no `stamp-release-inputs.sh` run.

Four mutations were each caught by exactly one scheduler test: removing the job limit, ignoring `PlanReferences`, writing a result to the wrong slot, and ignoring a launch failure.

End to end on this checkout (16 CPUs, `--all`, cold output directory each time):

| run | wall time | CPU | result |
|---|---|---|---|
| `--jobs 1` | 57.9 s | 191 % | 104 assemblies, 0 errors, 7 warnings |
| default (8 jobs) | 14.1 s | 826 % | 104 assemblies, 0 errors, 7 warnings |

`CompiledAssemblies` is identical between the two runs.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2753?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

