### PR TITLE
perf(cli): compile-check skips dependents whose references kept the same public surface

### DIFF
--- a/.agents/skills/uloop-compile-check/SKILL.md
+++ b/.agents/skills/uloop-compile-check/SKILL.md
@@ -55,7 +55,7 @@ A JSON payload:
 - `ErrorCount`, `WarningCount`: totals across every compiled assembly
 - `Errors`, `Warnings`: each with `Message`, `Code`, `File`, `Line`, `Column`, `Assembly`
 - `CompiledAssemblies`: the assemblies this run compiled, in dependency order
-- `SkippedAssemblies`: how many assemblies were left out because nothing they compile from changed
+- `SkippedAssemblies`: how many assemblies were left out: nothing they compile from changed, or every assembly they reference kept the same public surface
 - `ResponseFileSet`: the Bee build the run replayed
 - `ProjectRoot`: resolved project root
 - `Message`: one-line summary

--- a/.claude/skills/uloop-compile-check/SKILL.md
+++ b/.claude/skills/uloop-compile-check/SKILL.md
@@ -55,7 +55,7 @@ A JSON payload:
 - `ErrorCount`, `WarningCount`: totals across every compiled assembly
 - `Errors`, `Warnings`: each with `Message`, `Code`, `File`, `Line`, `Column`, `Assembly`
 - `CompiledAssemblies`: the assemblies this run compiled, in dependency order
-- `SkippedAssemblies`: how many assemblies were left out because nothing they compile from changed
+- `SkippedAssemblies`: how many assemblies were left out: nothing they compile from changed, or every assembly they reference kept the same public surface
 - `ResponseFileSet`: the Bee build the run replayed
 - `ProjectRoot`: resolved project root
 - `Message`: one-line summary

--- a/Packages/src/Editor/CliOnlyTools~/CompileCheck/Skill/SKILL.md
+++ b/Packages/src/Editor/CliOnlyTools~/CompileCheck/Skill/SKILL.md
@@ -55,7 +55,7 @@ A JSON payload:
 - `ErrorCount`, `WarningCount`: totals across every compiled assembly
 - `Errors`, `Warnings`: each with `Message`, `Code`, `File`, `Line`, `Column`, `Assembly`
 - `CompiledAssemblies`: the assemblies this run compiled, in dependency order
-- `SkippedAssemblies`: how many assemblies were left out because nothing they compile from changed
+- `SkippedAssemblies`: how many assemblies were left out: nothing they compile from changed, or every assembly they reference kept the same public surface
 - `ResponseFileSet`: the Bee build the run replayed
 - `ProjectRoot`: resolved project root
 - `Message`: one-line summary

