### PR TITLE
fix(cli): compile-check maps source paths the way Unity's Bee does

### DIFF
--- a/cli/dispatcher/internal/compilecheck/compiler.go
+++ b/cli/dispatcher/internal/compilecheck/compiler.go
@@ -252,6 +252,13 @@ func writeRewrittenResponseFile(
 	if rsp.AdditionalFile != "" {
 		lines = append(lines, quoteFlag(additionalFileFlagPrefix, rsp.AdditionalFile))
 	}
+	// Why Bee's second response file is replayed here: it carries flags that decide what the compiled
+	// assembly contains - a /pathmap that maps the project root away, so a source path an attribute
+	// bakes into metadata comes out relative - and Bee writes it per assembly, with nothing in it for
+	// some of them. Passing back exactly what it wrote is what makes this check's output match Unity's
+	// own; synthesizing the flag instead would be wrong for every assembly Bee left it out of. The
+	// diagnostics are untouched: csc prints the paths the response file lists, already project-relative.
+	lines = append(lines, rsp.CompanionFlags...)
 
 	path := filepath.Join(projectRoot, plan.OutputDir, rsp.AssemblyName+responseFileExtension)
 	if err := os.WriteFile(path, []byte(strings.Join(lines, "\n")), responseFilePermissions); err != nil {

--- a/cli/dispatcher/internal/compilecheck/compiler_test.go
+++ b/cli/dispatcher/internal/compilecheck/compiler_test.go
@@ -310,3 +310,56 @@ func TestCompileUnitInvokesCscThroughTheCompilerServer(t *testing.T) {
 		t.Errorf("csc arguments = %v, want %v", captured.Args, expected)
 	}
 }
+
+// compileUnitForCompanionFlags compiles the first unit with the given second-response-file flags and
+// returns the lines of the response file the compiler wrote for it.
+func compileUnitForCompanionFlags(t *testing.T, companionFlags []string) []string {
+	t.Helper()
+	projectRoot := t.TempDir()
+	plan := newCompilerPlan()
+	plan.Units[0].Assembly.CompanionFlags = companionFlags
+	captured := exec.Cmd{}
+	compiler := Compiler{
+		Paths:       EditorCompilerPaths{DotnetHostPath: "/dotnet", CompilerDllPath: "/csc.dll"},
+		ProjectRoot: projectRoot,
+		Timeout:     time.Minute,
+		Run:         stubRunner("", 0, &captured),
+	}
+	makeOutputDirectory(t, projectRoot, plan)
+
+	if _, err := compiler.CompileUnit(context.Background(), plan, plan.Units[0]); err != nil {
+		t.Fatalf("expected the unit to compile, got error: %v", err)
+	}
+
+	written, err := os.ReadFile(filepath.Join(projectRoot, plan.OutputDir, "A.rsp"))
+	if err != nil {
+		t.Fatalf("failed to read the rewritten response file: %v", err)
+	}
+
+	return strings.Split(string(written), "\n")
+}
+
+// Verifies a flag Bee wrote in the second response file is replayed as a whole line, so an assembly
+// whose attributes bake source paths into metadata produces what Unity's own build produces. The
+// whole line is compared: a mapping csc reads differently is not the same mapping.
+func TestCompileUnitReplaysTheCompanionFlags(t *testing.T) {
+	companionLine := `/pathmap:"/projects/Sample"=.`
+
+	lines := compileUnitForCompanionFlags(t, []string{companionLine})
+
+	if !slices.Contains(lines, companionLine) {
+		t.Errorf("the rewritten response file is missing the line %q\ngot:\n%s", companionLine, strings.Join(lines, "\n"))
+	}
+}
+
+// Verifies nothing is added when Bee wrote no second-response-file flags: Unity builds those
+// assemblies without a mapping, and adding one would make the output differ from Unity's.
+func TestCompileUnitAddsNoFlagsWhenThereAreNoCompanionFlags(t *testing.T) {
+	lines := compileUnitForCompanionFlags(t, nil)
+
+	for _, line := range lines {
+		if strings.HasPrefix(line, "/pathmap:") {
+			t.Errorf("the rewritten response file should carry no mapping, got the line %q", line)
+		}
+	}
+}

--- a/cli/dispatcher/internal/compilecheck/response_file.go
+++ b/cli/dispatcher/internal/compilecheck/response_file.go
@@ -9,6 +9,7 @@ import (
 
 const (
 	responseFileExtension      = ".rsp"
+	companionFileExtension     = ".rsp2"
 	referenceAssemblyExtension = ".ref.dll"
 
 	outputFlagPrefix         = "-out:"
@@ -31,6 +32,9 @@ type ResponseFile struct {
 	Sources        []string // unquoted, relative to the project root
 	AdditionalFile string   // /additionalfile value
 	OtherFlags     []string // every other flag line, verbatim
+	// CompanionFlags are the lines of the second response file Bee hands csc beside this one, kept
+	// verbatim and nil when that file is missing or empty.
+	CompanionFlags []string
 }
 
 // ParseResponseFile reads one Bee response file into its parts.
@@ -61,7 +65,41 @@ func ParseResponseFile(path string) (ResponseFile, error) {
 		return ResponseFile{}, fmt.Errorf("response file %s lists no source files", path)
 	}
 
+	companionFlags, err := readCompanionFlags(path)
+	if err != nil {
+		return ResponseFile{}, err
+	}
+	parsed.CompanionFlags = companionFlags
+
 	return parsed, nil
+}
+
+// readCompanionFlags reads the flags of the second response file Bee writes beside a response file.
+// Why they are copied rather than interpreted: Bee decides per assembly what goes in there - a
+// /pathmap that maps the project root away for some, nothing at all for others - and replaying
+// exactly what it wrote is what makes a source path an attribute bakes into metadata, which is what
+// [CallerFilePath] does, come out the way Unity's own build wrote it. A build that wrote no such
+// file is not an error: there is simply nothing extra to pass.
+func readCompanionFlags(responseFilePath string) ([]string, error) {
+	path := strings.TrimSuffix(responseFilePath, responseFileExtension) + companionFileExtension
+	content, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response file %s: %w", path, err)
+	}
+
+	var flags []string
+	for _, rawLine := range strings.Split(string(content), "\n") {
+		line := strings.TrimSpace(strings.TrimRight(rawLine, "\r"))
+		if line == "" {
+			continue
+		}
+		flags = append(flags, line)
+	}
+
+	return flags, nil
 }
 
 // appendLine sorts one response file line into the field it belongs to.

--- a/cli/dispatcher/internal/compilecheck/response_file_test.go
+++ b/cli/dispatcher/internal/compilecheck/response_file_test.go
@@ -151,3 +151,55 @@ func TestParseResponseFileRequiresSources(t *testing.T) {
 		t.Fatal("expected a response file without sources to fail the parse")
 	}
 }
