### PR TITLE
fix: installed skills no longer stay Outdated when a tool is turned off

### DIFF
--- a/Assets/Tests/Editor/SkillInstallLayoutTests.cs
+++ b/Assets/Tests/Editor/SkillInstallLayoutTests.cs
@@ -381,6 +381,34 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(registeredToolNames, Does.Contain("public-tool"));
         }
 
+        // Tests that a skill whose tool is disabled is left out of the freshness check, because installing
+        // deletes it on purpose and it would otherwise keep the target reported as outdated forever.
+        [Test]
+        public void GetInstalledState_WhenExpectedSkillToolIsDisabled_IgnoresThatSkill()
+        {
+            string temporaryRoot = CreateTemporaryProjectRoot();
+            CreateFakeSourceSkill(temporaryRoot, "uloop-compile", "CompileTool", "reference.md", "reference");
+            CreateFakeSourceSkill(temporaryRoot, "uloop-replay-input", "ReplayInputTool", "reference.md", "reference");
+            string targetRoot = Path.Combine(temporaryRoot, ".claude");
+            InstallFakeSkill(targetRoot, "uloop-compile", "reference.md", "reference");
+
+            SkillInstallState stateWithDisabledTool = SkillInstallLayout.GetInstalledState(
+                temporaryRoot,
+                targetRoot,
+                groupSkillsUnderUnityCliLoop: false,
+                new[] { "replay-input" });
+            SkillInstallState stateWithoutDisabledTool = SkillInstallLayout.GetInstalledState(
+                temporaryRoot,
+                targetRoot,
+                groupSkillsUnderUnityCliLoop: false,
+                Array.Empty<string>());
+
+            Assert.That(stateWithDisabledTool, Is.EqualTo(SkillInstallState.Installed),
+                "A disabled tool's uninstalled skill must not make the target outdated");
+            Assert.That(stateWithoutDisabledTool, Is.EqualTo(SkillInstallState.Outdated),
+                "An enabled tool's uninstalled skill must still make the target outdated");
+        }
+
         // Tests that skill setup file scans share the same generated-file exclusion behavior.
         [Test]
         public void IsExcludedSkillFile_WhenGeneratedSkillFileNameIsPassed_ReturnsTrue()
@@ -429,6 +457,25 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 Path.Combine(skillDir, SkillInstallLayout.SkillFileName),
                 $"---\nname: {skillName}\n{internalLine}---\n");
             File.WriteAllText(Path.Combine(skillDir, additionalFileRelativePath), additionalFileContent);
+        }
+
+        private static void InstallFakeSkill(
+            string targetRoot,
+            string skillName,
+            string additionalFileRelativePath,
+            string additionalFileContent)
+        {
+            string installedSkillDirectory = SkillInstallLayout.GetInstalledSkillDirectoryPathForLayout(
+                targetRoot,
+                skillName,
+                groupSkillsUnderUnityCliLoop: false);
+            Directory.CreateDirectory(installedSkillDirectory);
+            File.WriteAllText(
+                Path.Combine(installedSkillDirectory, SkillInstallLayout.SkillFileName),
+                $"---\nname: {skillName}\n---\n");
+            File.WriteAllText(
+                Path.Combine(installedSkillDirectory, additionalFileRelativePath),
+                additionalFileContent);
         }
 
         private static void WriteSourceSkill(

--- a/Assets/Tests/Editor/ToolSkillSynchronizerTests.cs
+++ b/Assets/Tests/Editor/ToolSkillSynchronizerTests.cs
@@ -89,7 +89,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                     _projectRoot,
                     requireSkillsDirectory: true,
                     groupSkillsUnderUnityCliLoop: false,
-                    includeFreshnessCheck: false);
+                    includeFreshnessCheck: false,
+                    disabledTools: Array.Empty<string>());
             await ToolSkillSynchronizer.InstallSkillFiles(
                 targets,
                 groupSkillsUnderUnityCliLoop: false,
@@ -732,7 +733,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                     temporaryRoot,
                     requireSkillsDirectory: true,
                     groupSkillsUnderUnityCliLoop: false,
-                    includeFreshnessCheck: true)
+                    includeFreshnessCheck: true,
+                    disabledTools: Array.Empty<string>())
                 .Select(target => target.DirName)
                 .ToArray();
 