--- a/cli/dispatcher/internal/compilecheck/plan.go
+++ b/cli/dispatcher/internal/compilecheck/plan.go
@@ -18,6 +18,10 @@ type CompileUnit struct {
 	Assembly ResponseFile
 	Sources  []string
 	Reason   string // empty when the unit was selected by --all rather than by a change
+	// SelectedAsDependent marks a unit picked up only because an assembly it references changed:
+	// nothing it compiles from was edited. It is false for a unit whose own sources changed and for
+	// every unit of an --all run.
+	SelectedAsDependent bool
 	// PlanReferences names the assemblies this one references that this run compiles too. It is
 	// what the scheduler waits for: a reference left out of the plan was not rebuilt, so its
 	// reference assembly from the last Unity build is already on disk and nothing has to wait.
@@ -62,10 +66,11 @@ func BuildCompilePlan(projectRoot string, dagDir string, all bool) (BuildPlan, e
 	units := make([]CompileUnit, 0, len(order))
 	for _, name := range order {
 		units = append(units, CompileUnit{
-			Assembly:       graph.byName[name],
-			Sources:        graph.sources[name],
-			Reason:         reasons[name],
-			PlanReferences: selectedReferences(graph, reasons, name),
+			Assembly:            graph.byName[name],
+			Sources:             graph.sources[name],
+			Reason:              reasons[name],
+			SelectedAsDependent: strings.HasPrefix(reasons[name], dependencyReasonPrefix),
+			PlanReferences:      selectedReferences(graph, reasons, name),
 		})
 	}
 

--- a/cli/dispatcher/internal/compilecheck/plan_test.go
+++ b/cli/dispatcher/internal/compilecheck/plan_test.go
@@ -277,3 +277,67 @@ func TestBuildCompilePlanRejectsARemovedAssemblyDefinition(t *testing.T) {
 		t.Fatal("expected a removed assembly definition to be refused")
 	}
 }
+
+// selectedAsDependentByName maps every unit of a plan to whether it was selected only through a reference.
+func selectedAsDependentByName(plan BuildPlan) map[string]bool {
+	flags := map[string]bool{}
+	for _, unit := range plan.Units {
+		flags[unit.Assembly.AssemblyName] = unit.SelectedAsDependent
+	}
+
+	return flags
+}
+
+// assertSelectedAsDependent checks the dependent-only mark of every unit the plan compiles.
+func assertSelectedAsDependent(t *testing.T, plan BuildPlan, want map[string]bool) {
+	t.Helper()
+	got := selectedAsDependentByName(plan)
+	if len(got) != len(want) {
+		t.Fatalf("plan compiles %v, want the assemblies %v", unitNames(plan), want)
+	}
+	for name, expected := range want {
+		if got[name] != expected {
+			t.Errorf("%s selected as dependent = %t, want %t", name, got[name], expected)
+		}
+	}
+}
+
+// Verifies an assembly whose own sources changed is never marked as selected through a reference,
+// even when it also references another assembly this run compiles.
+func TestBuildCompilePlanMarksAChangedDependentAsChanged(t *testing.T) {
+	projectRoot := newPlanProject(t)
+	touchSource(t, projectRoot, "A")
+	touchSource(t, projectRoot, "B")
+
+	plan, err := BuildCompilePlan(projectRoot, planDagDirectory, false)
+	if err != nil {
+		t.Fatalf("expected a plan, got error: %v", err)
+	}
+
+	assertSelectedAsDependent(t, plan, map[string]bool{"A": false, "B": false, "C": true})
+}
+
+// Verifies the assemblies pulled in only because they reference a changed one are marked as such.
+func TestBuildCompilePlanMarksTheAssembliesSelectedThroughAReference(t *testing.T) {
+	projectRoot := newPlanProject(t)
+	touchSource(t, projectRoot, "A")
+
+	plan, err := BuildCompilePlan(projectRoot, planDagDirectory, false)
+	if err != nil {
+		t.Fatalf("expected a plan, got error: %v", err)
+	}
+
+	assertSelectedAsDependent(t, plan, map[string]bool{"A": false, "B": true, "C": true})
+}
+
+// Verifies --all marks nothing as dependent-only, so no unit of such a run can ever be skipped.
+func TestBuildCompilePlanMarksNothingAsDependentWhenCompilingEverything(t *testing.T) {
+	projectRoot := newPlanProject(t)
+
+	plan, err := BuildCompilePlan(projectRoot, planDagDirectory, true)
+	if err != nil {
+		t.Fatalf("expected a plan, got error: %v", err)
+	}
+
+	assertSelectedAsDependent(t, plan, map[string]bool{"A": false, "B": false, "C": false})
+}

--- a/cli/dispatcher/internal/compilecheck/reference_surface.go
+++ b/cli/dispatcher/internal/compilecheck/reference_surface.go
@@ -1,0 +1,35 @@
+package compilecheck
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+)
+
+// referenceSurfaceUnchanged reports whether compiling this unit produced the very reference assembly
+// the last Unity build produced for it, which means the change it carries does not reach its public
+// surface: every assembly that references it would compile against exactly the same API.
+// Why the comparison is against Unity's own artifact rather than this check's previous output: the
+// dependents were last compiled against Unity's, so only that one answers whether they would see
+// anything new. Comparing against the previous run would only say the surface has not moved since
+// that run, and would hide an error a dependent has been carrying all along.
+// Why anything unreadable counts as changed: an assembly that failed to compile writes no reference
+// assembly at all, and compiling a dependent that did not need it costs time, while skipping one
+// that did costs a missed error.
+func referenceSurfaceUnchanged(projectRoot string, plan BuildPlan, unit CompileUnit) bool {
+	if unit.Assembly.RefOutputPath == "" {
+		return false
+	}
+
+	produced, err := os.ReadFile(
+		filepath.Join(projectRoot, plan.OutputDir, filepath.Base(unit.Assembly.RefOutputPath)))
+	if err != nil {
+		return false
+	}
+	fromUnityBuild, err := os.ReadFile(filepath.Join(projectRoot, unit.Assembly.RefOutputPath))
+	if err != nil {
+		return false
+	}
+
+	return bytes.Equal(produced, fromUnityBuild)
+}