+
+// writeCompanionResponseFile writes the .rsp2 Bee places beside the given response file.
+func writeCompanionResponseFile(t *testing.T, responseFilePath string, content string) {
+	t.Helper()
+	path := strings.TrimSuffix(responseFilePath, ".rsp") + ".rsp2"
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("failed to write the companion response file: %v", err)
+	}
+}
+
+// Verifies the flags Bee wrote in the second response file are carried over verbatim, including a
+// file that ends without a newline, which is how Bee writes it.
+func TestParseResponseFileReadsTheCompanionFlags(t *testing.T) {
+	path := writeResponseFile(t, sampleResponseFileLines(), "\n")
+	companionLine := `/pathmap:"/projects/Sample"=.`
+	writeCompanionResponseFile(t, path, companionLine)
+
+	parsed, err := ParseResponseFile(path)
+	if err != nil {
+		t.Fatalf("expected the sample to parse, got error: %v", err)
+	}
+
+	assertStrings(t, "companion flags", parsed.CompanionFlags, []string{companionLine})
+}
+
+// Verifies an empty second response file leaves no flags behind, since Bee writes an empty one for
+// every assembly it builds without the extra flags.
+func TestParseResponseFileAcceptsAnEmptyCompanionFile(t *testing.T) {
+	path := writeResponseFile(t, sampleResponseFileLines(), "\n")
+	writeCompanionResponseFile(t, path, "")
+
+	parsed, err := ParseResponseFile(path)
+	if err != nil {
+		t.Fatalf("expected the sample to parse, got error: %v", err)
+	}
+
+	if parsed.CompanionFlags != nil {
+		t.Errorf("companion flags = %v, want none", parsed.CompanionFlags)
+	}
+}
+
+// Verifies a missing second response file is not an error: an older build may not have written one.
+func TestParseResponseFileAcceptsAMissingCompanionFile(t *testing.T) {
+	parsed, err := ParseResponseFile(writeResponseFile(t, sampleResponseFileLines(), "\n"))
+	if err != nil {
+		t.Fatalf("expected the sample to parse, got error: %v", err)
+	}
+
+	if parsed.CompanionFlags != nil {
+		t.Errorf("companion flags = %v, want none", parsed.CompanionFlags)
+	}
+}