@@ -757,7 +759,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                     temporaryRoot,
                     requireSkillsDirectory: false,
                     groupSkillsUnderUnityCliLoop: false,
-                    includeFreshnessCheck: true)
+                    includeFreshnessCheck: true,
+                    disabledTools: Array.Empty<string>())
                 .ToArray();
 
             Assert.AreEqual(SkillTargetDetector.SkillTargetDirs.Length, detectedTargets.Length);
@@ -787,7 +790,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                     temporaryRoot,
                     requireSkillsDirectory: true,
                     groupSkillsUnderUnityCliLoop: false,
-                    includeFreshnessCheck: true)
+                    includeFreshnessCheck: true,
+                    disabledTools: Array.Empty<string>())
                 .ToArray();
 
             // Assert
@@ -856,7 +860,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                     temporaryRoot,
                     requireSkillsDirectory: true,
                     groupSkillsUnderUnityCliLoop: true,
-                    includeFreshnessCheck: true)
+                    includeFreshnessCheck: true,
+                    disabledTools: Array.Empty<string>())
                 .ToArray();
 
             Assert.AreEqual(SkillTargetDetector.SkillTargetDirs.Length, detectedTargets.Length);
@@ -881,7 +886,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                     temporaryRoot,
                     requireSkillsDirectory: true,
                     groupSkillsUnderUnityCliLoop: true,
-                    includeFreshnessCheck: true)
+                    includeFreshnessCheck: true,
+                    disabledTools: Array.Empty<string>())
                 .ToArray();
 
             foreach (ToolSkillSynchronizer.SkillTargetInfo target in detectedTargets)
@@ -904,7 +910,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                     temporaryRoot,
                     requireSkillsDirectory: true,
                     groupSkillsUnderUnityCliLoop: true,
-                    includeFreshnessCheck: true)
+                    includeFreshnessCheck: true,
+                    disabledTools: Array.Empty<string>())
                 .ToArray();
 
             Assert.That(detectedTargets.Length, Is.EqualTo(1));
@@ -933,7 +940,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                     temporaryRoot,
                     requireSkillsDirectory: true,
                     groupSkillsUnderUnityCliLoop: false,
-                    includeFreshnessCheck: true)
+                    includeFreshnessCheck: true,
+                    disabledTools: Array.Empty<string>())
                 .ToArray();
 
             foreach (ToolSkillSynchronizer.SkillTargetInfo target in detectedTargets)
@@ -961,7 +969,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                     temporaryRoot,
                     requireSkillsDirectory: true,
                     groupSkillsUnderUnityCliLoop: false,
-                    includeFreshnessCheck: true)
+                    includeFreshnessCheck: true,
+                    disabledTools: Array.Empty<string>())
                 .ToArray();
 
             Assert.AreEqual(SkillTargetDetector.SkillTargetDirs.Length, detectedTargets.Length);
@@ -992,7 +1001,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                     temporaryRoot,
                     requireSkillsDirectory: true,
                     groupSkillsUnderUnityCliLoop: true,
-                    includeFreshnessCheck: true)
+                    includeFreshnessCheck: true,
+                    disabledTools: Array.Empty<string>())
                 .ToArray();
 
             Assert.AreEqual(SkillTargetDetector.SkillTargetDirs.Length, detectedTargets.Length);
@@ -1019,7 +1029,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                     temporaryRoot,
                     requireSkillsDirectory: true,
                     groupSkillsUnderUnityCliLoop: false,
-                    includeFreshnessCheck: true)
+                    includeFreshnessCheck: true,
+                    disabledTools: Array.Empty<string>())
                 .ToArray();
 
             Assert.AreEqual(SkillTargetDetector.SkillTargetDirs.Length, detectedTargets.Length);
@@ -1065,7 +1076,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                     temporaryRoot,
                     requireSkillsDirectory: true,
                     groupSkillsUnderUnityCliLoop: true,
-                    includeFreshnessCheck: true)
+                    includeFreshnessCheck: true,
+                    disabledTools: Array.Empty<string>())
                 .ToArray();
 
             Assert.That(detectedTargets.Length, Is.EqualTo(1));
@@ -1097,7 +1109,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                     temporaryRoot,
                     requireSkillsDirectory: true,
                     groupSkillsUnderUnityCliLoop: true,