--- a/cli/dispatcher/internal/compilecheck/reference_surface_test.go
+++ b/cli/dispatcher/internal/compilecheck/reference_surface_test.go
@@ -1,0 +1,91 @@
+package compilecheck
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// newReferenceSurfaceProject builds a project whose plan compiles one assembly with a reference
+// assembly, and returns the project root together with that plan and unit.
+func newReferenceSurfaceProject(t *testing.T, refOutputPath string) (string, BuildPlan, CompileUnit) {
+	t.Helper()
+	projectRoot := t.TempDir()
+	plan := BuildPlan{
+		DagDir:    planDagDirectory,
+		OutputDir: filepath.Join("Library", "uloop", "compile-check", "aaaa.dag"),
+	}
+	unit := CompileUnit{Assembly: ResponseFile{AssemblyName: "A", RefOutputPath: refOutputPath}}
+	plan.Units = []CompileUnit{unit}
+	for _, directory := range []string{plan.OutputDir, planDagDirectory} {
+		if err := os.MkdirAll(filepath.Join(projectRoot, directory), outputDirPermissions); err != nil {
+			t.Fatalf("failed to create %s: %v", directory, err)
+		}
+	}
+
+	return projectRoot, plan, unit
+}
+
+// writeReferenceAssembly writes one reference assembly with the given bytes.
+func writeReferenceAssembly(t *testing.T, path string, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("failed to write %s: %v", path, err)
+	}
+}
+
+// Verifies a reference assembly identical to the one the last Unity build produced counts as an
+// unchanged public surface, which is what lets a dependent be left out of the run.
+func TestReferenceSurfaceUnchangedAcceptsIdenticalReferenceAssemblies(t *testing.T) {
+	unityPath := filepath.Join(planDagDirectory, "A.ref.dll")
+	projectRoot, plan, unit := newReferenceSurfaceProject(t, unityPath)
+	writeReferenceAssembly(t, filepath.Join(projectRoot, unityPath), "surface")
+	writeReferenceAssembly(t, filepath.Join(projectRoot, plan.OutputDir, "A.ref.dll"), "surface")
+
+	if !referenceSurfaceUnchanged(projectRoot, plan, unit) {
+		t.Error("identical reference assemblies should count as an unchanged surface")
+	}
+}
+
+// Verifies a single differing byte counts as a changed surface, so the dependents are compiled.
+func TestReferenceSurfaceUnchangedRejectsDifferingReferenceAssemblies(t *testing.T) {
+	unityPath := filepath.Join(planDagDirectory, "A.ref.dll")
+	projectRoot, plan, unit := newReferenceSurfaceProject(t, unityPath)
+	writeReferenceAssembly(t, filepath.Join(projectRoot, unityPath), "surface")
+	writeReferenceAssembly(t, filepath.Join(projectRoot, plan.OutputDir, "A.ref.dll"), "surfacf")
+
+	if referenceSurfaceUnchanged(projectRoot, plan, unit) {
+		t.Error("reference assemblies differing by one byte should count as a changed surface")
+	}
+}
+
+// Verifies a missing output - which is what a failed compile leaves behind - counts as changed.
+func TestReferenceSurfaceUnchangedRejectsAMissingOutput(t *testing.T) {
+	unityPath := filepath.Join(planDagDirectory, "A.ref.dll")
+	projectRoot, plan, unit := newReferenceSurfaceProject(t, unityPath)
+	writeReferenceAssembly(t, filepath.Join(projectRoot, unityPath), "surface")
+
+	if referenceSurfaceUnchanged(projectRoot, plan, unit) {
+		t.Error("a reference assembly this run did not produce should count as a changed surface")
+	}
+}
+
+// Verifies a missing Unity-side reference assembly counts as changed rather than as a match.
+func TestReferenceSurfaceUnchangedRejectsAMissingUnityOutput(t *testing.T) {
+	unityPath := filepath.Join(planDagDirectory, "A.ref.dll")
+	projectRoot, plan, unit := newReferenceSurfaceProject(t, unityPath)
+	writeReferenceAssembly(t, filepath.Join(projectRoot, plan.OutputDir, "A.ref.dll"), "surface")
+
+	if referenceSurfaceUnchanged(projectRoot, plan, unit) {
+		t.Error("a missing Unity reference assembly should count as a changed surface")
+	}
+}
+
+// Verifies an assembly built without a reference assembly has nothing to compare and counts as changed.
+func TestReferenceSurfaceUnchangedRejectsAnAssemblyWithoutAReferenceAssembly(t *testing.T) {
+	projectRoot, plan, unit := newReferenceSurfaceProject(t, "")
+
+	if referenceSurfaceUnchanged(projectRoot, plan, unit) {
+		t.Error("an assembly with no reference assembly should count as a changed surface")
+	}
+}