--- a/docs/compile-check.md
+++ b/docs/compile-check.md
@@ -18,7 +18,11 @@ references, scripting defines and analyzers. `compile-check` replays those respo
    opened; that is the authoritative answer. When the log is unreadable and the project has exactly
    one dag directory, that one is used. When there are two (a debug and a release dag) the choice
    falls back to `m_ScriptDebugInfoEnabled` in `Library/EditorOnlyScriptingSettings.json`. If none of
-   these can decide, the run stops with `COMPILE_CHECK_UNITY_BUILD_REQUIRED`.
+   these can decide, the run stops with `COMPILE_CHECK_UNITY_BUILD_REQUIRED`. Beside each `.rsp` Bee
+   writes a second response file, `.rsp2`, carrying a `/pathmap` that maps the project root to `.` —
+   empty for the assemblies that compile sources from `Assets`. The check replays whatever it finds
+   there, verbatim, so an assembly whose attributes bake source paths into metadata produces the same
+   output here as it does in Unity's own build.
 2. **Find the compiler.** The Editor version comes from `ProjectVersion.txt` (or `--editor-version`),
    and the Editor install is located the same way `uloop launch` locates it. The compiler is the one
    bundled with that install: `csc.dll` under the Editor's Roslyn directory, run through the


### PR DESCRIPTION
## Why

Unity's Bee starts csc with two response files: `dotnet exec csc.dll /nostdlib /noconfig /shared @X.rsp @X.rsp2`. The second one carries a `/pathmap` that maps the project root to `.`, so a source path an attribute bakes into metadata — what `[CallerFilePath]` does — comes out relative to the project instead of absolute.

Bee writes that file per assembly, and leaves it **empty** for the assemblies that compile sources from `Assets`: those are built without any mapping on purpose. `compile-check` replayed only the `.rsp`, so every assembly that bakes source paths into metadata produced an assembly that differed from Unity's own — which is what the planned "skip a dependent whose reference assembly is unchanged" optimisation compares.

## What

- `ParseResponseFile` reads the sibling `<AssemblyName>.rsp2` and keeps its non-empty lines in `ResponseFile.CompanionFlags` (nil when the file is missing or empty; missing is not an error, an unreadable file is).
- `writeRewrittenResponseFile` appends those lines verbatim after `-additionalfile`.
- The lines are **not** interpreted: no `/pathmap`-specific parsing, and the rule deciding when Bee writes one is not encoded here. Whatever Bee wrote for an assembly is what this check passes back, so a change on Bee's side is followed automatically.
- Diagnostics are unaffected: csc prints the paths the response file lists, which are already project-relative.

An earlier revision of this PR synthesised the `/pathmap` line for every assembly. Verification on a 569-assembly project showed that to be wrong for the 124 assemblies whose `.rsp2` is empty, so it was replaced by replaying the file.

## Tests

- `response_file_test.go`: a `.rsp2` with one line (no trailing newline) → that line in `CompanionFlags`; an empty `.rsp2` → nil; no `.rsp2` → nil and no error.
- `compiler_test.go`: a companion flag is written to the rewritten response file as a whole line (compared whole, not as a substring); with no companion flags, the response file carries no `/pathmap` line at all — the test that fails if the synthesised line comes back.

## Verification

- `cd cli/dispatcher && go test -race ./internal/compilecheck/` → ok
- `scripts/check-go-cli.sh` → exit 0
- This repository, `uloop compile-check --all`: `Success: true`, `ErrorCount: 0`, `WarningCount: 7`, 104 compiled assemblies — the same set as before this change, in 7.7 s.
- Byte-comparing `.ref.dll` against Unity's own build on a large external project is done by the reviewer.