-                    includeFreshnessCheck: true)
+                    includeFreshnessCheck: true,
+                    disabledTools: Array.Empty<string>())
                 .ToArray();
 
             Assert.That(detectedTargets.Length, Is.EqualTo(1));
@@ -1124,7 +1137,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                     temporaryRoot,
                     requireSkillsDirectory: true,
                     groupSkillsUnderUnityCliLoop: true,
-                    includeFreshnessCheck: true)
+                    includeFreshnessCheck: true,
+                    disabledTools: Array.Empty<string>())
                 .ToArray();
 
             Assert.That(detectedTargets.Length, Is.EqualTo(1));
@@ -1158,7 +1172,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                     temporaryRoot,
                     requireSkillsDirectory: true,
                     groupSkillsUnderUnityCliLoop: true,
-                    includeFreshnessCheck: true)
+                    includeFreshnessCheck: true,
+                    disabledTools: Array.Empty<string>())
                 .ToArray();
 
             Assert.That(detectedTargets.Length, Is.EqualTo(1));
@@ -1191,7 +1206,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                     temporaryRoot,
                     requireSkillsDirectory: true,
                     groupSkillsUnderUnityCliLoop: true,
-                    includeFreshnessCheck: true)
+                    includeFreshnessCheck: true,
+                    disabledTools: Array.Empty<string>())
                 .ToArray();
 
             Assert.That(detectedTargets.Length, Is.EqualTo(1));
@@ -1224,7 +1240,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                     temporaryRoot,
                     requireSkillsDirectory: true,
                     groupSkillsUnderUnityCliLoop: true,
-                    includeFreshnessCheck: true)
+                    includeFreshnessCheck: true,
+                    disabledTools: Array.Empty<string>())
                 .ToArray();
 
             Assert.That(detectedTargets.Length, Is.EqualTo(1));
@@ -1256,7 +1273,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                     temporaryRoot,
                     requireSkillsDirectory: true,
                     groupSkillsUnderUnityCliLoop: true,
-                    includeFreshnessCheck: true)
+                    includeFreshnessCheck: true,
+                    disabledTools: Array.Empty<string>())
                 .ToArray();
 
             Assert.That(detectedTargets.Length, Is.EqualTo(1));
@@ -1289,7 +1307,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                     temporaryRoot,
                     requireSkillsDirectory: true,
                     groupSkillsUnderUnityCliLoop: true,
-                    includeFreshnessCheck: true)
+                    includeFreshnessCheck: true,
+                    disabledTools: Array.Empty<string>())
                 .ToArray();
 
             Assert.That(detectedTargets.Length, Is.EqualTo(1));
@@ -1321,7 +1340,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                     temporaryRoot,
                     requireSkillsDirectory: true,
                     groupSkillsUnderUnityCliLoop: true,
-                    includeFreshnessCheck: true)
+                    includeFreshnessCheck: true,
+                    disabledTools: Array.Empty<string>())
                 .ToArray();
 
             Assert.That(detectedTargets.Length, Is.EqualTo(1));
@@ -1425,7 +1445,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                     temporaryRoot,
                     requireSkillsDirectory: true,
                     groupSkillsUnderUnityCliLoop: true,
-                    includeFreshnessCheck: true)
+                    includeFreshnessCheck: true,
+                    disabledTools: Array.Empty<string>())
                 .ToArray();
 
             Assert.That(detectedTargets.Length, Is.EqualTo(1));
@@ -1559,7 +1580,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                     temporaryRoot,
                     requireSkillsDirectory: true,
                     groupSkillsUnderUnityCliLoop: true,
-                    includeFreshnessCheck: true)
+                    includeFreshnessCheck: true,
+                    disabledTools: Array.Empty<string>())
                 .ToArray();
 
             Assert.That(detectedTargets.Length, Is.EqualTo(1));
@@ -1587,7 +1609,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                     temporaryRoot,
                     requireSkillsDirectory: true,
                     groupSkillsUnderUnityCliLoop: true,
-                    includeFreshnessCheck: true)
+                    includeFreshnessCheck: true,
+                    disabledTools: Array.Empty<string>())
                 .ToArray();
 
             Assert.That(detectedTargets.Length, Is.EqualTo(1));

--- a/Packages/src/Editor/Infrastructure/SkillSetup/SkillInstallLayout.cs
+++ b/Packages/src/Editor/Infrastructure/SkillSetup/SkillInstallLayout.cs
@@ -109,12 +109,19 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 Directory.Exists(GetInstalledSkillDirectoryPath(targetRoot, skill.Name, groupSkillsUnderUnityCliLoop)));
         }
 
