### PR TITLE
perf(cli): compile-check runs csc through the Roslyn compiler server

### DIFF
--- a/cli/dispatcher/internal/compilecheck/compiler.go
+++ b/cli/dispatcher/internal/compilecheck/compiler.go
@@ -17,9 +17,14 @@ const (
 	severityError   = "error"
 	severityWarning = "warning"
 
-	compilerExecArgument      = "exec"
-	compilerNoStdLibFlag      = "/nostdlib"
-	compilerNoConfigFlag      = "/noconfig"
+	compilerExecArgument = "exec"
+	compilerNoStdLibFlag = "/nostdlib"
+	compilerNoConfigFlag = "/noconfig"
+	// compilerSharedFlag connects csc to the Roslyn compiler server, which is how Unity's Bee starts
+	// it too. Compiling several assemblies in a row then reuses the server's JIT-compiled code and its
+	// cached reference metadata instead of paying for both once per assembly. When csc cannot reach
+	// the server it compiles in its own process, so this changes speed and nothing else.
+	compilerSharedFlag        = "/shared"
 	compilerLibraryTargetFlag = "-target:library"
 	multiLevelLookupSetting   = "DOTNET_MULTILEVEL_LOOKUP=0"
 
@@ -66,6 +71,8 @@ type Compiler struct {
 // mutable state, and every file this touches - the outputs it removes and the response file it
 // writes - is named after the assembly, so no two units address the same path. The output directory
 // itself is created once by the caller, before any unit starts.
+// A VBCSCompiler process may outlive the run: the compiler server stays up for a while so the next
+// invocation can reuse it, exactly as it does after a build Unity runs itself.
 func (c Compiler) CompileUnit(
 	ctx context.Context, plan BuildPlan, unit CompileUnit,
 ) (UnitResult, error) {
@@ -87,7 +94,7 @@ func (c Compiler) CompileUnit(
 
 	command := exec.CommandContext(invocationContext,
 		c.Paths.DotnetHostPath, compilerExecArgument, c.Paths.CompilerDllPath,
-		compilerNoStdLibFlag, compilerNoConfigFlag, "@"+responseFilePath)
+		compilerNoStdLibFlag, compilerNoConfigFlag, compilerSharedFlag, "@"+responseFilePath)
 	command.Dir = c.ProjectRoot
 	command.Env = append(os.Environ(), multiLevelLookupSetting)
 

--- a/cli/dispatcher/internal/compilecheck/compiler_test.go
+++ b/cli/dispatcher/internal/compilecheck/compiler_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -280,5 +281,32 @@ func TestCompileUnitOmitsRefOutWhenTheAssemblyHasNone(t *testing.T) {
 	}
 	if strings.Contains(string(written), referenceOutputFlagPref) {
 		t.Errorf("expected no -refout line, got:\n%s", written)
+	}
+}
+
+// Verifies csc is invoked with the whole argument list Unity's Bee uses, the compiler server flag
+// among them and in its place, since csc reads these positionally before the response file.
+func TestCompileUnitInvokesCscThroughTheCompilerServer(t *testing.T) {
+	projectRoot := t.TempDir()
+	plan := newCompilerPlan()
+	captured := exec.Cmd{}
+	compiler := Compiler{
+		Paths:       EditorCompilerPaths{DotnetHostPath: "/dotnet", CompilerDllPath: "/csc.dll"},
+		ProjectRoot: projectRoot,
+		Timeout:     time.Minute,
+		Run:         stubRunner("", 0, &captured),
+	}
+	makeOutputDirectory(t, projectRoot, plan)
+
+	if _, err := compiler.CompileUnit(context.Background(), plan, plan.Units[0]); err != nil {
+		t.Fatalf("expected the unit to compile, got error: %v", err)
+	}
+
+	expected := []string{
+		"/dotnet", "exec", "/csc.dll", "/nostdlib", "/noconfig", "/shared",
+		"@" + filepath.Join(projectRoot, plan.OutputDir, "A.rsp"),
+	}
+	if !slices.Equal(captured.Args, expected) {
+		t.Errorf("csc arguments = %v, want %v", captured.Args, expected)
 	}
 }

--- a/docs/compile-check.md
+++ b/docs/compile-check.md
@@ -22,7 +22,11 @@ references, scripting defines and analyzers. `compile-check` replays those respo
 2. **Find the compiler.** The Editor version comes from `ProjectVersion.txt` (or `--editor-version`),
    and the Editor install is located the same way `uloop launch` locates it. The compiler is the one
    bundled with that install: `csc.dll` under the Editor's Roslyn directory, run through the
-   `dotnet` host bundled beside it. Nothing is downloaded, and no system-wide .NET SDK is used.
+   `dotnet` host bundled beside it. Nothing is downloaded, and no system-wide .NET SDK is used. csc is
+   started through the Roslyn compiler server the way Unity's Bee starts it, so several assemblies in
+   a row reuse the server's JIT-compiled code and its cached reference metadata. The server process
+   stays up for a while after the run, exactly as it does after a build Unity ran itself; leave it
+   alone. When it cannot be reached, csc compiles in its own process and the result is the same.
 3. **Decide what to compile.** By default the run compiles the assemblies whose sources changed
    since the last Unity build, plus every assembly that references one of them. `--all` compiles
    every assembly in the build. Assemblies left out are counted in `SkippedAssemblies`. An


### PR DESCRIPTION
## What

csc is now started with `/shared`, the way Unity's Bee starts it: the invocation connects to the Roslyn compiler server (`VBCSCompiler.dll`, shipped beside the `csc.dll` the command already resolves) instead of paying to JIT-compile Roslyn and re-read the same reference metadata once per assembly.

- `/shared` sits between `/noconfig` and the response file, the position Bee uses; csc reads these positionally.
- Behaviour is unchanged: when the server cannot be reached, csc compiles in its own process. There is no option to turn it off — Unity always passes it, and the fallback removes any reason to.
- The server process stays up for a while after the run, exactly as it does after a build Unity ran itself. Documented, and deliberately not shut down or keepalive-tuned.

## Verification

`go test -race ./internal/compilecheck/` and `scripts/check-go-cli.sh` are green. The new test asserts the whole argument list rather than the presence of the flag; two mutations each fail it — dropping `/shared`, and swapping it with `/noconfig`.

End to end on this checkout (`--all`, output directory removed before the first run only):

| run | wall time | result |
|---|---|---|
| first (server cold) | 9.3 s | 104 assemblies, 0 errors, 7 warnings |
| second (server warm) | 6.1 s | 104 assemblies, 0 errors, 7 warnings |

`CompiledAssemblies` is identical to the PR-7 run (14.1 s on the same checkout, same 104 assemblies).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2754?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