--- a/cli/dispatcher/internal/compilecheck/scheduler.go
+++ b/cli/dispatcher/internal/compilecheck/scheduler.go
@@ -14,7 +14,10 @@ import (
 type unitCompletion struct {
 	index  int
 	result UnitResult
-	err    error
+	// changed says whether this unit's reference assembly came out different from the one the last
+	// Unity build produced, which is what decides whether its dependents still have to compile.
+	changed bool
+	err     error
 }
 
 // schedule is the readiness bookkeeping of one run: how many of a unit's references are still
@@ -23,6 +26,9 @@ type schedule struct {
 	pending    []int
 	dependents [][]int
 	ready      []int
+	// changedInputs counts, per unit, how many of the references it waited for came out with a
+	// different public surface than the last Unity build recorded.
+	changedInputs []int
 }
 
 // DefaultJobs is how many assemblies compile at once when the caller names no number.
@@ -37,14 +43,30 @@ func DefaultJobs() int {
 	return half
 }
 
+// schedulerRun is the state of one run of the scheduler: what is running, what has finished, and
+// what was left out because nothing it compiles against changed.
+type schedulerRun struct {
+	runContext          context.Context
+	compiler            Compiler
+	plan                BuildPlan
+	outputDirectoryPath string
+	state               *schedule
+	results             []UnitResult
+	compiled            []bool
+	completions         chan unitCompletion
+	running             int
+	referenceSkips      int
+}
+
 // compileUnits compiles a plan's assemblies, starting each one as soon as the assemblies it
-// references have been compiled and keeping at most jobs of them running at a time.
+// references have been compiled and keeping at most jobs of them running at a time. It reports the
+// results of the units it compiled, in the plan's order, and how many it left out.
 // Why the units cannot simply run in the plan's order all at once: a dependent reads the reference
 // assembly its reference writes, so starting it early would compile it against the previous run's
 // output or against nothing at all.
 func compileUnits(
 	ctx context.Context, compiler Compiler, plan BuildPlan, jobs int,
-) ([]UnitResult, error) {
+) ([]UnitResult, int, error) {
 	if jobs < 1 {
 		jobs = 1
 	}
@@ -52,54 +74,127 @@ func compileUnits(
 	// time, and every one of them would otherwise race to create the same directory.
 	outputDirectoryPath := filepath.Join(compiler.ProjectRoot, plan.OutputDir)
 	if err := os.MkdirAll(outputDirectoryPath, outputDirPermissions); err != nil {
-		return nil, fmt.Errorf("failed to create %s: %w", outputDirectoryPath, err)
+		return nil, 0, fmt.Errorf("failed to create %s: %w", outputDirectoryPath, err)
 	}
 
 	runContext, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	state := newSchedule(plan)
-	results := make([]UnitResult, len(plan.Units))
-	completions := make(chan unitCompletion, len(plan.Units))
-	running := 0
+	run := &schedulerRun{
+		runContext:          runContext,
+		compiler:            compiler,
+		plan:                plan,
+		outputDirectoryPath: outputDirectoryPath,
+		state:               newSchedule(plan),
+		results:             make([]UnitResult, len(plan.Units)),
+		compiled:            make([]bool, len(plan.Units)),
+		completions:         make(chan unitCompletion, len(plan.Units)),
+	}
+
 	var failure error
-
 	for {
-		for failure == nil && running < jobs && len(state.ready) > 0 {
-			index := state.ready[0]
-			state.ready = state.ready[1:]
-			running++
-			go func(index int) {
-				result, err := compiler.CompileUnit(runContext, plan, plan.Units[index])
-				completions <- unitCompletion{index: index, result: result, err: err}
-			}(index)
-		}
-		if running == 0 {
-			break
-		}
-
-		completion := <-completions
-		running--
-		// Why the first failure stops the run: it means the compiler itself could not be started,
-		// which every remaining unit would hit as well. Compile errors are not failures here - they
-		// arrive as diagnostics and the run continues so that one pass reports all of them.
-		if completion.err != nil {
-			if failure == nil {
-				failure = completion.err
+		if failure == nil {
+			if err := run.startReadyUnits(jobs); err != nil {
+				failure = err
 				cancel()
 			}
-
-			continue
 		}
-		results[completion.index] = completion.result
-		state.release(completion.index)
+		if run.running == 0 {
+			break
+		}
+		if err := run.collectOneCompletion(); err != nil && failure == nil {
+			failure = err
+			cancel()
+		}
 	}
 
 	if failure != nil {
-		return nil, failure
+		return nil, 0, failure
 	}
 
-	return results, nil
+	return run.compiledResults(), run.referenceSkips, nil
+}
+
+// startReadyUnits launches the units whose references are all done, up to the job limit, skipping
+// the ones that have nothing left to learn from compiling.
+func (run *schedulerRun) startReadyUnits(jobs int) error {
+	for run.running < jobs && len(run.state.ready) > 0 {
+		index := run.state.ready[0]
+		run.state.ready = run.state.ready[1:]
+		skipped, err := run.skipUnchangedDependent(index)
+		if err != nil {
+			return err
+		}
+		if skipped {
+			continue
+		}
+		run.running++
+		go run.compileOneUnit(index)
+	}
+
+	return nil
+}
+
+// skipUnchangedDependent leaves out a unit this run picked up only because something it references
+// was recompiled, when every one of those came out with the public surface the last Unity build
+// recorded: compiling it would read exactly the API it was last compiled against.
+// Why its earlier outputs are removed rather than left alone: a reference assembly an earlier run
+// wrote would otherwise be picked up as this run's own output, and the units below it would be
+// compiled against a result this run never produced.
+func (run *schedulerRun) skipUnchangedDependent(index int) (bool, error) {
+	unit := run.plan.Units[index]
+	if !unit.SelectedAsDependent || run.state.changedInputs[index] != 0 {
+		return false, nil
+	}
+	if err := removeUnitOutputs(run.outputDirectoryPath, unit); err != nil {
+		return false, err
+	}
+	run.referenceSkips++
+	run.state.release(index, false)
+
+	return true, nil
+}
+
+// compileOneUnit compiles one unit and reports what it produced, including whether its public
+// surface moved. Why the comparison happens here rather than in the loop: it reads two files, and
+// the loop has to stay free to start the next unit.
+func (run *schedulerRun) compileOneUnit(index int) {
+	unit := run.plan.Units[index]
+	result, err := run.compiler.CompileUnit(run.runContext, run.plan, unit)
+	changed := true
+	if err == nil {
+		changed = !referenceSurfaceUnchanged(run.compiler.ProjectRoot, run.plan, unit)
+	}
+	run.completions <- unitCompletion{index: index, result: result, changed: changed, err: err}
+}
+
+// collectOneCompletion waits for one unit to finish and hands what it produced to the schedule.
+// Why a failure stops the run: it means the compiler itself could not be started, which every
+// remaining unit would hit as well. Compile errors are not failures here - they arrive as
+// diagnostics and the run continues so that one pass reports all of them.
+func (run *schedulerRun) collectOneCompletion() error {
+	completion := <-run.completions
+	run.running--
+	if completion.err != nil {
+		return completion.err
+	}
+	run.results[completion.index] = completion.result
+	run.compiled[completion.index] = true
+	run.state.release(completion.index, completion.changed)
+
+	return nil
+}
+
+// compiledResults reports the units this run actually compiled, in the plan's order.
+func (run *schedulerRun) compiledResults() []UnitResult {
+	results := make([]UnitResult, 0, len(run.results))
+	for index, compiled := range run.compiled {
+		if compiled {
+			results = append(results, run.results[index])
+		}
+	}
+
+	return results
 }
 
 // newSchedule counts what every unit is waiting for and queues the units waiting for nothing.
@@ -110,9 +205,10 @@ func newSchedule(plan BuildPlan) *schedule {
 	}
 
 	state := &schedule{
-		pending:    make([]int, len(plan.Units)),
-		dependents: make([][]int, len(plan.Units)),
-		ready:      []int{},
+		pending:       make([]int, len(plan.Units)),
+		dependents:    make([][]int, len(plan.Units)),
+		ready:         []int{},
+		changedInputs: make([]int, len(plan.Units)),
 	}
 	for index, unit := range plan.Units {
 		for _, reference := range unit.PlanReferences {
@@ -133,10 +229,14 @@ func newSchedule(plan BuildPlan) *schedule {
 	return state
 }
 
-// release hands the units that were waiting on a finished one to the ready queue.
-func (state *schedule) release(index int) {
+// release hands the units that were waiting on a finished one to the ready queue, recording whether
+// what it produced still describes the same public surface as the last Unity build.
+func (state *schedule) release(index int, changed bool) {
 	for _, dependent := range state.dependents[index] {
 		state.pending[dependent]--
+		if changed {
+			state.changedInputs[dependent]++
+		}
 		if state.pending[dependent] == 0 {
 			state.ready = append(state.ready, dependent)
 		}

--- a/cli/dispatcher/internal/compilecheck/scheduler_test.go
+++ b/cli/dispatcher/internal/compilecheck/scheduler_test.go
@@ -3,6 +3,7 @@ package compilecheck
 import (
 	"context"
 	"errors"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -16,7 +17,10 @@ func newSchedulerPlan(references map[string][]string, names ...string) BuildPlan
 	units := make([]CompileUnit, 0, len(names))
 	for _, name := range names {
 		units = append(units, CompileUnit{
-			Assembly:       ResponseFile{AssemblyName: name},
+			Assembly: ResponseFile{
+				AssemblyName:  name,
+				RefOutputPath: filepath.Join(planDagDirectory, name+referenceAssemblyExtension),
+			},
 			PlanReferences: references[name],
 		})
 	}
@@ -30,14 +34,17 @@ func newSchedulerPlan(references map[string][]string, names ...string) BuildPlan
 
 // schedulerRecorder stands in for csc: it reports what ran, when, and how much ran at once.
 type schedulerRecorder struct {
-	mutex        sync.Mutex
-	hold         time.Duration
-	holdByUnit   map[string]time.Duration
-	failingUnit  string
-	running      int
-	maxRunning   int
-	started      map[string]bool
-	finished     map[string]bool
+	mutex       sync.Mutex
+	hold        time.Duration
+	holdByUnit  map[string]time.Duration
+	failingUnit string
+	running     int
+	maxRunning  int
+	started     map[string]bool
+	finished    map[string]bool
+	// surfaces holds, per unit, the bytes the fake compiler writes as that unit's reference
+	// assembly. A unit missing from it writes none, which is what a failed compile does.
+	surfaces     map[string]string
 	finishedWhen map[string][]string // unit -> the units already finished when it started
 }
 
@@ -47,6 +54,7 @@ func newSchedulerRecorder(hold time.Duration) *schedulerRecorder {
 		hold:         hold,
 		holdByUnit:   map[string]time.Duration{},
 		started:      map[string]bool{},
+		surfaces:     map[string]string{},
 		finished:     map[string]bool{},
 		finishedWhen: map[string][]string{},
 	}
@@ -76,6 +84,8 @@ func (recorder *schedulerRecorder) runner() CommandRunner {
 
 		time.Sleep(hold)
 
+		recorder.writeReferenceAssembly(cmd, name)
+
 		recorder.mutex.Lock()
 		recorder.running--
 		recorder.finished[name] = true
@@ -86,6 +96,23 @@ func (recorder *schedulerRecorder) runner() CommandRunner {
 		}
 
 		return "", "", 0, nil
+	}
+}
+
+// writeReferenceAssembly writes the reference assembly this fake invocation is set up to produce,
+// beside the response file it was given, which is where csc writes it too.
+func (recorder *schedulerRecorder) writeReferenceAssembly(cmd *exec.Cmd, name string) {
+	recorder.mutex.Lock()
+	surface, produces := recorder.surfaces[name]
+	recorder.mutex.Unlock()
+	if !produces {
+		return
+	}
+
+	last := cmd.Args[len(cmd.Args)-1]
+	path := filepath.Join(filepath.Dir(strings.TrimPrefix(last, "@")), name+referenceAssemblyExtension)
+	if err := os.WriteFile(path, []byte(surface), 0o600); err != nil {
+		panic(err)
 	}
 }
 
@@ -114,7 +141,7 @@ func TestCompileUnitsStartsAUnitOnlyAfterItsReferencesFinished(t *testing.T) {
 		map[string][]string{"B": {"A"}, "C": {"B"}}, "A", "B", "C")
 	recorder := newSchedulerRecorder(10 * time.Millisecond)
 
-	if _, err := compileUnits(
+	if _, _, err := compileUnits(
 		context.Background(), newSchedulerCompiler(t, recorder), plan, 4); err != nil {
 		t.Fatalf("expected the chain to compile, got error: %v", err)
 	}
@@ -133,7 +160,7 @@ func TestCompileUnitsRunsNoMoreThanTheRequestedNumberAtOnce(t *testing.T) {
 	plan := newSchedulerPlan(nil, "A", "B", "C", "D", "E")
 	recorder := newSchedulerRecorder(20 * time.Millisecond)
 
-	if _, err := compileUnits(
+	if _, _, err := compileUnits(
 		context.Background(), newSchedulerCompiler(t, recorder), plan, 2); err != nil {
 		t.Fatalf("expected the independent units to compile, got error: %v", err)
 	}
@@ -153,7 +180,7 @@ func TestCompileUnitsReturnsResultsInPlanOrder(t *testing.T) {
 		"B": 20 * time.Millisecond,
 	}
 
-	results, err := compileUnits(
+	results, _, err := compileUnits(
 		context.Background(), newSchedulerCompiler(t, recorder), plan, 3)
 	if err != nil {
 		t.Fatalf("expected the independent units to compile, got error: %v", err)
@@ -172,7 +199,7 @@ func TestCompileUnitsStopsTheRunWhenTheCompilerCannotBeStarted(t *testing.T) {
 	recorder := newSchedulerRecorder(10 * time.Millisecond)
 	recorder.failingUnit = "A"
 
-	_, err := compileUnits(context.Background(), newSchedulerCompiler(t, recorder), plan, 1)
+	_, _, err := compileUnits(context.Background(), newSchedulerCompiler(t, recorder), plan, 1)
 	if err == nil {
 		t.Fatal("expected the failure to start the compiler to be reported")
 	}
@@ -200,4 +227,178 @@ func indexOfUnit(t *testing.T, plan BuildPlan, name string) int {
 	t.Fatalf("the plan has no unit named %s", name)
 
 	return -1
+}
+
+// markSelectedAsDependent marks the named units as ones this run picked up only through a reference.
+func markSelectedAsDependent(t *testing.T, plan BuildPlan, names ...string) {
+	t.Helper()
+	for _, name := range names {
+		plan.Units[indexOfUnit(t, plan, name)].SelectedAsDependent = true
+	}
+}
+
+// writeUnityReferenceAssembly writes the reference assembly the last Unity build left for an assembly.
+func writeUnityReferenceAssembly(t *testing.T, projectRoot string, name string, surface string) {
+	t.Helper()
+	directory := filepath.Join(projectRoot, planDagDirectory)
+	if err := os.MkdirAll(directory, outputDirPermissions); err != nil {
+		t.Fatalf("failed to create the dag directory: %v", err)
+	}
+	path := filepath.Join(directory, name+referenceAssemblyExtension)
+	if err := os.WriteFile(path, []byte(surface), 0o600); err != nil {
+		t.Fatalf("failed to write %s: %v", path, err)
+	}
+}
+
+// compiledNames lists the assemblies a run reported results for, in the order it returned them.
+func compiledNames(results []UnitResult) []string {
+	names := make([]string, 0, len(results))
+	for _, result := range results {
+		names = append(names, result.Assembly)
+	}
+
+	return names
+}
+
+// Verifies a dependent is left out when the assembly it waited for came out byte-identical to the
+// one the last Unity build produced, and that the stale output of an earlier run is removed with it.
+func TestCompileUnitsSkipsADependentWhoseReferenceKeptItsSurface(t *testing.T) {
+	plan := newSchedulerPlan(map[string][]string{"B": {"A"}}, "A", "B")
+	markSelectedAsDependent(t, plan, "B")
+	recorder := newSchedulerRecorder(0)
+	recorder.surfaces["A"] = "surface"
+	recorder.surfaces["B"] = "b"
+	compiler := newSchedulerCompiler(t, recorder)
+	writeUnityReferenceAssembly(t, compiler.ProjectRoot, "A", "surface")
+	staleOutput := filepath.Join(
+		compiler.ProjectRoot, plan.OutputDir, "B"+referenceAssemblyExtension)
+	if err := os.MkdirAll(filepath.Dir(staleOutput), outputDirPermissions); err != nil {
+		t.Fatalf("failed to create the output directory: %v", err)
+	}
+	if err := os.WriteFile(staleOutput, []byte("stale"), 0o600); err != nil {
+		t.Fatalf("failed to write the stale output: %v", err)
+	}
+
+	results, skipped, err := compileUnits(context.Background(), compiler, plan, 2)
+	if err != nil {
+		t.Fatalf("expected the run to succeed, got error: %v", err)
+	}
+
+	assertStrings(t, "results", compiledNames(results), []string{"A"})
+	if skipped != 1 {
+		t.Errorf("reference skips = %d, want 1", skipped)
+	}
+	if recorder.started["B"] {
+		t.Error("a dependent whose reference kept its surface should not have been compiled")
+	}
+	if _, statErr := os.Stat(staleOutput); !os.IsNotExist(statErr) {
+		t.Error("the skipped unit's earlier output should have been removed")
+	}
+}
+
+// Verifies a dependent is compiled when its reference produced a different reference assembly.
+func TestCompileUnitsCompilesADependentWhoseReferenceChangedItsSurface(t *testing.T) {
+	plan := newSchedulerPlan(map[string][]string{"B": {"A"}}, "A", "B")
+	markSelectedAsDependent(t, plan, "B")
+	recorder := newSchedulerRecorder(0)
+	recorder.surfaces["A"] = "changed surface"
+	compiler := newSchedulerCompiler(t, recorder)
+	writeUnityReferenceAssembly(t, compiler.ProjectRoot, "A", "surface")
+
+	results, skipped, err := compileUnits(context.Background(), compiler, plan, 2)
+	if err != nil {
+		t.Fatalf("expected the run to succeed, got error: %v", err)
+	}
+
+	assertStrings(t, "results", compiledNames(results), []string{"A", "B"})
+	if skipped != 0 {
+		t.Errorf("reference skips = %d, want 0", skipped)
+	}
+}
+
+// Verifies the skip carries down the chain: a dependent left out changes nothing for its own
+// dependents, so they are left out too, which is what Unity's own build does.
+func TestCompileUnitsSkipsTheWholeChainBelowAnUnchangedSurface(t *testing.T) {
+	plan := newSchedulerPlan(map[string][]string{"B": {"A"}, "C": {"B"}}, "A", "B", "C")
+	markSelectedAsDependent(t, plan, "B", "C")
+	recorder := newSchedulerRecorder(0)
+	recorder.surfaces["A"] = "surface"
+	compiler := newSchedulerCompiler(t, recorder)
+	writeUnityReferenceAssembly(t, compiler.ProjectRoot, "A", "surface")
+
+	results, skipped, err := compileUnits(context.Background(), compiler, plan, 3)
+	if err != nil {
+		t.Fatalf("expected the run to succeed, got error: %v", err)
+	}
+
+	assertStrings(t, "results", compiledNames(results), []string{"A"})
+	if skipped != 2 {
+		t.Errorf("reference skips = %d, want 2", skipped)
+	}
+	if recorder.started["C"] {
+		t.Error("a unit below a skipped one should not have been compiled")
+	}
+}
+
+// Verifies an assembly asked for on its own - by --all, or because its own sources changed - is
+// compiled even when everything it references kept its surface.
+func TestCompileUnitsNeverSkipsAUnitThatWasNotSelectedThroughAReference(t *testing.T) {
+	plan := newSchedulerPlan(map[string][]string{"B": {"A"}}, "A", "B")
+	recorder := newSchedulerRecorder(0)
+	recorder.surfaces["A"] = "surface"
+	compiler := newSchedulerCompiler(t, recorder)
+	writeUnityReferenceAssembly(t, compiler.ProjectRoot, "A", "surface")
+
+	results, skipped, err := compileUnits(context.Background(), compiler, plan, 2)
+	if err != nil {
+		t.Fatalf("expected the run to succeed, got error: %v", err)
+	}
+
+	assertStrings(t, "results", compiledNames(results), []string{"A", "B"})
+	if skipped != 0 {
+		t.Errorf("reference skips = %d, want 0", skipped)
+	}
+}
+
+// Verifies one changed reference is enough: a dependent waiting on two assemblies is compiled when
+// either of them changed its surface.
+func TestCompileUnitsCompilesADependentWhenOnlyOneReferenceChanged(t *testing.T) {
+	plan := newSchedulerPlan(map[string][]string{"B": {"A", "D"}}, "A", "D", "B")
+	markSelectedAsDependent(t, plan, "B")
+	recorder := newSchedulerRecorder(0)
+	recorder.surfaces["A"] = "surface"
+	recorder.surfaces["D"] = "changed surface"
+	compiler := newSchedulerCompiler(t, recorder)
+	writeUnityReferenceAssembly(t, compiler.ProjectRoot, "A", "surface")
+	writeUnityReferenceAssembly(t, compiler.ProjectRoot, "D", "surface")
+
+	results, skipped, err := compileUnits(context.Background(), compiler, plan, 3)
+	if err != nil {
+		t.Fatalf("expected the run to succeed, got error: %v", err)
+	}
+
+	assertStrings(t, "results", compiledNames(results), []string{"A", "D", "B"})
+	if skipped != 0 {
+		t.Errorf("reference skips = %d, want 0", skipped)
+	}
+}
+
+// Verifies a dependent is compiled when its reference failed to compile and wrote no reference
+// assembly, so the run still reports the errors that failure causes on the other side.
+func TestCompileUnitsCompilesADependentWhoseReferenceProducedNothing(t *testing.T) {
+	plan := newSchedulerPlan(map[string][]string{"B": {"A"}}, "A", "B")
+	markSelectedAsDependent(t, plan, "B")
+	recorder := newSchedulerRecorder(0)
+	compiler := newSchedulerCompiler(t, recorder)
+	writeUnityReferenceAssembly(t, compiler.ProjectRoot, "A", "surface")
+
+	results, skipped, err := compileUnits(context.Background(), compiler, plan, 2)
+	if err != nil {
+		t.Fatalf("expected the run to succeed, got error: %v", err)
+	}
+
+	assertStrings(t, "results", compiledNames(results), []string{"A", "B"})
+	if skipped != 0 {
+		t.Errorf("reference skips = %d, want 0", skipped)
+	}
 }

--- a/cli/dispatcher/internal/compilecheck/session.go
+++ b/cli/dispatcher/internal/compilecheck/session.go
@@ -34,10 +34,9 @@ type Options struct {
 
 // Result is everything one compile-check run produced.
 type Result struct {
-	DagDir       string
-	Units        []UnitResult
-	Skipped      int
-	ChangedCount int
+	DagDir  string
+	Units   []UnitResult
+	Skipped int
 }
 
 // Run compiles the assemblies that need checking and collects their diagnostics.
@@ -69,16 +68,18 @@ func Run(ctx context.Context, options Options) (Result, error) {
 		jobs = DefaultJobs()
 	}
 
-	units, err := compileUnits(ctx, compiler, plan, jobs)
+	units, referenceSkips, err := compileUnits(ctx, compiler, plan, jobs)
 	if err != nil {
 		return Result{}, err
 	}
 
 	return Result{
-		DagDir:       dagDir,
-		Units:        units,
-		Skipped:      plan.Skipped,
-		ChangedCount: len(plan.Units),
+		DagDir: dagDir,
+		Units:  units,
+		// Why the two counts are added: both name an assembly the run did not compile - one because
+		// nothing it compiles from changed, the other because everything it references kept the
+		// public surface the last Unity build recorded.
+		Skipped: plan.Skipped + referenceSkips,
 	}, nil
 }
 

--- a/docs/compile-check.md
+++ b/docs/compile-check.md
@@ -32,8 +32,16 @@ references, scripting defines and analyzers. `compile-check` replays those respo
    stays up for a while after the run, exactly as it does after a build Unity ran itself; leave it
    alone. When it cannot be reached, csc compiles in its own process and the result is the same.
 3. **Decide what to compile.** By default the run compiles the assemblies whose sources changed
-   since the last Unity build, plus every assembly that references one of them. `--all` compiles
-   every assembly in the build. Assemblies left out are counted in `SkippedAssemblies`. An
+   since the last Unity build, plus every assembly that references one of them. An assembly pulled
+   in only through a reference is dropped again once everything it references has been compiled and
+   every one of those reference assemblies (`.ref.dll`, which holds the public surface alone) came
+   out byte-identical to the last Unity build's. That is the decision Unity itself makes through
+   Bee: a change that does not reach the public surface — a method body, say — cannot change what a
+   dependent compiles to. The comparison is always against Unity's own artifact, never against the
+   previous `compile-check` output, which would only say that nothing moved since that run and would
+   hide an error a dependent has been carrying all along. `--all` compiles
+   every assembly in the build and skips nothing. Assemblies left out are counted in
+   `SkippedAssemblies`. An
    assembly's sources are re-globbed from its own directory, stopping at nested assembly
    boundaries; the files an `.asmref` attaches to it are taken from the last build's response file
    instead, wherever that folder sits — including inside a nested assembly's directory, which the
@@ -79,7 +87,9 @@ CPUs and never less than one, and `--jobs 1` compiles them one after another.
 The command prints a JSON payload with `Success`, `ErrorCount`, `WarningCount`, `Errors`,
 `Warnings` (each diagnostic carrying `Message`, `Code`, `File`, `Line`, `Column`, `Assembly`),
 `CompiledAssemblies`, `SkippedAssemblies`, `ResponseFileSet`, `ProjectRoot` and a one-line
-`Message`. The process exits 1 when `ErrorCount` is greater than zero.
+`Message`. `SkippedAssemblies` counts both the assemblies nothing changed for and the ones left
+out because every assembly they reference kept the same public surface. The process exits 1 when
+`ErrorCount` is greater than zero.
 
 ## Limitations
 


### PR DESCRIPTION
## Why

An assembly is pulled into a run either because its own sources changed or because something it references was recompiled. In the second case there is nothing to learn from compiling it when the reference came out exactly as the last Unity build left it: a dependent reads the reference assembly (`.ref.dll`), which holds the public surface alone, so a change that stops at a method body cannot change what the dependent compiles to.

Unity makes the same call through Bee, which is why it compiles fewer assemblies than this check did for the same edit — on a large project, 75 where the check compiled 87.

## What

- `CompileUnit.SelectedAsDependent` marks the units the plan picked up only through a reference. It is false for a unit whose own sources changed and for every unit of an `--all` run, so neither can ever be skipped.
- `reference_surface.go` compares the reference assembly a unit just produced against the one the last Unity build produced for it. Anything unreadable counts as changed — a failed compile writes no reference assembly — because compiling one assembly too many costs time while skipping one costs a missed error.
- The scheduler carries a per-unit count of references that changed their surface. A dependent whose references all matched is dropped: its stale outputs are removed first (otherwise a reference assembly an earlier run wrote would be picked up as this run's own output), and its dependents are released so the skip carries down the chain.
- The comparison is always against Unity's artifact, never this check's previous output — that would only say nothing moved since the last run, and would hide an error a dependent has been carrying all along.
- `SkippedAssemblies` now counts both kinds of omission. `Result.ChangedCount`, which nothing read, is gone.

## Tests

- `plan_test.go`: an assembly whose own sources changed is not marked as dependent-only even when it also references a changed one; the assemblies pulled in only through a reference are; `--all` marks nothing.
- `reference_surface_test.go`: identical bytes, one differing byte, a missing output, a missing Unity-side artifact, and an assembly built without a reference assembly.
- `scheduler_test.go`: a dependent is skipped and its stale output removed; it is compiled when the surface changed; the skip carries down a chain; a unit not selected through a reference is never skipped; one changed reference out of two is enough to compile; a reference that produced nothing compiles its dependent.

Each rule was mutation-checked: dropping the stale-output removal, ignoring the changed-reference count, ignoring the dependent-only mark, dropping the count increment, and not releasing the dependents of a skipped unit each fail at least one test.

## Verification

- `cd cli/dispatcher && go test -race ./internal/compilecheck/` → ok
- `scripts/check-go-cli.sh` → exit 0; `check-skill-size` → ok; `sync-tool-docs --check` → no drift
- This repository, `--all`: 104 compiled assemblies, 0 errors, 7 warnings, 0 skipped — the same set as #2755, as an `--all` run skips nothing.
- This repository, default mode after a method-body-only edit in one `Domain` source (a local variable renamed): 33 assemblies compiled / 71 skipped in 2.5 s, against 50 compiled / 54 skipped in 4.4 s for the same working tree on #2755. The edit was reverted afterwards.
- Assembly counts and wall time on a large external project are measured by the reviewer.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2756?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