+        // Skills of disabled tools are deleted on every install, so counting them as expected would
+        // report the target as outdated forever, with no install able to settle it.
         internal static SkillInstallState GetInstalledState(
             string projectRoot,
             string targetRoot,
-            bool groupSkillsUnderUnityCliLoop)
+            bool groupSkillsUnderUnityCliLoop,
+            IReadOnlyCollection<string> disabledTools)
         {
-            List<SkillSourceInfo> expectedSkills = SkillSourceRootEnumerator.GetSkillSourceInfos(projectRoot);
+            Debug.Assert(disabledTools != null, "disabledTools must not be null");
+
+            List<SkillSourceInfo> expectedSkills = SkillSourceRootEnumerator.GetSkillSourceInfos(projectRoot)
+                .Where(skill => !SkillDisabledToolFilter.IsSkillDisabledByToolSettings(skill, disabledTools))
+                .ToList();
             bool hasLayoutSkills = HasInstalledSkillsForLayout(projectRoot, targetRoot, groupSkillsUnderUnityCliLoop);
             if (expectedSkills.Count == 0)
             {

--- a/Packages/src/Editor/Infrastructure/SkillSetup/SkillTargetDetector.cs
+++ b/Packages/src/Editor/Infrastructure/SkillSetup/SkillTargetDetector.cs
@@ -41,9 +41,11 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             string projectRoot,
             bool requireSkillsDirectory,
             bool groupSkillsUnderUnityCliLoop,
-            bool includeFreshnessCheck)
+            bool includeFreshnessCheck,
+            IReadOnlyCollection<string> disabledTools)
         {
             Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be null or empty");
+            Debug.Assert(disabledTools != null, "disabledTools must not be null");
 
             List<ToolSkillSynchronizer.SkillTargetInfo> targets = new();
 
@@ -66,7 +68,8 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                     targetRoot,
                     hasSkillsDirectory,
                     groupSkillsUnderUnityCliLoop,
-                    includeFreshnessCheck);
+                    includeFreshnessCheck,
+                    disabledTools);
                 bool hasULoopSkills = installState == SkillInstallState.Installed
                     || installState == SkillInstallState.Checking
                     || installState == SkillInstallState.Outdated;
@@ -118,7 +121,8 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             string targetRoot,
             bool hasSkillsDirectory,
             bool groupSkillsUnderUnityCliLoop,
-            bool includeFreshnessCheck)
+            bool includeFreshnessCheck,
+            IReadOnlyCollection<string> disabledTools)
         {
             if (!hasSkillsDirectory)
             {
@@ -132,7 +136,11 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                     : SkillInstallState.Missing;
             }
 
-            return SkillInstallLayout.GetInstalledState(projectRoot, targetRoot, groupSkillsUnderUnityCliLoop);
+            return SkillInstallLayout.GetInstalledState(
+                projectRoot,
+                targetRoot,
+                groupSkillsUnderUnityCliLoop,
+                disabledTools);
         }
     }
 }

--- a/Packages/src/Editor/Infrastructure/SkillSetup/ToolSkillSetupService.cs
+++ b/Packages/src/Editor/Infrastructure/SkillSetup/ToolSkillSetupService.cs
@@ -40,7 +40,8 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             List<ToolSkillSynchronizer.SkillTargetInfo> targets =
                 ToolSkillSynchronizer.DetectTargetsForLayoutAtProjectRoot(
                     projectRoot,
-                    groupSkillsUnderUnityCliLoop);
+                    groupSkillsUnderUnityCliLoop,
+                    _toolSettingsPort.GetDisabledTools());
             return targets.Select(ToDomainInfo).ToList();
         }
 

--- a/Packages/src/Editor/Infrastructure/SkillSetup/ToolSkillSynchronizer.cs
+++ b/Packages/src/Editor/Infrastructure/SkillSetup/ToolSkillSynchronizer.cs
@@ -81,15 +81,18 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
 
         internal static List<SkillTargetInfo> DetectTargetsForLayoutAtProjectRoot(
             string projectRoot,
-            bool groupSkillsUnderUnityCliLoop)
+            bool groupSkillsUnderUnityCliLoop,
+            IReadOnlyCollection<string> disabledTools)
         {
             Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be null or empty");
+            Debug.Assert(disabledTools != null, "disabledTools must not be null");
 
             return SkillTargetDetector.DetectTargetsForLayoutStateAtProjectRoot(
                 projectRoot,
                 requireSkillsDirectory: false,
                 groupSkillsUnderUnityCliLoop,
-                includeFreshnessCheck: true);
+                includeFreshnessCheck: true,
+                disabledTools);
         }
 
         internal static List<SkillTargetInfo> DetectTargetsForLayoutFastAtProjectRoot(
@@ -98,11 +101,14 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
         {
             Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be null or empty");
 
+            // The fast path reports Checking instead of comparing skill files, so tool settings
+            // cannot change its result.
             return SkillTargetDetector.DetectTargetsForLayoutStateAtProjectRoot(
                 projectRoot,
                 requireSkillsDirectory: false,
                 groupSkillsUnderUnityCliLoop,
-                includeFreshnessCheck: false);
+                includeFreshnessCheck: false,
+                System.Array.Empty<string>());
         }
 
         internal static async Task<SkillInstallResult> InstallSkillFilesForToolWithDisabledTools(

--- a/cli/dispatcher/internal/dispatcher/skills.go
+++ b/cli/dispatcher/internal/dispatcher/skills.go
@@ -224,6 +224,8 @@ func runSkillsList(projectRoot string, skills []skillDefinition, options skillCo
 		location = "Global"
 	}
 
+	disabledTools := loadDisabledToolsForSkills(projectRoot, options.global)
+
 	clicore.WriteLine(stdout, "")
 	clicore.WriteLine(stdout, "uloop Skills Status:")
 	clicore.WriteLine(stdout, "")
@@ -237,7 +239,11 @@ func runSkillsList(projectRoot string, skills []skillDefinition, options skillCo
 		clicore.WriteFormat(stdout, "Location: %s\n", baseDir)
 		clicore.WriteLine(stdout, strings.Repeat("=", 50))
 		for _, skill := range skills {
-			status, err := getSkillStatus(baseDir, skill, groupManagedSkillsForOptions(options))
+			status, err := getSkillStatusForList(
+				baseDir,
+				skill,
+				disabledTools,
+				groupManagedSkillsForOptions(options))
 			if err != nil {
 				clierrors.WriteClassifiedError(stderr, err, clierrors.ErrorContext{ProjectRoot: projectRoot, Command: clicore.SkillsCommandName})
 				return 1
@@ -379,7 +385,7 @@ func installSkillsForTarget(projectRoot string, target skillTarget, skills []ski
 		}
 	}
 
-	disabledTools := loadDisabledToolsForSkillInstall(projectRoot, global)
+	disabledTools := loadDisabledToolsForSkills(projectRoot, global)
 	for _, skill := range skills {
 		if err := installSkillForTarget(baseDir, skill, disabledTools, grouped, &result); err != nil {
 			return skillInstallResult{}, err
@@ -393,11 +399,26 @@ func installSkillsForTarget(projectRoot string, target skillTarget, skills []ski
 	return result, nil
 }
 
-func loadDisabledToolsForSkillInstall(projectRoot string, global bool) []string {
+// Tool settings live in the project, so a global install or listing has none to honor.
+func loadDisabledToolsForSkills(projectRoot string, global bool) []string {
 	if global {
 		return []string{}
 	}
 	return clicore.LoadDisabledTools(projectRoot)
+}
+
+// A disabled tool's skill is removed on install by design, so reporting it as a missing
+// install would read as a broken install the user cannot repair.
+func getSkillStatusForList(
+	baseDir string,
+	skill skillDefinition,
+	disabledTools []string,
+	grouped bool,
+) (string, error) {
+	if isSkillDisabledByToolSettings(skill, disabledTools) {
+		return "disabled", nil
+	}
+	return getSkillStatus(baseDir, skill, grouped)
 }
 
 func installSkillForTarget(

--- a/cli/dispatcher/internal/dispatcher/skills_display.go
+++ b/cli/dispatcher/internal/dispatcher/skills_display.go
@@ -53,6 +53,8 @@ func statusIcon(status string) string {
 		return "^"
 	case "conflict":
 		return "!"
+	case "disabled":
+		return "o"
 	default:
 		return "-"
 	}
@@ -66,6 +68,8 @@ func statusText(status string) string {
 		return "outdated"
 	case "conflict":
 		return "conflict"
+	case "disabled":
+		return "disabled"
 	default:
 		return "not installed"
 	}

--- a/cli/dispatcher/internal/dispatcher/skills_test.go
+++ b/cli/dispatcher/internal/dispatcher/skills_test.go
@@ -766,6 +766,56 @@ func TestRunSkillsListDefaultsToFlatLayout(t *testing.T) {
 	}
 }
 
+// Tests that the list command reports a skill whose tool is disabled as disabled rather than as a missing install.
+func TestRunSkillsListReportsSkillOfDisabledToolAsDisabled(t *testing.T) {
+	projectRoot := t.TempDir()
+	writeToolSettings(t, projectRoot, `{"disabledTools":["disabled-skill"]}`)
+	skill := skillDefinition{
+		name:     "uloop-disabled-skill",
+		toolName: "disabled-skill",
+		content:  []byte("---\nname: uloop-disabled-skill\n---\n"),
+	}
+	options := skillCommandOptions{
+		targets: []skillTarget{targetConfigs["claude"]},
+	}
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+
+	code := runSkillsList(projectRoot, []skillDefinition{skill}, options, stdout, stderr)
+
+	if code != 0 {
+		t.Fatalf("list should succeed: code=%d stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "uloop-disabled-skill (disabled)") {
+		t.Fatalf("skill of a disabled tool should be reported as disabled: %s", stdout.String())
+	}
+}
+
+// Tests that the list command still reports an enabled tool's uninstalled skill as not installed.
+func TestRunSkillsListReportsSkillOfEnabledToolAsNotInstalled(t *testing.T) {
+	projectRoot := t.TempDir()
+	writeToolSettings(t, projectRoot, `{"disabledTools":["other-skill"]}`)
+	skill := skillDefinition{
+		name:     "uloop-enabled-skill",
+		toolName: "enabled-skill",
+		content:  []byte("---\nname: uloop-enabled-skill\n---\n"),
+	}
+	options := skillCommandOptions{
+		targets: []skillTarget{targetConfigs["claude"]},
+	}
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+
+	code := runSkillsList(projectRoot, []skillDefinition{skill}, options, stdout, stderr)
+
+	if code != 0 {
+		t.Fatalf("list should succeed: code=%d stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "uloop-enabled-skill (not installed)") {
+		t.Fatalf("skill of an enabled tool should stay not installed: %s", stdout.String())
+	}
+}
+
 // Tests that the public uninstall command removes only the flat layout by default.
 func TestRunSkillsUninstallDefaultsToFlatLayout(t *testing.T) {
 	projectRoot := t.TempDir()


### PR DESCRIPTION
## Summary
- Installed skills no longer stay stuck on "Outdated" in a project that turns any tool off.
- `uloop skills list` now says a turned-off tool's skill is `disabled` instead of pretending it is missing.

## User Impact
- Before: turning a tool off in Settings made every skill target report `Outdated` forever. Installing skills deletes that tool's skill folder on purpose, but the freshness check still expected the folder to be there, so each install left the badge unchanged and there was no way to clear it.
- Before: the same skill showed up in `uloop skills list` as `not installed`, which read like a broken install that a re-run should repair.
- After: skills of turned-off tools are left out of the freshness check, so the badge settles on `Installed` right after an install; the listing labels them `disabled` so the absence reads as intended.

## Changes
- Pass the project's disabled tools from the tool settings down to the skill freshness check and drop their skills from the expected set. The fast path is untouched because it reports `Checking` without comparing files.
- Add a `disabled` status to the skills listing, resolved before the on-disk comparison. Tool settings are per project, so a global listing still honors none.

## Verification
- `dist/darwin-arm64/uloop compile` — 0 errors
- `dist/darwin-arm64/uloop run-tests --filter-type class --filter-value SkillInstallLayoutTests` — 19 passed
- `dist/darwin-arm64/uloop run-tests --filter-type regex --filter-value "ToolSkillSynchronizerTests|SkillStatusContractTests"` — 66 passed
- Fault injection: removing the new filter makes the added test fail with `Expected: Installed / But was: Outdated`, and restoring it turns the test green again.
- `scripts/check-go-cli.sh` — format, vet, lint, tests and binary rebuild all pass


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/2757?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

